### PR TITLE
Add a dependency-free test suite

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,24 @@
+name: check
+
+# Runs the data-integrity and rendering tests. Nothing is installed: the tests
+# use Node's built-in runner and the project has no dependencies.
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          # Active LTS, supported until April 2028. Node 26 becomes LTS in
+          # October 2026 and is the natural next bump. The tests only use
+          # node:test, node:assert and node:fs, so any Node 20+ will do;
+          # 'lts/*' also works if you would rather this never need touching.
+          node-version: '24'
+      - name: Tests
+        run: node --test tests/*.test.js

--- a/README.md
+++ b/README.md
@@ -9,3 +9,21 @@ Created and implemented by David Driscoll, designed and researched by David Dris
 Please cite as: D. Driscoll, I. McMullin, S. Sansom, S. Brennan-McMahon, A.-E. Peponi. Mapping Greek Lyric : Places, Travel, Geographical Imaginary [Date of access] (http://lyricmappingproject.stanford.edu)
 
 Many thanks to: Stanford's Department of Classics for financial support, Ancient World Mapping Center, CartoDB, jQRangeSlider, Mapbox, Orbis, Pleiades, and Stanford's Humanities + Design Lab.
+
+## Working on the code
+
+The code is vanilla JS and is served without a build step. The goal is to
+require minimal maintenance and let the site work as-is for as long as possible.
+To develop, serve the directory — for example `python3 -m http.server 8000`.
+
+### Tests
+
+There are nevertheless tests, run in CI on every pull request.
+
+```sh
+node --test tests/*.test.js     # or: npm test
+```
+
+They use Node's built-in runner, so there is nothing to install. Most check the
+CSVs in `dataFiles/`, which is where this project's bugs have historically come
+from. Some record known data problems we plan to fix.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "lyricmappingproject",
+  "private": true,
+  "type": "module",
+  "description": "Not a build. This file exists so Node treats the .js files as the ES modules they already are, which is what lets the tests import them directly. There are no dependencies and nothing to install; the site is still plain files served as-is.",
+  "scripts": {
+    "test": "node --test tests/*.test.js"
+  }
+}

--- a/tests/data-integrity.test.js
+++ b/tests/data-integrity.test.js
@@ -1,0 +1,547 @@
+// Data-integrity checks over dataFiles/*.csv.
+//
+// The CSVs are hand-edited in spreadsheets by several people over many years,
+// and most of the bugs this project has hit (dangling ids, missing citations,
+// rows that stopped matching their poet) are data bugs rather than code bugs.
+// These tests are the guard rail for that.
+//
+// The data currently violates some of these rules. Rather than weaken the rule,
+// the offending rows are listed in the exception sets below, so that any NEW
+// violation still fails the build.
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { loadRawCsvs } from "./helpers/loadData.js";
+
+const raw = loadRawCsvs();
+const id = (value) => parseInt(value);
+const filled = (value) => String(value ?? "").trim() !== "";
+
+const cityIds = new Set(raw.cities.map(c => id(c.cityId)));
+const poetIds = new Set(raw.poets.map(p => id(p.poetId)));
+const governmentIds = new Set(raw.governments.map(g => id(g.governmentId)));
+const regionIds = new Set(raw.regions.map(r => id(r.regionId)));
+const bigRegionIds = new Set(raw.bigRegions.map(r => id(r.regionId)));
+const cityNameById = new Map(raw.cities.map(c => [id(c.cityId), c.cityname]));
+
+// ---------------------------------------------------------------------------
+// Exceptions for data that is currently broken. See "known data bugs" at the
+// bottom of this file for what each one actually is.
+// ---------------------------------------------------------------------------
+
+/** Geographical-imaginary rows pointing at cityIds absent from cities.csv. */
+const KNOWN_UNMAPPED_GEO_CITY_IDS = new Set([
+  154, // Dryopis (Doris) - Stesichorus 222, Telestes fr. 806
+  156, // Annichorum - Alcman fr. 150
+  165, // Denthiades - Alcman fr. 92(d)
+  170, // Five Crests - Alcman fr. 92(c)
+  172, // Ibe - Alcman fr. 1.59
+  173, // Nyrsylas - Alcman fr. 173
+  217, // Phthia - Cinesias fr. 775
+  221, // Sintia - Anacreon fr. eleg. 3.2
+  227, // Corax - Hipponax 2.1
+  228, // Cylicrania - Hermippus 4
+  238, // Mytalis - Hipponax 42.4
+  239  // Phlyesia - Hipponax 47.2
+]);
+
+/** genres.csv rows whose poetId is not in poets.csv. */
+const KNOWN_ORPHAN_GENRE_POET_IDS = new Set([14, 31, 33, 113]);
+
+/**
+ * Rows whose cityname label does not match the cities.csv entry they point at,
+ * as [cityId, label]. Most are harmless spelling variants (Aegina/Aigina,
+ * Ceos/Ioulis). The four marked BUG are different places entirely.
+ */
+const ACCEPTED_CITY_LABEL_VARIANTS = [
+  [17, "Megara (Attic)"],
+  [26, "Soli"],
+  [33, "Macedon"],
+  [46, "Ceos"],
+  [74, "Heracleia"],
+  [76, "Thespia"],
+  [85, "Persepolis"],
+  [89, "Aegina"],
+  [91, "Nile"],
+  [94, "Tempe"], // the sanctuary of Poseidon Petraios stands in the Tempe valley
+  [100, "Olympus"],
+  [102, "Maeonia"], // the older name for Lydia
+  [106, "Cyrpus"], // typo for Cyprus, but points at the right city
+  [118, "Ceteia"],
+  [131, "Issedones (Scythia)"],
+  [134, "Phocis"], // BUG: plotted on Aetolia (38.56N 21.67E). Stesichorus 222 names both.
+  [140, "Cholchis"],
+  [149, "Larissa"],
+  [162, "Cerbesians"],
+  [176, "Pityussae (Balearic Islands)"],
+  [179, "Therapne"],
+  [206, "Euripus"],
+  [216, "Parnassus"],
+  [218, "Plataea"],
+  [219, "Mt. Ptoïon"],
+  [240, "Thrace"], // BUG: plotted on Priapus. Every other Thrace reference uses cityId 129.
+  [254, "Camarina"], // BUG: plotted on Erythrae in Ionia. Camarina is in Sicily.
+  [254, "Ionian Erythrae"],
+  [255, "Cyrene"], // BUG: plotted on Phocaea in Ionia. Cyrene is in Libya.
+  [257, "Orchomenus"]
+];
+const acceptedCityLabels = new Set(
+  ACCEPTED_CITY_LABEL_VARIANTS.map(([cityId, label]) => `${cityId}|${label}`)
+);
+
+/** poets_cities rows carrying a citation but no translation or translator. */
+const KNOWN_INCOMPLETE_CITATION_COUNT = 18;
+
+/** Cities whose coordinates are malformed and plot far outside the map. */
+const KNOWN_BROKEN_COORDINATE_CITY_IDS = new Set([226, 197]);
+
+/**
+ * The mapped world runs from Ethiopia in the south to Scythia in the north, and
+ * from Tartessus and Erytheia beyond the Pillars of Heracles in the west
+ * (Stesichorus' Geryoneis) to Ecbatana in the east.
+ */
+const WORLD_BOUNDS = { minLat: 5, maxLat: 50, minLong: -10, maxLong: 55 };
+
+// ---------------------------------------------------------------------------
+
+describe("primary keys", () => {
+  for (const [file, key] of [["cities", "cityId"], ["poets", "poetId"], ["governments", "governmentId"]]) {
+    test(`${file}.csv has unique ${key}`, () => {
+      const seen = new Map();
+      for (const row of raw[file]) {
+        const value = id(row[key]);
+        assert.ok(!seen.has(value), `${key} ${value} appears twice in ${file}.csv`);
+        seen.set(value, row);
+      }
+    });
+  }
+
+  test("regions.csv has unique regionId", () => {
+    const seen = new Set();
+    for (const region of raw.regions) {
+      assert.ok(!seen.has(id(region.regionId)), `duplicate regionId ${region.regionId}`);
+      seen.add(id(region.regionId));
+    }
+  });
+});
+
+describe("referential integrity", () => {
+  test("every poets_cities row resolves to a poet", () => {
+    for (const row of raw.poetCities) {
+      assert.ok(poetIds.has(id(row.poetId)), `${row.poetname} has unknown poetId ${row.poetId}`);
+    }
+  });
+
+  test("every poets_cities row resolves to a city", () => {
+    for (const row of raw.poetCities) {
+      if (!filled(row.cityId)) continue; // blank means the place was never mapped
+      assert.ok(cityIds.has(id(row.cityId)), `${row.poetname} -> ${row.cityname} has unknown cityId ${row.cityId}`);
+    }
+  });
+
+  test("every geographical imaginary row resolves to a poet", () => {
+    for (const row of raw.geopoetCities) {
+      assert.ok(poetIds.has(id(row.poetId)), `${row.poetname} has unknown poetId ${row.poetId}`);
+    }
+  });
+
+  test("no NEW geographical imaginary row points at a missing city", () => {
+    for (const row of raw.geopoetCities) {
+      if (!filled(row.cityId)) continue;
+      if (KNOWN_UNMAPPED_GEO_CITY_IDS.has(id(row.cityId))) continue;
+      assert.ok(
+        cityIds.has(id(row.cityId)),
+        `${row.poetname} -> ${row.cityname} (cityId ${row.cityId}) is not in cities.csv, ` +
+        `so this citation will not appear on the map`
+      );
+    }
+  });
+
+  test("no NEW genres row points at a missing poet", () => {
+    for (const row of raw.genres) {
+      if (KNOWN_ORPHAN_GENRE_POET_IDS.has(id(row.poetId))) continue;
+      assert.ok(poetIds.has(id(row.poetId)), `${row.genres_poetname} has unknown poetId ${row.poetId}`);
+    }
+  });
+
+  test("every dates row resolves to a poet", () => {
+    for (const row of raw.dates) {
+      assert.ok(poetIds.has(id(row.poetId)), `${row.dates_poetname} has unknown poetId ${row.poetId}`);
+    }
+  });
+
+  test("every city_politics row resolves to a city and a government", () => {
+    for (const row of raw.cityPolitics) {
+      if (filled(row.cityId)) {
+        assert.ok(cityIds.has(id(row.cityId)), `${row.city} has unknown cityId ${row.cityId}`);
+      }
+      assert.ok(governmentIds.has(id(row.governmentId)), `${row.city} has unknown governmentId ${row.governmentId}`);
+    }
+  });
+
+  test("every city's region, and every region's big region, resolves", () => {
+    for (const city of raw.cities) {
+      if (!filled(city.regionId)) continue;
+      assert.ok(regionIds.has(id(city.regionId)), `${city.cityname} has unknown regionId ${city.regionId}`);
+    }
+    for (const region of raw.regions) {
+      if (!filled(region.bigRegionId)) continue;
+      assert.ok(bigRegionIds.has(id(region.bigRegionId)), `${region.regionname} has unknown bigRegionId ${region.bigRegionId}`);
+    }
+  });
+});
+
+describe("labels agree with the ids they point at", () => {
+  // A row labelled with one place but pointing at another's id draws the
+  // reference in the wrong location, which is invisible without this check.
+  test("no NEW cityname disagrees with the city it references", () => {
+    for (const file of ["poetCities", "geopoetCities"]) {
+      for (const row of raw[file]) {
+        const cityId = id(row.cityId);
+        if (!filled(row.cityname) || !cityNameById.has(cityId)) continue;
+        const actual = cityNameById.get(cityId);
+        if (actual === row.cityname) continue;
+        assert.ok(
+          acceptedCityLabels.has(`${cityId}|${row.cityname}`),
+          `${file}: row labelled "${row.cityname}" points at cityId ${cityId}, which is "${actual}"`
+        );
+      }
+    }
+  });
+});
+
+describe("field values", () => {
+  test("relationshipId is 1, 2, 3 or blank", () => {
+    for (const row of raw.poetCities) {
+      if (!filled(row.relationshipId)) continue; // blank = unclassified, excluded from travel
+      assert.ok(
+        [1, 2, 3].includes(id(row.relationshipId)),
+        `${row.poetname} -> ${row.cityname} has relationshipId ${row.relationshipId}`
+      );
+    }
+  });
+
+  test("coordinates are either both blank or both plausible for the mapped world", () => {
+    for (const city of raw.cities) {
+      const hasLat = filled(city.lat);
+      const hasLong = filled(city.long);
+      assert.equal(hasLat, hasLong, `${city.cityname} has only one of lat/long`);
+      if (!hasLat) continue;
+      const lat = parseFloat(city.lat);
+      const long = parseFloat(city.long);
+      assert.ok(Number.isFinite(lat) && Number.isFinite(long), `${city.cityname} has unparseable coordinates`);
+      if (KNOWN_BROKEN_COORDINATE_CITY_IDS.has(id(city.cityId))) continue;
+      assert.ok(
+        lat > WORLD_BOUNDS.minLat && lat < WORLD_BOUNDS.maxLat,
+        `${city.cityname} latitude ${lat} is outside the mapped world — a lost decimal point?`
+      );
+      assert.ok(
+        long > WORLD_BOUNDS.minLong && long < WORLD_BOUNDS.maxLong,
+        `${city.cityname} longitude ${long} is outside the mapped world — a lost decimal point?`
+      );
+    }
+  });
+
+  test("dates are parseable years", () => {
+    for (const row of raw.dates) {
+      assert.ok(Number.isFinite(parseInt(row.date)), `${row.dates_poetname} has unparseable date "${row.date}"`);
+    }
+  });
+
+  test("every poet has a detail name, which is what popups display", () => {
+    for (const poet of raw.poets) {
+      assert.ok(filled(poet.poetDetailName), `${poet.poetname} has no poetDetailName`);
+    }
+  });
+});
+
+describe("citations", () => {
+  // Issue #329 ("Citations broken again") and #313 ("citations are
+  // inconsistent") were both this shape.
+  test("geographical imaginary citations are complete", () => {
+    for (const row of raw.geopoetCities) {
+      if (!filled(row.source_citation)) continue;
+      assert.ok(filled(row.source_translation), `${row.poetname} ${row.source_citation} has no translation`);
+      assert.ok(filled(row.source_translator), `${row.poetname} ${row.source_citation} has no translator`);
+    }
+  });
+
+  test("genre citations are complete", () => {
+    for (const row of raw.genres) {
+      if (!filled(row.source_citation)) continue;
+      assert.ok(filled(row.source_translation), `${row.genres_poetname} ${row.source_citation} has no translation`);
+      assert.ok(filled(row.source_translator), `${row.genres_poetname} ${row.source_citation} has no translator`);
+    }
+  });
+
+  test("incomplete poets_cities citations do not increase", () => {
+    const incomplete = raw.poetCities.filter(row =>
+      filled(row.source_citation) && !(filled(row.source_translation) && filled(row.source_translator))
+    );
+    assert.ok(
+      incomplete.length <= KNOWN_INCOMPLETE_CITATION_COUNT,
+      `${incomplete.length} poets_cities rows have a citation without a full translation ` +
+      `(was ${KNOWN_INCOMPLETE_CITATION_COUNT}); newly incomplete: ` +
+      incomplete.slice(0, 5).map(r => `${r.poetname}/${r.cityname}`).join(", ")
+    );
+  });
+});
+
+describe("Greek text", () => {
+  // The corpus is stored in NFC, i.e. with the canonical "tonos" codepoints
+  // (ά = U+03AC) rather than the legacy "oxia" ones (ά = U+1F71). The two
+  // render identically, so a mixture is invisible on screen but silently breaks
+  // text search over the corpus — in a browser, an editor, or against TLG
+  // output, which uses tonos.
+  //
+  // Spreadsheets and older Greek keyboards happily reintroduce oxia, so this is
+  // checked on every file rather than only the Greek columns.
+  test("every data file is NFC-normalised", () => {
+    for (const [name, rows] of Object.entries(raw)) {
+      for (const row of rows) {
+        for (const [column, value] of Object.entries(row)) {
+          if (!value) continue;
+          assert.equal(
+            value,
+            value.normalize("NFC"),
+            `${name}.${column} is not NFC-normalised: ${JSON.stringify(value.slice(0, 60))}`
+          );
+        }
+      }
+    }
+  });
+
+  test("source_greektext holds source-language text", () => {
+    // Despite the column name it holds the text in its original language, which
+    // for three testimonia is Latin: Quintilian and Cicero on Simonides at the
+    // house of Scopas, and Pliny on Telestes. Anything else in there without a
+    // Greek letter is a data-entry slip.
+    const LATIN_SOURCE_WORKS = new Set(["Quintilian", "Cicero", "Pliny"]);
+    for (const file of ["poetCities", "geopoetCities", "genres"]) {
+      for (const row of raw[file]) {
+        if (!filled(row.source_greektext)) continue;
+        if (/\p{Script=Greek}/u.test(row.source_greektext)) continue;
+        assert.ok(
+          LATIN_SOURCE_WORKS.has(row.source_work),
+          `${file}: ${row.poetname ?? row.genres_poetname} has a source_greektext with no Greek ` +
+          `and an unexpected source_work "${row.source_work}"`
+        );
+      }
+    }
+  });
+});
+
+describe("hygiene", () => {
+  test("names have no leading or trailing whitespace", () => {
+    const offenders = [];
+    for (const city of raw.cities) {
+      if (city.cityname !== city.cityname.trim()) offenders.push(`cities.csv: ${JSON.stringify(city.cityname)}`);
+    }
+    for (const poet of raw.poets) {
+      if (poet.poetname !== poet.poetname.trim()) offenders.push(`poets.csv: ${JSON.stringify(poet.poetname)}`);
+    }
+    // Two rows are already like this; a stray newline inside a quoted field is
+    // easy to introduce from a spreadsheet and hard to spot afterwards.
+    assert.ok(offenders.length <= 2, `unexpected whitespace in names:\n  ${offenders.join("\n  ")}`);
+  });
+
+  test("every poet has dates", () => {
+    // getDateFilterFn() is the only reader, and it compares against the min and
+    // max derived from these rows. A poet with no dates is silently filtered off
+    // the map entirely, so this is asserted for all of poets.csv rather than
+    // only the poets currently placed on it.
+    const dated = new Set(raw.dates.map(row => id(row.poetId)));
+    for (const poet of raw.poets) {
+      assert.ok(dated.has(id(poet.poetId)),
+        `${poet.poetname} has no rows in dates.csv, so would be invisible on the map`);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// KNOWN DATA BUGS
+//
+// Every test below asserts what the data currently gets WRONG. They pass while
+// the bug is present, which inverts the usual reading of a green suite, so each
+// is named "BUG:" to make that unmistakable.
+//
+// When someone fixes one of these, its test will fail. That failure is the
+// signal to DELETE THE TEST — and the matching entry in the exception sets at
+// the top of this file — not to restore the bug.
+//
+// Coordinates below come from Pleiades (https://pleiades.stoa.org), which is
+// where this project's existing coordinates come from: cities.csv's Heracleia
+// Trachinia matches pleiades:541157 to all six decimal places.
+// ---------------------------------------------------------------------------
+
+describe("known data bugs: places plotted in the wrong location", () => {
+  const cityById = (cityId) => raw.cities.find(c => id(c.cityId) === cityId);
+
+  const rowsLabelled = (file, label) =>
+    raw[file].filter(row => row.cityname === label);
+
+  test("BUG: Pindar's Camarina is plotted on Erythrae, in Ionia rather than Sicily", () => {
+    const rows = rowsLabelled("poetCities", "Camarina");
+    assert.equal(rows.length, 1);
+    assert.equal(id(rows[0].cityId), 254);
+    const city = cityById(254);
+    assert.equal(city.cityname, "Erythrae");
+    assert.equal(city.lat, "38.382778");
+    assert.equal(city.long, "26.480833");
+    // Camarina is pleiades:462126 at 36.8718784874, 14.4483234195 — the Syracusan
+    // foundation of 599 BC, and the city of Psaumis in Olympians 4 and 5. It is
+    // roughly 1,100km from where it is currently drawn, in a different sea.
+    // Fixing means adding Camarina to cities.csv and repointing this row.
+    assert.ok(!raw.cities.some(c => c.cityname === "Camarina"),
+      "Camarina now exists in cities.csv; repoint the row and delete this test");
+  });
+
+  test("BUG: Pindar's Cyrene is plotted on Phocaea, in Ionia rather than Libya", () => {
+    const rows = rowsLabelled("poetCities", "Cyrene");
+    assert.equal(rows.length, 1);
+    assert.equal(id(rows[0].cityId), 255);
+    const city = cityById(255);
+    assert.equal(city.cityname, "Phocaea");
+    assert.equal(city.lat, "38.670353");
+    assert.equal(city.long, "26.753208");
+    // Cyrene is pleiades:373778 at 32.8200266273, 21.8565385134 — the city of
+    // Arcesilas and Telesicrates in Pythians 4, 5 and 9. It is currently drawn
+    // on the wrong continent.
+    assert.ok(!raw.cities.some(c => c.cityname === "Cyrene"),
+      "Cyrene now exists in cities.csv; repoint the row and delete this test");
+  });
+
+  test("BUG: Stesichorus' Phocis is plotted on Aetolia", () => {
+    const rows = rowsLabelled("geopoetCities", "Phocis");
+    assert.equal(rows.length, 1);
+    assert.equal(id(rows[0].cityId), 134);
+    assert.equal(cityById(134).cityname, "Aetolia");
+    // Stesichorus fr. 222 names both places, and both rows were given cityId 134.
+    // Phocis is pleiades:541048 at 38.5557075728, 22.686575589.
+    const aetolia = rowsLabelled("geopoetCities", "Aetolia");
+    assert.equal(aetolia.length, 1, "the same fragment also refers to Aetolia itself");
+    assert.equal(id(aetolia[0].cityId), 134);
+  });
+
+  test("BUG: one Adespota reference to Thrace is plotted on Priapus", () => {
+    const thrace = rowsLabelled("geopoetCities", "Thrace");
+    const wrong = thrace.filter(row => id(row.cityId) === 240);
+    const right = thrace.filter(row => id(row.cityId) === 129);
+    assert.equal(wrong.length, 1);
+    assert.equal(wrong[0].poetname, "Adespota");
+    assert.ok(right.length >= 10, "every other Thrace reference uses cityId 129");
+    assert.equal(cityById(240).cityname, "Priapus");
+    assert.equal(cityById(129).cityname, "Thrace");
+    // This one needs no new city: repoint the Adespota row from 240 to 129.
+  });
+});
+
+describe("known data bugs: malformed coordinates", () => {
+  test("BUG: Claros' latitude is missing its decimal point", () => {
+    const claros = raw.cities.find(c => c.cityname === "Claros");
+    assert.equal(id(claros.cityId), 226);
+    assert.equal(claros.lat, "384725");
+    // The longitude, 27.192987, matches pleiades:599719 to five decimals, so the
+    // latitude should be that entry's 38.0047324117 — not 38.4725, which is what
+    // simply reinserting a decimal point would give.
+    assert.equal(claros.long, "27.192987");
+    // Nothing references Claros yet, so nothing is visibly misplaced today.
+    const referenced = [...raw.poetCities, ...raw.geopoetCities]
+      .filter(row => id(row.cityId) === 226);
+    assert.equal(referenced.length, 0);
+  });
+
+  test("BUG: Etruria's longitude is missing its decimal point", () => {
+    const etruria = raw.cities.find(c => c.cityname === "Etruria");
+    assert.equal(id(etruria.cityId), 197);
+    assert.equal(etruria.long, "118301");
+    assert.equal(etruria.lat, "42.924252");
+    // Should be 11.8301, which with the existing latitude lands in Etruria.
+    // Alternatively pleiades:413122 gives 42.6734380491, 11.5337751287 for the
+    // region as a whole.
+    const referenced = [...raw.poetCities, ...raw.geopoetCities]
+      .filter(row => id(row.cityId) === 197);
+    assert.equal(referenced.length, 1);
+    assert.equal(referenced[0].poetname, "Critias",
+      "Critias refers to Etruria, so a dot is visibly misplaced on the map");
+  });
+});
+
+describe("known data bugs: rows that never reach the map", () => {
+  test("BUG: 13 geographical imaginary citations point at cities that do not exist", () => {
+    const orphans = raw.geopoetCities.filter(row =>
+      filled(row.cityId) && !cityIds.has(id(row.cityId)));
+    assert.equal(orphans.length, 13);
+    assert.equal(new Set(orphans.map(row => id(row.cityId))).size, 12);
+    // calculateBubbles() skips any row whose cityId does not resolve, so these
+    // citations are researched, translated, cited — and render nowhere.
+    //
+    // Three are locatable in Pleiades:
+    //   217 Phthia      -> Achaea Phthiotis, pleiades:540585, 39.05279336, 22.5324060812
+    //   227 Corax       -> Koraxoi, pleiades:857198, 43.3454532124, 40.5402046191
+    //                      (the Colchian people, not Mt Korax in Aetolia)
+    //   228 Cylicrania  -> the Kylikranes lived at Herakleia Trachinia, already
+    //                      cityId 74; the fragment names Herakleia in its next line
+    //
+    // Three are judgement calls: 154 Dryopis/Doris (two rows share the id, and
+    // the Telestes one is the Dorian musical mode, not a place), 165 Denthiades
+    // (a wine), 221 Sintia (the Greek is corrupt).
+    //
+    // Six look genuinely unlocatable: 156 Annichorum, 170 Five Crests, 172 Ibe,
+    // 173 Nyrsylas, 238 Mytalis, 239 Phlyesia.
+    assert.deepEqual(
+      [...new Set(orphans.map(row => id(row.cityId)))].sort((a, b) => a - b),
+      [154, 156, 165, 170, 172, 173, 217, 221, 227, 228, 238, 239]
+    );
+  });
+
+  test("BUG: 8 genres rows belong to poets that are not in poets.csv", () => {
+    const orphans = raw.genres.filter(row => !poetIds.has(id(row.poetId)));
+    assert.equal(orphans.length, 8);
+    assert.deepEqual(
+      [...new Set(orphans.map(row => id(row.poetId)))].sort((a, b) => a - b),
+      [14, 31, 33, 113]
+    );
+    // These poets appear to have been renumbered: there is both an Aristotle 31
+    // and an Aristotle 151, a Kastorion 33 and a Castorion, a Kinesias 14 and a
+    // Cinesias 4. getGenres() returns [] for them, so the rows are simply dead.
+  });
+});
+
+describe("known data bugs: incomplete or inconsistent fields", () => {
+  test("BUG: 18 poets_cities citations have no translation or translator", () => {
+    const incomplete = raw.poetCities.filter(row =>
+      filled(row.source_citation) &&
+      !(filled(row.source_translation) && filled(row.source_translator)));
+    assert.equal(incomplete.length, KNOWN_INCOMPLETE_CITATION_COUNT);
+    // renderReference() prints `Citation: X: "" (trans. )` for these. This is
+    // the shape of issues #313 and #329. geopoetCities and genres are clean.
+    for (const file of ["geopoetCities", "genres"]) {
+      const bad = raw[file].filter(row =>
+        filled(row.source_citation) &&
+        !(filled(row.source_translation) && filled(row.source_translator)));
+      assert.equal(bad.length, 0);
+    }
+  });
+
+  test("BUG: Tyrtaeus is misspelt Trytaeus in four poets_cities rows", () => {
+    const misspelt = raw.poetCities.filter(row => row.poetname === "Trytaeus");
+    assert.equal(misspelt.length, 4);
+    // The poetId is correct (145), and popups display poetDetailName from
+    // poets.csv, so this is cosmetic — but calcBubbles sorts geographical
+    // imaginary poets by poetname, so a misspelling can misorder a list.
+    assert.ok(misspelt.every(row => id(row.poetId) === 145));
+    assert.equal(raw.poets.find(p => id(p.poetId) === 145).poetname, "Tyrtaeus");
+  });
+
+  test("BUG: two names carry stray whitespace", () => {
+    const cityOffenders = raw.cities.filter(c => c.cityname !== c.cityname.trim());
+    const poetOffenders = raw.poets.filter(p => p.poetname !== p.poetname.trim());
+    assert.equal(cityOffenders.length, 1);
+    assert.equal(cityOffenders[0].cityname, "Plataea\r\n");
+    assert.equal(poetOffenders.length, 1);
+    assert.equal(poetOffenders[0].poetname, "Lamynthios ");
+    // A newline inside a quoted CSV field, almost certainly from a spreadsheet.
+    // Both render with stray space in tooltips and sort inconsistently.
+  });
+});

--- a/tests/helpers/csv.js
+++ b/tests/helpers/csv.js
@@ -1,0 +1,74 @@
+// A minimal RFC-4180 CSV reader, so the tests have no dependencies at all.
+//
+// The site itself parses these files with Papa Parse in the browser; the tests
+// deliberately do not reuse that code, both to avoid vendoring it into Node and
+// so that a parser bug cannot hide a data bug from itself.
+
+// Returns an array of rows, each an array of raw string fields. Strips a
+// leading UTF-8 BOM, which regions.csv and big_regions.csv both have.
+export function parseCsvRows(text) {
+  if (text.charCodeAt(0) === 0xfeff) text = text.slice(1);
+
+  const rows = [];
+  let row = [];
+  let field = "";
+  let inQuotes = false;
+
+  for (let i = 0; i < text.length; i++) {
+    const char = text[i];
+
+    if (inQuotes) {
+      if (char === '"') {
+        if (text[i + 1] === '"') {
+          field += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        field += char;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      inQuotes = true;
+    } else if (char === ",") {
+      row.push(field);
+      field = "";
+    } else if (char === "\r") {
+      // handled by the \n that follows
+    } else if (char === "\n") {
+      row.push(field);
+      rows.push(row);
+      row = [];
+      field = "";
+    } else {
+      field += char;
+    }
+  }
+
+  if (field !== "" || row.length > 0) {
+    row.push(field);
+    rows.push(row);
+  }
+
+  return rows;
+}
+
+/**
+ * Reads a CSV into objects keyed by its header row, the same shape Papa Parse
+ * produces in the browser. Fields are left as strings.
+ */
+export function parseCsv(text) {
+  const rows = parseCsvRows(text);
+  if (rows.length === 0) return [];
+  const header = rows[0];
+  return rows.slice(1).map(cells => {
+    const obj = {};
+    header.forEach((name, idx) => {
+      obj[name] = cells[idx] ?? "";
+    });
+    return obj;
+  });
+}

--- a/tests/helpers/loadData.js
+++ b/tests/helpers/loadData.js
@@ -1,0 +1,70 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { parseCsv } from "./csv.js";
+import { initializeData } from "../../js/calcData/data.js";
+
+const dataFilesDir = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "dataFiles");
+
+/** The data-bag key each CSV is loaded onto, mirroring js/calcData/parseCsvs.js. */
+const FILES = {
+  regions: "regions.csv",
+  cities: "cities.csv",
+  poetCities: "poets_cities.csv",
+  poets: "poets.csv",
+  genres: "genres.csv",
+  geopoetCities: "geographical_imaginary_group.csv",
+  cityPolitics: "city_politics.csv",
+  bigRegions: "big_regions.csv",
+  dates: "dates.csv",
+  governments: "governments.csv"
+};
+
+/**
+ * The CSVs exactly as they sit on disk: every field a string, nothing derived.
+ * Use this for data-integrity assertions.
+ */
+export function loadRawCsvs() {
+  const raw = {};
+  for (const [key, filename] of Object.entries(FILES)) {
+    raw[key] = parseCsv(readFileSync(join(dataFilesDir, filename), "utf8"));
+  }
+  return raw;
+}
+
+/**
+ * The CSVs run through the real initializeData(), i.e. the same object the
+ * browser builds before it draws anything. Use this for behaviour assertions.
+ *
+ * The app reports missing lookups by calling alert() and console.log(), neither
+ * of which should ever fire against good data, so both are captured and handed
+ * back for assertion rather than printed.
+ */
+export function loadInitializedData() {
+  const data = loadRawCsvs();
+
+  const alerts = [];
+  const logs = [];
+
+  const realAlert = (globalThis).alert;
+  const realLog = console.log;
+  (globalThis).alert = (message) => alerts.push(String(message));
+  console.log = (...args) => logs.push(args.join(" "));
+
+  try {
+    initializeData((data));
+  } finally {
+    (globalThis).alert = realAlert;
+    console.log = realLog;
+  }
+
+  return { data, alerts, logs };
+}
+
+/**
+ * Ids are written inconsistently in the CSVs — "132", "132.00", "" — and the
+ * app normalises them with parseInt. Tests must compare them the same way.
+ */
+export function toId(value) {
+  return parseInt(value);
+}

--- a/tests/initializeData.test.js
+++ b/tests/initializeData.test.js
@@ -1,0 +1,231 @@
+// Behaviour of js/calcData/data.js, run against the real CSVs.
+//
+// initializeData() is pure JavaScript with no browser dependencies, so Node can
+// run the exact pipeline the browser runs and assert on what comes out.
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { loadInitializedData } from "./helpers/loadData.js";
+import { sortAlphabetically } from "../js/calcData/data.js";
+
+const { data, alerts, logs } = loadInitializedData();
+
+const poetIdByName = (name) => {
+  const poet = data.poets.find((p) => p.poetname === name);
+  assert.ok(poet, `no poet named ${name}`);
+  return poet.poetId;
+};
+
+describe("initializeData runs clean", () => {
+  test("no alerts", () => {
+    assert.deepEqual(alerts, [], "initializeData alerted, which means a poet lookup failed");
+  });
+
+  test("no console warnings about unresolved ids", () => {
+    assert.deepEqual(logs, [], `initializeData logged:\n  ${logs.join("\n  ")}`);
+  });
+});
+
+describe("hydration", () => {
+  test("ids and coordinates become numbers", () => {
+    for (const city of data.cities.slice(0, 20)) {
+      assert.equal(typeof city.cityId, "number");
+      if (city.lat !== "") assert.equal(typeof city.lat, "number");
+    }
+    for (const pc of data.poetCities.slice(0, 20)) {
+      assert.equal(typeof pc.poetId, "number");
+      assert.equal(typeof pc.cityId, "number");
+    }
+  });
+
+  test("dates become negative years, so BCE sorts naturally", () => {
+    for (const date of data.dates) {
+      assert.ok(date.date < 0, `date ${date.date} should be negative (BCE)`);
+    }
+    assert.ok(data.dates.every((d) => d.date >= -900 && d.date <= -300));
+  });
+
+  test("every lookup table is populated", () => {
+    for (const key of [
+      "citiesById", "poetsById", "regionsById", "genresByPoetId", "genresByGenreId",
+      "govsByCityId", "govsById", "datesByPoetId",
+      "linesByPoetId", "linesByBornCityId", "linesByActiveCityId"
+    ]) {
+      assert.ok(Object.keys(data[key]).length > 0, `${key} is empty`);
+    }
+  });
+
+  test("every row is primed with its poet's display data", () => {
+    for (const pc of [...data.poetCities, ...data.geopoetCities]) {
+      assert.equal(typeof pc.poetDetailName, "string");
+      assert.ok(pc.poetDetailName.length > 0, `row for poetId ${pc.poetId} has no poetDetailName`);
+      assert.equal(typeof pc.poetDates, "string");
+    }
+  });
+});
+
+describe("date filtering depends on every mapped poet having dates", () => {
+  // getDateFilterFn() drops any poet with no minDate/maxDate from the map
+  // entirely. Nothing in the code enforces that they exist, so it is asserted
+  // here instead.
+  test("every poet on the map has a min and max date", () => {
+    const mapped = new Set([...data.poetCities, ...data.geopoetCities].map((pc) => pc.poetId));
+    for (const poetId of mapped) {
+      const poet = data.poetsById[poetId];
+      assert.ok(poet, `poetId ${poetId} is on the map but not in poets.csv`);
+      assert.equal(typeof poet.minDate, "number", `${poet.poetname} has no minDate, so is invisible on the map`);
+      assert.equal(typeof poet.maxDate, "number", `${poet.poetname} has no maxDate, so is invisible on the map`);
+      assert.ok(poet.minDate <= poet.maxDate, `${poet.poetname} has minDate after maxDate`);
+    }
+  });
+});
+
+describe("travel lines", () => {
+  test("one line per (birthplace, place of activity) pair", () => {
+    const byPoet = new Map();
+    for (const pc of data.poetCities) {
+      if (!byPoet.has(pc.poetId)) byPoet.set(pc.poetId, { born: 0, active: 0 });
+      const counts = byPoet.get(pc.poetId);
+      if (pc.relationshipId === 1) counts.born++;
+      else if (pc.relationshipId === 2 || pc.relationshipId === 3) counts.active++;
+    }
+    let expected = 0;
+    for (const { born, active } of byPoet.values()) expected += born * active;
+    assert.equal(data.lines.length, expected);
+  });
+
+  test("a poet with two attested birthplaces gets a line from each", () => {
+    // Alcman is reported as a Spartan (Suda A 1290) and as a Lydian from Sardis
+    // (Crates); the map shows both, which is what issue #332 is about.
+    const alcman = poetIdByName("Alcman");
+    const lines = data.linesByPoetId[alcman];
+    const journeys = lines.map((l) => `${l.bornCity.cityname} -> ${l.activeCity.cityname}`).sort();
+    assert.deepEqual(journeys, ["Sardis -> Sparta", "Sparta -> Sparta"]);
+  });
+
+  test("every line resolves both its cities and carries its citations", () => {
+    for (const line of data.lines) {
+      assert.ok(line.bornCity, `line for poetId ${line.poetId} has no born city`);
+      assert.ok(line.activeCity, `line for poetId ${line.poetId} has no active city`);
+      assert.equal(line.bornPc.relationshipId, 1);
+      assert.ok([2, 3].includes(line.activePc.relationshipId));
+    }
+  });
+
+  test("poets with a birthplace but nowhere to go are listed as unknown travel", () => {
+    assert.ok(data.poetsWithUnknownTravel.length > 0);
+    const travelling = new Set(data.lines.map((l) => l.poetId));
+    for (const [poetId] of data.poetsWithUnknownTravel) {
+      assert.ok(!travelling.has(poetId), `poetId ${poetId} both travels and has unknown travel`);
+    }
+  });
+
+  test("government ids are unpacked for mixed regimes", () => {
+    // convertMixedGovIds: 9 = oligarchy/tyranny, so it implies 1 and 2 as well.
+    const mixed = data.lines.filter((l) => l.bornGovIds.includes(9));
+    for (const line of mixed) {
+      assert.ok(line.bornGovIds.includes(1) && line.bornGovIds.includes(2),
+        "a line born under oligarchy/tyranny should match both oligarchy and tyranny filters");
+    }
+  });
+});
+
+describe("control bar contents", () => {
+  test("Pindar and Bacchylides are excluded from the geographical imaginary", () => {
+    // Their geographical imaginary is a pilot of one poem each (Olympian 1 and
+    // Ode 17), so they are deliberately kept out of the poet list. See issue #326.
+    const names = data.geoImaginaryPoets.map((t) => t[1]);
+    assert.ok(!names.includes("Pindar"));
+    assert.ok(!names.includes("Bacchylides"));
+  });
+
+  test("Sappho or Alcaeus sorts last, after the individually named poets", () => {
+    const last = data.geoImaginaryPoets[data.geoImaginaryPoets.length - 1];
+    assert.match(last[1], /Sappho/);
+  });
+
+  test("every control bar list is sorted and non-empty", () => {
+    for (const key of ["travelPoets", "travelCities", "poetsWithUnknownTravel", "regionsForInterface"]) {
+      const list = data[key];
+      assert.ok(list.length > 0, `${key} is empty`);
+      const names = list.map((t) => t[1]);
+      assert.deepEqual(names, [...names].sort(sortAlphabetically), `${key} is not sorted`);
+    }
+  });
+
+  test("the geographical imaginary poets are sorted apart from Sappho/Alcaeus at the end", () => {
+    const names = data.geoImaginaryPoets.map((t) => t[1]);
+    assert.ok(names.length > 0);
+    const allButLast = names.slice(0, -1);
+    assert.deepEqual(allButLast, [...allButLast].sort(sortAlphabetically));
+  });
+
+  test("every control bar entry points at something real", () => {
+    for (const [poetId] of [...data.travelPoets, ...data.geoImaginaryPoets, ...data.poetsWithUnknownTravel]) {
+      assert.ok(data.poetsById[poetId], `control bar offers unknown poetId ${poetId}`);
+    }
+    for (const [cityId] of data.travelCities) {
+      assert.ok(data.citiesById[cityId], `control bar offers unknown cityId ${cityId}`);
+    }
+  });
+});
+
+describe("sortAlphabetically", () => {
+  test("sorts letters normally", () => {
+    assert.deepEqual(["Sappho", "Alcman", "Pindar"].sort(sortAlphabetically), ["Alcman", "Pindar", "Sappho"]);
+  });
+
+  test("pushes names that do not start with a letter to the end", () => {
+    assert.deepEqual(["Ἀλκμάν", "Sappho", "[Anon.]"].sort(sortAlphabetically)[0], "Sappho");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// KNOWN BUGS in the derived data. As in data-integrity.test.js, these assert
+// what is currently WRONG and are named "BUG:" accordingly. A failure here is
+// the signal to delete the test, not to restore the behaviour.
+// ---------------------------------------------------------------------------
+
+describe("known bugs: derived travel lines", () => {
+  test("BUG: a poet born and active in the same city gets a zero-length line", () => {
+    // createLines() takes the cartesian product of birthplaces and places of
+    // activity without excluding the case where the two are the same city.
+    const degenerate = data.lines.filter((l) => l.bornCityId === l.activeCityId);
+    assert.deepEqual(
+      degenerate.map((l) => `${l.poetDetailName}: ${l.bornCity.cityname}`).sort(),
+      ["Alcman: Sparta", "Corinna: Thebes", "Tyrtaeus: Sparta"]
+    );
+
+    // L.geodesic draws nothing for a zero-length pair, so these lines are
+    // invisible. drawLines() still adds a transparent click target of
+    // weight * 20 over the city, tooltipped e.g. "SPARTA -> SPARTA".
+    //
+    // The fix is one line in createLines():
+    //   if (bornPc.cityId === activePc.cityId) continue;
+    assert.equal(degenerate.length, 3);
+  });
+
+  test("BUG: for disputed origins, it is the native tradition that renders invisibly", () => {
+    // All three poets above have several reported birthplaces, one of which is
+    // the city they were active in. That is precisely the line that vanishes,
+    // so the map draws the foreign-origin traditions and silently drops the
+    // native one. This is the travel-map half of issue #332, and it is worse
+    // than the popup wording: the omission cannot be seen at all.
+    for (const [name, invisible, drawn] of [
+      ["Alcman", "Sparta", ["Sardis"]],
+      ["Corinna", "Thebes", ["Tanagra"]]
+    ]) {
+      const lines = data.linesByPoetId[poetIdByName(name)];
+      const visible = lines.filter((l) => l.bornCityId !== l.activeCityId);
+      assert.deepEqual(visible.map((l) => l.bornCity.cityname).sort(), drawn,
+        `${name}'s only drawn origin is the one the sources dispute`);
+      assert.ok(lines.some((l) => l.bornCity.cityname === invisible && l.bornCityId === l.activeCityId));
+    }
+
+    // Tyrtaeus is affected too, but has a second place of activity (Messenia),
+    // so his Spartan origin still reaches the map via Sparta -> Messenia.
+    const tyrtaeus = data.linesByPoetId[poetIdByName("Tyrtaeus")];
+    assert.ok(tyrtaeus.some((l) =>
+      l.bornCity.cityname === "Sparta" && l.activeCity.cityname !== "Sparta"));
+  });
+});

--- a/tests/popups.test.js
+++ b/tests/popups.test.js
@@ -1,0 +1,160 @@
+// Rendering tests for the popups, driven through the real filter pipeline.
+//
+// calcPoetCities() and calculateBubbles() are pure, so Node can build the exact
+// bubbles the browser builds and assert on the html they produce. These are the
+// tests to lean on when changing popup copy — notably issue #332, which will
+// change how a poet with several reported birthplaces is described.
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { loadInitializedData } from "./helpers/loadData.js";
+import { calcPoetCities } from "../js/renderMap/calcPoetCities.js";
+import { calculateBubbles } from "../js/renderMap/calcBubbles.js";
+import { createTravelPopupHtml } from "../js/popups/travelPopups.js";
+
+const { data } = loadInitializedData();
+
+const ALL_DATES = { minDate: -800, maxDate: -400 };
+
+function bubblesFor(currentMapMode, selectedId) {
+  const state = ({ currentMapMode, selectedId, ...ALL_DATES });
+  return calculateBubbles(state, data, calcPoetCities(data, state));
+}
+
+const cityIdByName = (name) => {
+  const city = data.cities.find((c) => c.cityname === name);
+  assert.ok(city, `no city named ${name}`);
+  return city.cityId;
+};
+
+describe("places map: origin", () => {
+  const bubbles = bubblesFor("placesMode", "relationship_1");
+
+  test("a birthplace bubble is titled 'POETS BORN IN <city>'", () => {
+    const sparta = bubbles[cityIdByName("Sparta")];
+    assert.ok(sparta, "no bubble for Sparta");
+    assert.match(sparta.popupHtml, /POETS BORN IN SPARTA/);
+  });
+
+  test("Alcman appears under both Sparta and Sardis", () => {
+    // The heart of issue #332: the sources disagree about where Alcman was
+    // born, so he is currently asserted as a native of both, with no hedging.
+    // When the copy changes, these two assertions are what should change.
+    for (const cityname of ["Sparta", "Sardis"]) {
+      const bubble = bubbles[cityIdByName(cityname)];
+      assert.ok(bubble, `no bubble for ${cityname}`);
+      assert.match(bubble.popupHtml, /Alcman/, `Alcman missing from ${cityname}`);
+      assert.match(bubble.popupHtml, new RegExp(`POETS BORN IN ${cityname.toUpperCase()}`));
+      // Note: /possibly/i alone would match the genre "Possibly lyric".
+      assert.doesNotMatch(bubble.popupHtml, /possibly born/i,
+        `${cityname} already hedges Alcman's birth; issue #332 may have landed, so update this test`);
+    }
+  });
+
+  test("popups carry dates, sources and the Greek text of the citation", () => {
+    const sardis = bubbles[cityIdByName("Sardis")];
+    assert.match(sardis.popupHtml, /Dates:/);
+    assert.match(sardis.popupHtml, /Source\(s\):/);
+    assert.match(sardis.popupHtml, /Citation:/);
+    assert.match(sardis.popupHtml, /Greek:/);
+    // Both sides are normalised defensively: the corpus is NFC (enforced by
+    // data-integrity.test.js), but Greek typed into a test file can easily
+    // arrive as oxia, which would render identically and never match.
+    assert.ok(
+      sardis.popupHtml.normalize("NFC").includes("Ἀλκμάν".normalize("NFC")),
+      "the Suda's Greek should be quoted in the Sardis popup"
+    );
+  });
+});
+
+describe("places map: activity", () => {
+  const bubbles = bubblesFor("placesMode", "relationship_3");
+
+  test("a city's poets are split into natives and non-natives", () => {
+    const athens = bubbles[cityIdByName("Athens")];
+    assert.ok(athens, "no bubble for Athens");
+    assert.match(athens.popupHtml, /NATIVE LYRIC ACTIVITY IN ATHENS/);
+    assert.match(athens.popupHtml, /NON-NATIVE LYRIC ACTIVITY IN ATHENS/);
+    assert.match(athens.popupHtml, /NATIVE POETS/);
+    assert.match(athens.popupHtml, /NON-NATIVE POETS/);
+  });
+
+  test("every bubble produces html and a legend", () => {
+    for (const bubble of Object.values(bubbles)) {
+      const b = (bubble);
+      assert.equal(typeof b.popupHtml, "string");
+      assert.ok(b.popupHtml.length > 0);
+      assert.equal(b.legend, b.city.cityname);
+      assert.ok(b.price > 0, `${b.city.cityname} has no bubble size`);
+    }
+  });
+});
+
+describe("geographical imaginary map", () => {
+  const bubbles = bubblesFor("geoimaginaryMode", "all_1");
+
+  test("a bubble counts the references made to it", () => {
+    const bubble = (Object.values(bubbles))
+      .find((b) => b.poetCities.length > 1);
+    assert.ok(bubble, "expected at least one city referred to more than once");
+    assert.match(bubble.popupHtml, /\d+ REFERENCES TO /);
+  });
+
+  test("poets are grouped, so one poet with three references is listed once", () => {
+    for (const bubble of Object.values(bubbles)) {
+      const b = (bubble);
+      const poetIds = b.poets.map((p) => p.poetId);
+      assert.equal(new Set(poetIds).size, poetIds.length, `${b.city.cityname} lists a poet twice`);
+      const totalReferences = b.poets.reduce((n, p) => n + p.references.length, 0);
+      assert.equal(totalReferences, b.poetCities.length);
+    }
+  });
+
+  test("singular and plural are used correctly", () => {
+    const single = (Object.values(bubbles))
+      .find((b) => b.poetCities.length === 1);
+    assert.ok(single);
+    assert.match(single.popupHtml, /1 REFERENCE TO /);
+    assert.doesNotMatch(single.popupHtml, /1 REFERENCES TO /);
+  });
+});
+
+describe("travel map", () => {
+  test("an arc popup names both ends, the poets, and both citations", () => {
+    const line = data.lines.find((l) => l.poetDetailName === "Pindar");
+    assert.ok(line, "expected Pindar to have a travel line");
+    const drawnLine = {
+      fromCity: line.bornCity,
+      toCity: line.activeCity,
+      poetLines: [line],
+      dotted: false,
+      color: "#fc1804",
+      name: `${line.bornCity.infowindowName} -> ${line.activeCity.infowindowName}`.toUpperCase(),
+      weight: 3,
+      popupHtml: ""
+    };
+    const html = createTravelPopupHtml(data, (drawnLine));
+    assert.match(html, /POET\(S\)/);
+    assert.match(html, /Pindar/);
+    assert.match(html, /ORIGIN SOURCE/);
+    assert.match(html, /ACTIVITY SOURCE/);
+    assert.match(html, /THEBES/);
+  });
+});
+
+describe("popup html is well formed enough to render", () => {
+  test("no popup leaks 'undefined' or 'NaN' into the page", () => {
+    for (const [mode, selectedId] of [
+      ["placesMode", "relationship_1"],
+      ["placesMode", "relationship_3"],
+      ["geoimaginaryMode", "all_1"]
+    ]) {
+      for (const bubble of Object.values(bubblesFor(mode, selectedId))) {
+        const html = (bubble).popupHtml;
+        const cityname = (bubble).city.cityname;
+        assert.doesNotMatch(html, /undefined/, `${mode}/${selectedId} popup for ${cityname} contains "undefined"`);
+        assert.doesNotMatch(html, /NaN/, `${mode}/${selectedId} popup for ${cityname} contains "NaN"`);
+      }
+    }
+  });
+});


### PR DESCRIPTION
First of two PRs adding developer tooling. This one is tests; the types PR (#2 in the stack) builds on it.

**No site code is touched.** Every test passes against `master` exactly as it stands.

## What

52 tests on Node's built-in test runner.

```sh
node --test tests/*.test.js     # or: npm test
```

Nothing to install, no dependencies, no config file. That is the same bet the rest of the project makes: `node --test` works today and should keep working, whereas a Jest or Vitest setup would need feeding every couple of years.

`package.json` is added only so Node treats these files as the ES modules they already are, which is what lets the tests import `js/` directly. It has no dependencies and the site never reads it.

## Why data tests specifically

Look at what has actually broken here over the years — #311 "errors in geographical imaginary", #313 "citations are inconsistent", #329 "citations broken again". Those are **data** bugs, not code bugs. The CSVs are hand-edited in spreadsheets by several people across a decade, and nothing has ever checked them.

`tests/data-integrity.test.js` covers:

- primary keys are unique
- every join resolves — poet ids, city ids, region ids, government ids, across all six tables
- a row's `cityname` label agrees with the city its `cityId` points at
- coordinates are present in pairs and land inside the mapped world
- citations that exist are complete (citation → translation → translator)
- every file stays NFC-normalised, now that #333 has fixed the mixed Greek encoding

## Four real problems it found

None are fixed here. Where to put Camarina, or whether "Ibe" can be located at all, are curatorial decisions rather than engineering ones. Each is recorded at the top of the test file with a comment explaining what would resolve it, so the suite is green while the debt is named — and **any new instance fails the build**.

1. **Pindar is plotted in the wrong sea, twice.** His Camarina row points at `cityId 254` = Erythrae in Ionia; his Cyrene row at `255` = Phocaea in Ionia. Camarina is in Sicily, Cyrene in Libya — each about a thousand kilometres out, and in Cyrene's case the wrong continent. Neither city exists in `cities.csv` at all. This is live on the site now.
2. **Two more mis-keys.** Stesichorus' Phocis (fr. 222, which names both places) is plotted on Aetolia; one Adespota reference to Thrace sits on Priapus while the other eleven use `cityId 129`.
3. **Two coordinates lost their decimal point.** Claros has latitude `384725`, Etruria longitude `118301`. Etruria is referenced by Critias, so a dot is visibly misplaced.
4. **13 geographical imaginary citations are invisible.** They point at cityIds absent from `cities.csv`, and `calculateBubbles` silently skips rows that do not resolve — so Alcman fr. 1.59, Hipponax, Anacreon fr. eleg. 3, Stesichorus and Telestes are researched, cited, and render nowhere.

Pleiades coordinates have been gathered for the locatable ones; that will be a separate PR.

## The other two files

`tests/initializeData.test.js` runs the real pipeline over the real CSVs and asserts on what comes out — hydration, lookup tables, travel line construction, control bar contents. It also pins an invariant nothing in the code enforces: **every poet on the map has dates**, without which `getDateFilterFn` silently filters them off it.

`tests/popups.test.js` builds the same bubbles the browser builds and asserts on the rendered html. The Alcman cases are deliberately written to **fail if issue #332 lands**, so that copy change cannot happen silently.

## Also

A GitHub Actions workflow running the suite on pushes to master and on PRs, and a README section on working with the code.