### PR TITLE
Add JSDoc types and a TypeScript check, with no build step

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,7 +1,10 @@
 name: check
 
-# Runs the data-integrity and rendering tests. Nothing is installed: the tests
-# use Node's built-in runner and the project has no dependencies.
+# Runs the tests, then typechecks both the site source and the tests.
+#
+# Nothing is bundled or compiled. The tests run with no install at all; the
+# typecheck needs @types/node, which is the project's only dependency and is
+# type declarations rather than code.
 
 on:
   push:
@@ -20,5 +23,13 @@ jobs:
           # node:test, node:assert and node:fs, so any Node 20+ will do;
           # 'lts/*' also works if you would rather this never need touching.
           node-version: '24'
+
+      # Deliberately before the install, to keep it honest that the test suite
+      # needs nothing but Node.
       - name: Tests
         run: node --test tests/*.test.js
+
+      - name: Install type declarations
+        run: npm ci
+      - name: Typecheck
+        run: npx -y -p typescript@5 tsc -p jsconfig.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+node_modules

--- a/README.md
+++ b/README.md
@@ -27,3 +27,18 @@ node --test tests/*.test.js     # or: npm test
 They use Node's built-in runner, so there is nothing to install. Most check the
 CSVs in `dataFiles/`, which is where this project's bugs have historically come
 from. Some record known data problems we plan to fix.
+
+### Types
+
+Types are JSDoc comments, declared in `types/` and checked by TypeScript in
+`--noEmit` mode. Nothing is compiled: the shipped files stay plain JavaScript,
+and deleting `jsconfig.json` and `types/` would leave the site working exactly
+as it does now.
+
+```sh
+npm ci && npm run typecheck
+```
+
+The one dependency is `@types/node`, needed to check the tests. It is type
+declarations rather than code: nothing from `node_modules` is imported, served
+or deployed.

--- a/index.js
+++ b/index.js
@@ -10,11 +10,14 @@ function main() {
   initializeCloseEssayClicks();
 
   const map = initializeMap();
-  const data = {};
+  // Starts empty; parseCsvs fills the raw arrays and initializeData derives the rest.
+  const data = /** @type {Data} */ ({});
+  /** @type {State} */
   const state = {
     "currentMapMode": "placesMode",
     "minDate": -800,
-    "maxDate": -400
+    "maxDate": -400,
+    "selectedId": "relationship_3"
   };
 
   parseCsvs(data)

--- a/js/assertUnreachable.js
+++ b/js/assertUnreachable.js
@@ -1,0 +1,22 @@
+/**
+ * Called in the branch where a union has been exhausted.
+ *
+ * TypeScript checks that the call really is unreachable: add a member to the
+ * union without handling it and `value` stops being `never`, so this stops
+ * compiling. That is what lets the callers drop their casts — after an
+ * if/else chain ending here, the remaining values are known, not merely assumed.
+ *
+ * At runtime it does what this codebase has always done with an unexpected
+ * state — alert, then fail — except that it fails immediately and names the
+ * offending value, instead of continuing and throwing something unrelated a
+ * few lines later.
+ *
+ * @param {never} value
+ * @param {string} message
+ * @returns {never}
+ */
+export function assertUnreachable(value, message) {
+  const description = `${message}: ${String(value)}`;
+  alert(description);
+  throw new Error(description);
+}

--- a/js/calcData/data.js
+++ b/js/calcData/data.js
@@ -1,27 +1,44 @@
 import { getPoet, getCity, getGenres, getGovs } from "./getters.js";
 
+/**
+ * Hydrates the raw CSV rows in place (ids and coordinates become numbers, dates
+ * become negative years) and builds every derived lookup the map needs.
+ * @param {Data} data
+ */
 export function initializeData(data) {
-  data.genres.forEach(genre => genre.genreId = parseInt(genre.genreId));
-  data.cities.forEach(city => city.cityId = parseInt(city.cityId));
-  data.cities.forEach(city => city.regionId = parseInt(city.regionId));
-  data.cities.forEach(city => city.lat = parseFloat(city.lat));
-  data.cities.forEach(city => city.long = parseFloat(city.long));
-  data.cityPolitics.forEach(city => city.cityId = parseInt(city.cityId));
-  data.cityPolitics.forEach(city => city.governmentId = parseInt(city.governmentId));
-  data.cityPolitics.forEach(cp => cp.date = -1 * parseInt(cp.date));
-  data.poetCities.forEach(poetCity => poetCity.relationshipId = parseInt(poetCity.relationshipId));
-  data.poetCities.forEach(poetCity => poetCity.poetId = parseInt(poetCity.poetId));
-  data.poetCities.forEach(poetCity => poetCity.cityId = parseInt(poetCity.cityId));
-  data.geopoetCities.forEach(poetCity => poetCity.poetId = parseInt(poetCity.poetId));
-  data.geopoetCities.forEach(poetCity => poetCity.imaginaryid = parseInt(poetCity.imaginaryid));
-  data.geopoetCities.forEach(poetCity => poetCity.cityId = parseInt(poetCity.cityId));
-  data.regions.forEach(region => region.regionId = parseInt(region.regionId));
-  data.regions.forEach(region => region.bigRegionId = parseInt(region.bigRegionId));
-  data.dates.forEach(date => {
+  // Papa Parse hands back every field as a string. These arrays are aliased as
+  // any[] for the hydration pass below; everywhere else in the codebase they
+  // are the hydrated types declared in types/globals.d.ts.
+  /** @type {any[]} */ const rawGenres = data.genres;
+  /** @type {any[]} */ const rawCities = data.cities;
+  /** @type {any[]} */ const rawCityPolitics = data.cityPolitics;
+  /** @type {any[]} */ const rawPoetCities = data.poetCities;
+  /** @type {any[]} */ const rawGeopoetCities = data.geopoetCities;
+  /** @type {any[]} */ const rawRegions = data.regions;
+  /** @type {any[]} */ const rawDates = data.dates;
+  /** @type {any[]} */ const rawGovernments = data.governments;
+
+  rawGenres.forEach(genre => genre.genreId = parseInt(genre.genreId));
+  rawCities.forEach(city => city.cityId = parseInt(city.cityId));
+  rawCities.forEach(city => city.regionId = parseInt(city.regionId));
+  rawCities.forEach(city => city.lat = parseFloat(city.lat));
+  rawCities.forEach(city => city.long = parseFloat(city.long));
+  rawCityPolitics.forEach(city => city.cityId = parseInt(city.cityId));
+  rawCityPolitics.forEach(city => city.governmentId = parseInt(city.governmentId));
+  rawCityPolitics.forEach(cp => cp.date = -1 * parseInt(cp.date));
+  rawPoetCities.forEach(poetCity => poetCity.relationshipId = parseInt(poetCity.relationshipId));
+  rawPoetCities.forEach(poetCity => poetCity.poetId = parseInt(poetCity.poetId));
+  rawPoetCities.forEach(poetCity => poetCity.cityId = parseInt(poetCity.cityId));
+  rawGeopoetCities.forEach(poetCity => poetCity.poetId = parseInt(poetCity.poetId));
+  rawGeopoetCities.forEach(poetCity => poetCity.imaginaryid = parseInt(poetCity.imaginaryid));
+  rawGeopoetCities.forEach(poetCity => poetCity.cityId = parseInt(poetCity.cityId));
+  rawRegions.forEach(region => region.regionId = parseInt(region.regionId));
+  rawRegions.forEach(region => region.bigRegionId = parseInt(region.bigRegionId));
+  rawDates.forEach(date => {
     date.poetId = parseInt(date.poetId);
     date.date = -1 * parseInt(date.date);
   })
-  data.governments.forEach(gov => gov.governmentId = parseInt(gov.governmentId));
+  rawGovernments.forEach(gov => gov.governmentId = parseInt(gov.governmentId));
 
   // create useful maps by key
   data.citiesById = {}
@@ -62,6 +79,10 @@ export function initializeData(data) {
   sortPoetCities(data, data.geopoetCities);
 }
 
+/**
+ * @param {Data} data
+ * @param {(PoetCity | GeoPoetCity)[]} poetCities
+ */
 function sortPoetCities(data, poetCities) {
   poetCities.sort((a, b) => {
     const poetA = getPoet(data, a.poetId);
@@ -70,6 +91,12 @@ function sortPoetCities(data, poetCities) {
   })
 }
 
+/**
+ * Copies a poet's display name, dates, sources and genres onto a row (or a
+ * travel line) so popups can render without a second lookup.
+ * @param {{ poetId: number, poetname?: string } & Partial<PoetPrimed>} obj
+ * @param {Data} data
+ */
 function primeObjWithPoetData(obj, data) {
   const poet = getPoet(data, obj.poetId);
 
@@ -89,6 +116,13 @@ function primeObjWithPoetData(obj, data) {
   obj.poetGenres = genres.map(genre => genre.genre).join(", ");
 }
 
+/**
+ * Sorts alphabetically, but pushes names starting with a non-letter (e.g. Greek
+ * characters) to the end.
+ * @param {string} a
+ * @param {string} b
+ * @returns {number}
+ */
 export function sortAlphabetically(a, b) {
   const aIsLetter = a.charAt(0).match(/[a-z]/i) !== null;
   const bIsLetter = b.charAt(0).match(/[a-z]/i) !== null;
@@ -97,6 +131,7 @@ export function sortAlphabetically(a, b) {
   return a < b ? -1 : 1;
 }
 
+/** @param {Data} data */
 function createGovsByCityId(data) {
   data.govsByCityId = {};
   for (const cp of data.cityPolitics) {
@@ -105,6 +140,7 @@ function createGovsByCityId(data) {
   }
 }
 
+/** @param {Data} data */
 function createGovsById(data) {
   data.govsById = {};
   for (const gov of data.governments) {
@@ -112,6 +148,7 @@ function createGovsById(data) {
   }
 }
 
+/** @param {Data} data */
 function addBigRegionIdToCities(data) {
   for (const city of data.cities) {
     if (
@@ -124,13 +161,15 @@ function addBigRegionIdToCities(data) {
   }
 }
 
+/** @param {Data} data */
 function addDatesToPoets(data) {
   data.datesByPoetId = {};
   for (const date of data.dates) {
     if (!data.datesByPoetId[date.poetId]) data.datesByPoetId[date.poetId] = [];
     data.datesByPoetId[date.poetId].push(date.date);
   }
-  for (const poetId in data.datesByPoetId) {
+  for (const poetIdStr in data.datesByPoetId) {
+    const poetId = Number(poetIdStr);
     const poet = getPoet(data, poetId);
     if (poet) {
       poet.minDate = Math.min(...data.datesByPoetId[poetId]);
@@ -139,6 +178,7 @@ function addDatesToPoets(data) {
   }
 }
 
+/** @param {Data} data */
 function createGenresByGenreId(data) {
   data.genresByGenreId = {}
   for (const genre of data.genres) {
@@ -155,17 +195,23 @@ function createGenresByGenreId(data) {
   }
 }
 
+/**
+ * @param {Iterable<number>} poetIds
+ * @param {Data} data
+ * @returns {IdNameTuple[]}
+ */
 function createAlphabetizedListOfPoetsFromIds(poetIds, data) {
   return Array
     .from(poetIds)
     .map(poetId => {
       const poet = getPoet(data, poetId);
       const poetDetailName = poet.poetDetailName;
-      return [poetId, poetDetailName];
+      return /** @type {IdNameTuple} */ ([poetId, poetDetailName]);
     })
     .sort((a, b) => sortAlphabetically(a[1], b[1]));
 }
 
+/** @param {Data} data */
 function createGeoImaginaryPoets(data) {
   const poetIdsToOmit = [
     151, // Aristotle
@@ -188,7 +234,12 @@ function createGeoImaginaryPoets(data) {
   putPoetIdAtEndOfPoetIdNameTuples(data.geoImaginaryPoets, sappAlcPoetId);
 }
 
+/**
+ * @param {IdNameTuple[]} array mutated in place
+ * @param {number} poetId
+ */
 function putPoetIdAtEndOfPoetIdNameTuples(array, poetId) {
+  /** @type {number | undefined} */
   let foundIdx;
   for (let idx = 0; idx < array.length; idx++) {
     if (array[idx][0] === poetId) {
@@ -203,6 +254,7 @@ function putPoetIdAtEndOfPoetIdNameTuples(array, poetId) {
   }
 }
 
+/** @param {Data} data */
 function createTravelPoets(data) {
   // why do we omit these guys?
   const poetIdsToOmit = [
@@ -218,6 +270,7 @@ function createTravelPoets(data) {
   data.travelPoets = createAlphabetizedListOfPoetsFromIds(poetIds, data);
 }
 
+/** @param {Data} data */
 function createTravelCities(data) {
   const cityIds = new Set(
     data.lines.flatMap(line => [line.bornCityId, line.activeCityId])
@@ -226,11 +279,12 @@ function createTravelCities(data) {
     .from(cityIds)
     .map(cityId => {
       const city = getCity(data, cityId);
-      return [cityId, city.cityname];
+      return /** @type {IdNameTuple} */ ([cityId, city.cityname]);
     })
     .sort((a, b) => sortAlphabetically(a[1], b[1]));
 }
 
+/** @param {Data} data */
 function createRegionsForInterface(data) {
   const regionIdsToOmit = [
     27, // Aeolis
@@ -249,11 +303,17 @@ function createRegionsForInterface(data) {
   ];
   data.regionsForInterface = data.regions
     .filter(region => !regionIdsToOmit.includes(region.regionId))
-    .map(region => [region.regionId, region.regionname])
+    .map(region => /** @type {IdNameTuple} */ ([region.regionId, region.regionname]))
     .sort((a, b) => sortAlphabetically(a[1], b[1]));
 }
 
+/**
+ * Builds one travel line per (birthplace, place-of-activity) pair. Poets with
+ * several attested birthplaces therefore yield several lines.
+ * @param {Data} data
+ */
 function createLines(data) {
+  /** @type {Record<number, { bornPcs: PoetCity[], activePcs: PoetCity[] }>} */
   const poets = {}
   for (const pc of data.poetCities) {
     if (!poets[pc.poetId]) poets[pc.poetId] = {
@@ -295,7 +355,8 @@ function createLines(data) {
               .map(gov => gov.governmentId)
               .flatMap(govId => convertMixedGovIds(govId))
           )];
-          const line = {
+          // The PoetPrimed fields are filled in by primeObjWithPoetData below.
+          const line = /** @type {Line} */ ({
             poetId: poetId,
             bornCityId: bornPc.cityId,
             activeCityId: activePc.cityId,
@@ -307,7 +368,7 @@ function createLines(data) {
             poetDetailName: poet.poetDetailName,
             bornGovIds: bornGovIds,
             activeGovIds: activeGovIds
-          };
+          });
           primeObjWithPoetData(line, data);
           data.lines.push(line);
         }
@@ -317,9 +378,13 @@ function createLines(data) {
   data.poetsWithUnknownTravel.sort((a, b) => sortAlphabetically(a[1], b[1]));
 }
 
+/**
+ * Some gov ids correspond to two government types (e.g. Kingship/Tyranny ->
+ * both kingship and tyranny); here we unpack these and include those types too.
+ * @param {number} govId
+ * @returns {number[]}
+ */
 function convertMixedGovIds(govId) {
-  // some gov ids correspond to two government types (e.g. Kingship/Tyranny -> both kingship and tyranny)
-  // here we unpack these and include those types as well
   if (govId === 9) {
     return [9, 1, 2] // oligarchy/tyranny, oligarchy, tyranny
   } else if (govId === 10) {
@@ -329,6 +394,7 @@ function convertMixedGovIds(govId) {
   } else return [govId];
 }
 
+/** @param {Data} data */
 function keyLines(data) {
   data.linesByPoetId = {};
   for (const line of data.lines) {
@@ -355,6 +421,7 @@ function keyLines(data) {
   }
 }
 
+/** @param {Data} data */
 function createGenreIdsWithNames(data) {
   const genresToOmit = [
     "1", // Diaskeue
@@ -363,7 +430,7 @@ function createGenreIdsWithNames(data) {
   data.genreIdsWithName =
     Object
       .keys(data.genresByGenreId)
-      .map((id) => [id, data.genresByGenreId[id]])
+      .map((id) => /** @type {[string, string]} */ ([id, data.genresByGenreId[Number(id)]]))
       .filter(kv => !genresToOmit.includes(kv[0]))
       .sort((a, b) => sortAlphabetically(a[1], b[1]));
 }

--- a/js/calcData/getters.js
+++ b/js/calcData/getters.js
@@ -1,18 +1,40 @@
+/**
+ * @param {Data} data
+ * @param {number} poetId
+ * @returns {Poet}
+ */
 export function getPoet(data, poetId) {
-  if (data.poetsById[poetId]) return data.poetsById[poetId];
-  console.log(`poetId ${poetId} does not exist in poetsById`);
+  const poet = data.poetsById[poetId];
+  if (!poet) console.log(`poetId ${poetId} does not exist in poetsById`);
+  return poet;
 }
 
+/**
+ * @param {Data} data
+ * @param {number} poetId
+ * @returns {Genre[]}
+ */
 export function getGenres(data, poetId) {
   if (data.genresByPoetId[poetId]) return data.genresByPoetId[poetId];
   else return [];
 }
 
+/**
+ * @param {Data} data
+ * @param {number} cityId
+ * @returns {City}
+ */
 export function getCity(data, cityId) {
-  if (data.citiesById[cityId]) return data.citiesById[cityId];
-  console.log(`cityId ${cityId} does not exist in citiesById`);
+  const city = data.citiesById[cityId];
+  if (!city) console.log(`cityId ${cityId} does not exist in citiesById`);
+  return city;
 }
 
+/**
+ * @param {Data} data
+ * @param {number} cityId
+ * @returns {CityPolitics[]}
+ */
 export function getGovs(data, cityId) {
   if (data.govsByCityId[cityId]) {
     return data.govsByCityId[cityId];
@@ -21,6 +43,11 @@ export function getGovs(data, cityId) {
   return [];
 }
 
+/**
+ * Splits state.selectedId (e.g. "poet_93") into its filter type and numeric id.
+ * @param {State} state
+ * @returns {[string, number]}
+ */
 export function getMapTypeNum(state) {
   const [type, stringNum] = state.selectedId.split("_");
   const num = parseInt(stringNum);

--- a/js/calcData/getters.js
+++ b/js/calcData/getters.js
@@ -43,13 +43,54 @@ export function getGovs(data, cityId) {
   return [];
 }
 
+/** The filters the places and geographical imaginary control bars offer. */
+export const PLACES_FILTER_TYPES = /** @type {PlacesFilterType[]} */ ([
+  "all", "relationship", "poet", "genre"
+]);
+
+/** The filters the travel control bar offers. */
+export const TRAVEL_FILTER_TYPES = /** @type {TravelFilterType[]} */ ([
+  "all", "poet", "destination", "smallregion", "region", "gov"
+]);
+
 /**
- * Splits state.selectedId (e.g. "poet_93") into its filter type and numeric id.
+ * Splits state.selectedId (e.g. "poet_93") into its filter type and numeric id,
+ * checking the type against the filters the given map actually offers.
+ *
+ * Validating here rather than trusting the string is what lets callers switch
+ * exhaustively over four or six cases instead of eight, with no branch for a
+ * filter their map cannot produce. selectedId always comes from a radio button
+ * this code generated, so a mismatch means the interface builders and the map
+ * modes have got out of step.
+ * @template {MapFilterType} T
  * @param {State} state
- * @returns {[string, number]}
+ * @param {T[]} allowed
+ * @param {string} mapName
+ * @returns {[T, number]}
  */
-export function getMapTypeNum(state) {
+function getFilter(state, allowed, mapName) {
   const [type, stringNum] = state.selectedId.split("_");
-  const num = parseInt(stringNum);
-  return [type, num];
+  const filterType = allowed.find(known => known === type);
+  if (!filterType) {
+    const message = `"${type}" is not a ${mapName} filter (selectedId "${state.selectedId}")`;
+    alert(message);
+    throw new Error(message);
+  }
+  return [filterType, parseInt(stringNum)];
+}
+
+/**
+ * @param {State} state
+ * @returns {[PlacesFilterType, number]}
+ */
+export function getPlacesFilter(state) {
+  return getFilter(state, PLACES_FILTER_TYPES, "places");
+}
+
+/**
+ * @param {State} state
+ * @returns {[TravelFilterType, number]}
+ */
+export function getTravelFilter(state) {
+  return getFilter(state, TRAVEL_FILTER_TYPES, "travel");
 }

--- a/js/calcData/parseCsvs.js
+++ b/js/calcData/parseCsvs.js
@@ -1,9 +1,19 @@
+/**
+ * @param {string} file raw CSV text
+ * @returns {Promise<{ data: any[] }>}
+ */
 async function papaParsePromise(file) {
   return new Promise(function (complete, error) {
     Papa.parse(file, { header: true, complete, error });
   });
 }
 
+/**
+ * Loads every CSV in dataFiles/ onto the shared data bag. Papa Parse yields
+ * every field as a string; initializeData() hydrates the numeric ones.
+ * @param {Data} data
+ * @returns {Promise<any[]>}
+ */
 export async function parseCsvs(data) {
   return Promise.all([
     parseCsv(data, "regions", "./dataFiles/regions.csv"),
@@ -19,6 +29,11 @@ export async function parseCsvs(data) {
   ])
 }
 
+/**
+ * @param {Data} data
+ * @param {keyof Data} parameter which key on the data bag to populate
+ * @param {string} filename
+ */
 async function parseCsv(data, parameter, filename) {
   return fetch(filename)
     .then((file) => file.text())

--- a/js/drawMap/drawBubbles.js
+++ b/js/drawMap/drawBubbles.js
@@ -1,5 +1,10 @@
 import { LYRIC_WHITE, LYRIC_RED } from "../constants/colors.js";
 
+/**
+ * Draws every city circle and its label, and re-sizes them on zoom.
+ * @param {LyricMap} map
+ * @param {Record<number, DrawableBubble>} bubbles
+ */
 export function drawBubblesAndLegends(map, bubbles) {
   const drawnBubbles = drawBubbles(map, bubbles);
   drawLegends(map, bubbles);
@@ -13,7 +18,13 @@ export function drawBubblesAndLegends(map, bubbles) {
   });
 }
 
+/**
+ * @param {LyricMap} map
+ * @param {Record<number, DrawableBubble>} bubbles
+ * @returns {any[]} the Leaflet circles, for re-sizing on zoom
+ */
 function drawBubbles(map, bubbles) {
+  /** @type {any[]} */
   const drawnBubbles = [];
 
   for (const bubble of Object.values(bubbles)) {
@@ -29,6 +40,14 @@ function drawBubbles(map, bubbles) {
   return drawnBubbles;
 }
 
+/**
+ * Draws a visible circle plus a larger invisible one, so small bubbles are
+ * still easy to click.
+ * @param {any} location a Leaflet LatLng
+ * @param {LyricMap} map
+ * @param {DrawableBubble} bubble
+ * @returns {any[]}
+ */
 function drawBubble(location, map, bubble) {
   const radius = calculateBubbleSize(map.getZoom(), bubble.price);
   const transparentCircle = L.circle(location,
@@ -59,6 +78,10 @@ function drawBubble(location, map, bubble) {
   return [transparentCircle, circle];
 }
 
+/**
+ * @param {LyricMap} map
+ * @param {Record<number, DrawableBubble>} bubbles
+ */
 function drawLegends(map, bubbles) {
   map.legendLayerGroup.clearLayers();
   for (const bubble of Object.values(bubbles)) {
@@ -72,6 +95,11 @@ function drawLegends(map, bubbles) {
   }
 }
 
+/**
+ * @param {any} location a Leaflet LatLng
+ * @param {LyricMap} map
+ * @param {DrawableBubble} bubble
+ */
 function drawLegend(location, map, bubble) {
   if (map.getZoom() >= minimumZoomToShowLegend(bubble.price)) {
     const textMarker = L.marker(location, {
@@ -86,6 +114,11 @@ function drawLegend(location, map, bubble) {
   }
 }
 
+/**
+ * Bigger bubbles get labelled sooner as you zoom out.
+ * @param {number} price
+ * @returns {number}
+ */
 function minimumZoomToShowLegend(price) {
   if (price >= 22) return 0;
   if (price >= 20) return 7;
@@ -93,6 +126,11 @@ function minimumZoomToShowLegend(price) {
   return 9;
 }
 
+/**
+ * @param {number} zoom
+ * @param {number} price
+ * @returns {number} radius in metres
+ */
 function calculateBubbleSize(zoom, price) {
   let multiplier = 900; // base zoom at 6 and below
 

--- a/js/drawMap/drawLines.js
+++ b/js/drawMap/drawLines.js
@@ -1,3 +1,9 @@
+/**
+ * Draws each travel arc as a geodesic curve with an arrowhead, plus a fat
+ * invisible copy underneath so thin lines are still clickable.
+ * @param {LyricMap} map
+ * @param {Record<number, DrawnLine>} calculatedLines
+ */
 export function drawLines(map, calculatedLines) {
   map.lineLayerGroup.clearLayers();
   for (const hash in calculatedLines) {

--- a/js/drawMap/initializeMap.js
+++ b/js/drawMap/initializeMap.js
@@ -1,3 +1,8 @@
+/**
+ * Creates the Leaflet map over the Orbis tiles and attaches the three layer
+ * groups the rest of the app draws into.
+ * @returns {LyricMap}
+ */
 export function initializeMap() {
   const map = L.map('map').setView([38.9, 26.38], 6);
   L.tileLayer('https://d3msn78fivoryj.cloudfront.net/orbis_tiles/{z}/{x}/{y}.jpg', {

--- a/js/essay/essay.js
+++ b/js/essay/essay.js
@@ -1,16 +1,21 @@
+import { assertUnreachable } from "../assertUnreachable.js";
+
 /**
  * Fills the overlay panel with either the introduction or the credits.
  * @param {"home" | "credits"} path
  */
 export function createEssay(path) {
-  if (path === "home") {
-    byId("essayContent").innerHTML = createIntroHtml();
-    byId('creditsLink').addEventListener('click', () => createEssay("credits"));
-  } else if (path === "credits") {
-    byId("essayContent").innerHTML = createCreditsHtml();
-    byId("homeLink").addEventListener('click', () => createEssay("home"));
-  } else {
-    alert("unrecognized path in createEssay");
+  switch (path) {
+    case "home":
+      byId("essayContent").innerHTML = createIntroHtml();
+      byId('creditsLink').addEventListener('click', () => createEssay("credits"));
+      break;
+    case "credits":
+      byId("essayContent").innerHTML = createCreditsHtml();
+      byId("homeLink").addEventListener('click', () => createEssay("home"));
+      break;
+    default:
+      assertUnreachable(path, "unrecognized path in createEssay");
   }
 }
 

--- a/js/essay/essay.js
+++ b/js/essay/essay.js
@@ -1,24 +1,42 @@
+/**
+ * Fills the overlay panel with either the introduction or the credits.
+ * @param {"home" | "credits"} path
+ */
 export function createEssay(path) {
   if (path === "home") {
-    document.getElementById("essayContent").innerHTML = createIntroHtml();
-    document.getElementById('creditsLink').addEventListener('click', () => createEssay("credits"));
+    byId("essayContent").innerHTML = createIntroHtml();
+    byId('creditsLink').addEventListener('click', () => createEssay("credits"));
   } else if (path === "credits") {
-    document.getElementById("essayContent").innerHTML = createCreditsHtml();
-    document.getElementById("homeLink").addEventListener('click', () => createEssay("home"));
+    byId("essayContent").innerHTML = createCreditsHtml();
+    byId("homeLink").addEventListener('click', () => createEssay("home"));
   } else {
     alert("unrecognized path in createEssay");
   }
 }
 
+/**
+ * The overlay is closed by clicking its title, its close button, or the page
+ * behind it.
+ */
 export function initializeCloseEssayClicks() {
   ["essayTitle", "essayCloseButton", "wholeScreen"].forEach(id => {
-    document.getElementById(id).addEventListener('click', closeEssay);
+    byId(id).addEventListener('click', closeEssay);
   })
 }
 
 function closeEssay() {
-  document.getElementById("essayBox").classList.add("hideEssay");
-  document.getElementById("essayContent").classList.add("hideEssay");
+  byId("essayBox").classList.add("hideEssay");
+  byId("essayContent").classList.add("hideEssay");
+}
+
+/**
+ * document.getElementById, asserting the element is present. Every id used here
+ * is hard-coded in index.html.
+ * @param {string} id
+ * @returns {HTMLElement}
+ */
+function byId(id) {
+  return /** @type {HTMLElement} */ (document.getElementById(id));
 }
 
 function createIntroHtml() {

--- a/js/interface/commonInterface.js
+++ b/js/interface/commonInterface.js
@@ -1,10 +1,22 @@
+/**
+ * Builds one control-bar radio button from an [id, label] pair. The prefix and
+ * id are joined to form state.selectedId, e.g. "poet_93".
+ * @param {[number | string, string]} tuple
+ * @param {string} prefix
+ * @returns {string}
+ */
 export function createInputFromTuple(tuple, prefix) {
   return createInput(`${prefix}_${tuple[0]}`, tuple[1]);
 }
 
+/**
+ * @param {string} id
+ * @param {string} label
+ * @returns {string}
+ */
 export function createInput(id, label) {
   return (`
     <input type="radio" name="city" id="${id}" class="hiddenRadio">
-    <label for="${id}" class="picker-label">${label}</label>           
+    <label for="${id}" class="picker-label">${label}</label>
   `);
 }

--- a/js/interface/commonInterface.js
+++ b/js/interface/commonInterface.js
@@ -1,12 +1,31 @@
+// The control bar is plain HTML built as strings, so a radio button's id is the
+// only thing tying a click back to a filter. That id is `${prefix}_${num}`, it
+// becomes state.selectedId, and getPlacesFilter() / getTravelFilter() parse it
+// back apart.
+//
+// The prefix is therefore typed rather than a bare string: misspell one here and
+// it stops compiling, instead of producing a button that alerts when clicked.
+// Which prefixes each map is allowed to emit is checked by the control bar tests.
+
 /**
- * Builds one control-bar radio button from an [id, label] pair. The prefix and
- * id are joined to form state.selectedId, e.g. "poet_93".
+ * Builds one control-bar radio button from an [id, label] pair.
  * @param {[number | string, string]} tuple
- * @param {string} prefix
+ * @param {MapFilterType} prefix
  * @returns {string}
  */
 export function createInputFromTuple(tuple, prefix) {
-  return createInput(`${prefix}_${tuple[0]}`, tuple[1]);
+  return createFilterInput(prefix, tuple[0], tuple[1]);
+}
+
+/**
+ * Builds one control-bar radio button for a fixed filter, e.g. ("all", 1).
+ * @param {MapFilterType} prefix
+ * @param {number | string} num
+ * @param {string} label
+ * @returns {string}
+ */
+export function createFilterInput(prefix, num, label) {
+  return createInput(`${prefix}_${num}`, label);
 }
 
 /**
@@ -14,7 +33,7 @@ export function createInputFromTuple(tuple, prefix) {
  * @param {string} label
  * @returns {string}
  */
-export function createInput(id, label) {
+function createInput(id, label) {
   return (`
     <input type="radio" name="city" id="${id}" class="hiddenRadio">
     <label for="${id}" class="picker-label">${label}</label>

--- a/js/interface/geoImaginaryInterface.js
+++ b/js/interface/geoImaginaryInterface.js
@@ -1,5 +1,10 @@
 import { createInput, createInputFromTuple } from "./commonInterface.js";
 
+/**
+ * The control bar for the geographical-imaginary map.
+ * @param {Data} data
+ * @returns {string}
+ */
 export function createGeoImaginaryInterfaceHtml(data) {
   return (`
   <div class="buttonContainer" tabindex="0">

--- a/js/interface/geoImaginaryInterface.js
+++ b/js/interface/geoImaginaryInterface.js
@@ -1,4 +1,4 @@
-import { createInput, createInputFromTuple } from "./commonInterface.js";
+import { createFilterInput, createInputFromTuple } from "./commonInterface.js";
 
 /**
  * The control bar for the geographical-imaginary map.
@@ -12,7 +12,7 @@ export function createGeoImaginaryInterfaceHtml(data) {
       <div class="controlBarLabel">
       LOCATIONS IN POETRY: 
       </div>
-      ${createInput("all_1", "ALL REFERENCES")}
+      ${createFilterInput("all", 1, "ALL REFERENCES")}
     </fieldset>
   </div>
 

--- a/js/interface/interface.js
+++ b/js/interface/interface.js
@@ -3,9 +3,15 @@ import { createGeoImaginaryInterfaceHtml } from "./geoImaginaryInterface.js";
 import { createPlacesInterfaceHtml } from "./placesInterface.js";
 import { createTravelInterfaceHtml } from "./travelInterface.js";
 
+/**
+ * Redraws the map whenever a different filter is picked in the control bar.
+ * @param {LyricMap} map
+ * @param {Data} data
+ * @param {State} state
+ */
 export function addPoetsEventListener(map, data, state) {
-  document.querySelector('#poetsSelector').addEventListener('click', () => {
-    const currentSelected = document.querySelector('div.buttonContainer input:checked').id;
+  /** @type {HTMLElement} */ (document.querySelector('#poetsSelector')).addEventListener('click', () => {
+    const currentSelected = /** @type {HTMLInputElement} */ (document.querySelector('div.buttonContainer input:checked')).id;
     if (state.selectedId != currentSelected) {
       state.selectedId = currentSelected;
       updateMap(map, data, state);
@@ -13,17 +19,31 @@ export function addPoetsEventListener(map, data, state) {
   });
 }
 
+/**
+ * Rebuilds the control bar and map whenever a different map mode is picked.
+ * @param {LyricMap} map
+ * @param {Data} data
+ * @param {State} state
+ */
 export function addMapModeEventListener(map, data, state) {
-  document.querySelector('#mapModeSelector').addEventListener('click', () => {
-    const currentSelected = document.querySelector('fieldset input:checked').id;
+  /** @type {HTMLElement} */ (document.querySelector('#mapModeSelector')).addEventListener('click', () => {
+    const currentSelected = /** @type {HTMLInputElement} */ (document.querySelector('fieldset input:checked')).id;
     if (state.currentMapMode != currentSelected) {
-      state.currentMapMode = currentSelected;
+      state.currentMapMode = /** @type {State["currentMapMode"]} */ (currentSelected);
       updateMapMode(map, data, state);
     }
   });
 }
 
+/**
+ * Swaps in the control bar for the current mode, selects its default filter and
+ * redraws.
+ * @param {LyricMap} map
+ * @param {Data} data
+ * @param {State} state
+ */
 export function updateMapMode(map, data, state) {
+  /** @type {string | undefined} */
   let interfaceHtml;
   if (state.currentMapMode === "placesMode") {
     interfaceHtml = createPlacesInterfaceHtml(data);
@@ -38,7 +58,7 @@ export function updateMapMode(map, data, state) {
     alert("unrecognized map mode");
   }
 
-  document.getElementById("poetsSelector").innerHTML = interfaceHtml;
-  document.getElementById(state.selectedId).checked = true;
+  /** @type {HTMLElement} */ (document.getElementById("poetsSelector")).innerHTML = /** @type {string} */ (interfaceHtml);
+  /** @type {HTMLInputElement} */ (document.getElementById(state.selectedId)).checked = true;
   updateMap(map, data, state);
 }

--- a/js/interface/interface.js
+++ b/js/interface/interface.js
@@ -2,6 +2,7 @@ import { updateMap } from "../renderMap/updateMap.js";
 import { createGeoImaginaryInterfaceHtml } from "./geoImaginaryInterface.js";
 import { createPlacesInterfaceHtml } from "./placesInterface.js";
 import { createTravelInterfaceHtml } from "./travelInterface.js";
+import { assertUnreachable } from "../assertUnreachable.js";
 
 /**
  * Redraws the map whenever a different filter is picked in the control bar.
@@ -43,22 +44,26 @@ export function addMapModeEventListener(map, data, state) {
  * @param {State} state
  */
 export function updateMapMode(map, data, state) {
-  /** @type {string | undefined} */
   let interfaceHtml;
-  if (state.currentMapMode === "placesMode") {
-    interfaceHtml = createPlacesInterfaceHtml(data);
-    state.selectedId = "relationship_3";
-  } else if (state.currentMapMode === "travelMode") {
-    interfaceHtml = createTravelInterfaceHtml(data);
-    state.selectedId = "all_1";
-  } else if (state.currentMapMode === "geoimaginaryMode") {
-    interfaceHtml = createGeoImaginaryInterfaceHtml(data);
-    state.selectedId = "all_1";
-  } else {
-    alert("unrecognized map mode");
+  switch (state.currentMapMode) {
+    case "placesMode":
+      interfaceHtml = createPlacesInterfaceHtml(data);
+      state.selectedId = "relationship_3";
+      break;
+    case "travelMode":
+      interfaceHtml = createTravelInterfaceHtml(data);
+      state.selectedId = "all_1";
+      break;
+    case "geoimaginaryMode":
+      interfaceHtml = createGeoImaginaryInterfaceHtml(data);
+      state.selectedId = "all_1";
+      break;
+    default:
+      // Never returns, so interfaceHtml is known to be set below.
+      assertUnreachable(state.currentMapMode, "unrecognized map mode");
   }
 
-  /** @type {HTMLElement} */ (document.getElementById("poetsSelector")).innerHTML = /** @type {string} */ (interfaceHtml);
+  /** @type {HTMLElement} */ (document.getElementById("poetsSelector")).innerHTML = interfaceHtml;
   /** @type {HTMLInputElement} */ (document.getElementById(state.selectedId)).checked = true;
   updateMap(map, data, state);
 }

--- a/js/interface/placesInterface.js
+++ b/js/interface/placesInterface.js
@@ -1,5 +1,11 @@
 import { createInput, createInputFromTuple } from "./commonInterface.js";
 
+/**
+ * The control bar for the places map: origin/activity, poets with no known
+ * travel, and genres.
+ * @param {Data} data
+ * @returns {string}
+ */
 export function createPlacesInterfaceHtml(data) {
   return (`
     <div class="buttonContainer" tabindex="0">

--- a/js/interface/placesInterface.js
+++ b/js/interface/placesInterface.js
@@ -1,4 +1,4 @@
-import { createInput, createInputFromTuple } from "./commonInterface.js";
+import { createFilterInput, createInputFromTuple } from "./commonInterface.js";
 
 /**
  * The control bar for the places map: origin/activity, poets with no known
@@ -13,8 +13,8 @@ export function createPlacesInterfaceHtml(data) {
         <div class="controlBarLabel">
           PLACE OF:
         </div>
-        ${createInput("relationship_1", "ORIGIN")}
-        ${createInput("relationship_3", "ACTIVITY")}
+        ${createFilterInput("relationship", 1, "ORIGIN")}
+        ${createFilterInput("relationship", 3, "ACTIVITY")}
       </fieldset>
     </div>
 

--- a/js/interface/slider.js
+++ b/js/interface/slider.js
@@ -1,7 +1,14 @@
 import { updateMap } from "../renderMap/updateMap.js";
 
+/**
+ * Wires up the date range slider (values are negative years, i.e. BCE) and
+ * redraws the map whenever it moves.
+ * @param {LyricMap} map
+ * @param {Data} data
+ * @param {State} state
+ */
 export function initializeSlider(map, data, state) {
-  const slider = document.getElementById('slider');
+  const slider = /** @type {any} */ (document.getElementById('slider'));
 
   noUiSlider.create(slider, {
     start: [-800, -400],
@@ -12,8 +19,8 @@ export function initializeSlider(map, data, state) {
     },
     step: 50,
     tooltips: [
-      { to: function (value) { return `${-1 * value} BCE`; } },
-      { to: function (value) { return `${-1 * value} BCE`; } }
+      { to: function (/** @type {number} */ value) { return `${-1 * value} BCE`; } },
+      { to: function (/** @type {number} */ value) { return `${-1 * value} BCE`; } }
     ],
     // following from https://github.com/leongersen/noUiSlider/issues/1223
     handleAttributes: [
@@ -22,7 +29,7 @@ export function initializeSlider(map, data, state) {
     ]
   });
 
-  slider.noUiSlider.on("update", function (values) {
+  slider.noUiSlider.on("update", function (/** @type {string[]} */ values) {
     const [minDate, maxDate] = values.map(value => parseInt(value));
     if (state.minDate !== minDate || state.maxDate !== maxDate) {
       [state.minDate, state.maxDate] = [minDate, maxDate];

--- a/js/interface/travelInterface.js
+++ b/js/interface/travelInterface.js
@@ -1,4 +1,4 @@
-import { createInput, createInputFromTuple } from "./commonInterface.js";
+import { createFilterInput, createInputFromTuple } from "./commonInterface.js";
 import { TRAVEL_RED, TRAVEL_PURPLE, TRAVEL_YELLOW } from "../constants/colors.js";
 
 /**
@@ -14,7 +14,7 @@ export function createTravelInterfaceHtml(data) {
       <div class="controlBarLabel">
         MOBILITY
       </div>
-      ${createInput("all_1", "ALL CASES")}
+      ${createFilterInput("all", 1, "ALL CASES")}
     </fieldset>
   </div>
 

--- a/js/interface/travelInterface.js
+++ b/js/interface/travelInterface.js
@@ -1,6 +1,12 @@
 import { createInput, createInputFromTuple } from "./commonInterface.js";
 import { TRAVEL_RED, TRAVEL_PURPLE, TRAVEL_YELLOW } from "../constants/colors.js";
 
+/**
+ * The control bar for the travel map: poet, city, region, small region and
+ * political system.
+ * @param {Data} data
+ * @returns {string}
+ */
 export function createTravelInterfaceHtml(data) {
   return (`
   <div class="buttonContainer tabindex="0"">
@@ -69,13 +75,13 @@ export function createTravelInterfaceHtml(data) {
       POLITICAL SYSTEM 
       (<span style="color:${TRAVEL_RED};">to</span>/<span style="color:${TRAVEL_PURPLE};">from</span>/<span style="color:${TRAVEL_YELLOW};">within</span>):
     </div>
-    ${[
+    ${/** @type {[number, string][]} */ ([
       [3, "Democracy"],
       [4, "Kingship"],
       [7, "Mixed"],
       [1, "Oligarchy"],
       [2, "Tyranny"]
-    ].map(tuple => createInputFromTuple(tuple, "gov")).join("")}
+    ]).map(tuple => createInputFromTuple(tuple, "gov")).join("")}
     <div class="picker-label" style="cursor: auto">[Mapping in Progress]</label>		
   </fieldset>
 </div>

--- a/js/popups/popups.js
+++ b/js/popups/popups.js
@@ -2,6 +2,14 @@ import { LYRIC_GREY, LYRIC_RED } from "../constants/colors.js";
 import { getMapTypeNum } from "../calcData/getters.js";
 import { createNumberedListOfPoets, createDetailedListOfPoets, renderReference } from "./popupsCommon.js";
 
+/**
+ * Builds the html shown when a city bubble is clicked, for whichever of the
+ * places / geographical-imaginary maps is showing.
+ * @param {State} state
+ * @param {Data} data
+ * @param {Bubble} bubble
+ * @returns {string | undefined}
+ */
 export function createPopupHtml(state, data, bubble) {
   const [type, num] = getMapTypeNum(state);
   if (state.currentMapMode === "placesMode") {
@@ -15,10 +23,19 @@ export function createPopupHtml(state, data, bubble) {
   }
 }
 
+/**
+ * The ACTIVITY popup, which splits a city's poets into natives and incomers.
+ * @param {State} state
+ * @param {Data} data
+ * @param {Bubble} bubble
+ * @returns {string}
+ */
 function createActivePopupHtml(state, data, bubble) {
   const cityname = bubble.city.infowindowName.toUpperCase();
   const poetCities = bubble.poetCities;
+  /** @type {RenderedPoetCity[]} */
   const bornPoetCities = [];
+  /** @type {RenderedPoetCity[]} */
   const otherPoetCities = [];
   for (const pc of poetCities) {
     if (pc.relationshipId === 1) bornPoetCities.push(pc);
@@ -35,7 +52,7 @@ function createActivePopupHtml(state, data, bubble) {
   if (bornPoetCities.length > 0) {
     nativeHeader = `
       <h5 style="color:${LYRIC_GREY}">${nativeTitle}</h2>
-      ${createNumberedListOfPoets(bornPoetCities.map(pc => pc.poetDetailName), data)}    
+      ${createNumberedListOfPoets(bornPoetCities.map(pc => pc.poetDetailName))}
     `;
     nativeDetails = `
       <h4 style="color:${LYRIC_GREY}">NATIVE POETS</h4>
@@ -46,7 +63,7 @@ function createActivePopupHtml(state, data, bubble) {
   if (otherPoetCities.length > 0) {
     nonNativeHeader = `
       <h5 style="color:${LYRIC_GREY}">${nonNativeTitle}</h2>
-      ${createNumberedListOfPoets(otherPoetCities.map(pc => pc.poetDetailName), data)}    
+      ${createNumberedListOfPoets(otherPoetCities.map(pc => pc.poetDetailName))}
     `;
     nonNativeDetails = `
       <h4 style="color:${LYRIC_GREY}">NON-NATIVE POETS</h4>
@@ -64,6 +81,12 @@ function createActivePopupHtml(state, data, bubble) {
   `);
 }
 
+/**
+ * @param {State} state
+ * @param {Data} data
+ * @param {Bubble} bubble
+ * @returns {string}
+ */
 function createHeader(state, data, bubble) {
   const cityname = bubble.city.infowindowName.toUpperCase();
   const title = createTitle(state, data, cityname, bubble);
@@ -73,6 +96,12 @@ function createHeader(state, data, bubble) {
   `);
 }
 
+/**
+ * @param {State} state
+ * @param {Data} data
+ * @param {Bubble} bubble
+ * @returns {string}
+ */
 function createPlacesPopupHtml(state, data, bubble) {
   const poetCities = bubble.poetCities;
   return (`
@@ -83,6 +112,11 @@ function createPlacesPopupHtml(state, data, bubble) {
   `);
 }
 
+/**
+ * @param {GeoBubblePoet[]} poets
+ * @param {Data} data
+ * @returns {string}
+ */
 function createGeoHeaderListOfPoets(poets, data) {
   return (`
     <p>
@@ -95,6 +129,11 @@ function createGeoHeaderListOfPoets(poets, data) {
   `);
 }
 
+/**
+ * @param {GeoBubblePoet[]} poets
+ * @param {Data} data
+ * @returns {string}
+ */
 function createDetailedGeoListOfPoets(poets, data) {
   return (`
     ${poets.map((poet, idx) => {
@@ -109,6 +148,13 @@ function createDetailedGeoListOfPoets(poets, data) {
   `);
 }
 
+/**
+ * @param {State} state
+ * @param {Data} data
+ * @param {string} cityname already upper-cased
+ * @param {Bubble} bubble
+ * @returns {string | undefined}
+ */
 function createTitle(state, data, cityname, bubble) {
   if (state.currentMapMode === "placesMode") {
     return createPlacesModeTitle(state, data, cityname);
@@ -118,6 +164,12 @@ function createTitle(state, data, cityname, bubble) {
   }
 }
 
+/**
+ * @param {State} state
+ * @param {Data} data
+ * @param {string} cityname already upper-cased
+ * @returns {string | undefined}
+ */
 function createPlacesModeTitle(state, data, cityname) {
   const [type, num] = getMapTypeNum(state);
   if (type === "relationship" && num === 1) {
@@ -130,11 +182,19 @@ function createPlacesModeTitle(state, data, cityname) {
   }
 }
 
+/**
+ * @param {State} state
+ * @param {Data} data
+ * @param {Bubble} bubble
+ * @returns {string}
+ */
 function createGeoImaginaryPopupHtml(state, data, bubble) {
+  // calcBubbles always populates poets in geoimaginaryMode.
+  const poets = /** @type {GeoBubblePoet[]} */ (bubble.poets);
   return (`
     ${createHeader(state, data, bubble)}
-    ${createGeoHeaderListOfPoets(bubble.poets, data)}
+    ${createGeoHeaderListOfPoets(poets, data)}
     <h4 style="color:${LYRIC_GREY}">DETAILS</h4>
-    ${createDetailedGeoListOfPoets(bubble.poets, data)}
+    ${createDetailedGeoListOfPoets(poets, data)}
   `);
 }

--- a/js/popups/popups.js
+++ b/js/popups/popups.js
@@ -1,5 +1,5 @@
 import { LYRIC_GREY, LYRIC_RED } from "../constants/colors.js";
-import { getMapTypeNum } from "../calcData/getters.js";
+import { getPlacesFilter } from "../calcData/getters.js";
 import { createNumberedListOfPoets, createDetailedListOfPoets, renderReference } from "./popupsCommon.js";
 
 /**
@@ -11,7 +11,7 @@ import { createNumberedListOfPoets, createDetailedListOfPoets, renderReference }
  * @returns {string | undefined}
  */
 export function createPopupHtml(state, data, bubble) {
-  const [type, num] = getMapTypeNum(state);
+  const [type, num] = getPlacesFilter(state);
   if (state.currentMapMode === "placesMode") {
     if (type === "relationship" && num === 3) {
       return createActivePopupHtml(state, data, bubble);
@@ -171,7 +171,7 @@ function createTitle(state, data, cityname, bubble) {
  * @returns {string | undefined}
  */
 function createPlacesModeTitle(state, data, cityname) {
-  const [type, num] = getMapTypeNum(state);
+  const [type, num] = getPlacesFilter(state);
   if (type === "relationship" && num === 1) {
     return `POETS BORN IN ${cityname}`;
   } else if (type === "poet") {

--- a/js/popups/popupsCommon.js
+++ b/js/popups/popupsCommon.js
@@ -1,6 +1,18 @@
 import { LYRIC_RED } from "../constants/colors.js";
 import { getGenres } from "../calcData/getters.js";
 
+/**
+ * Anything a detail paragraph can be rendered from: a rendered poet-city row in
+ * places / geographical-imaginary mode, or a travel line in travel mode. Travel
+ * lines carry no citation of their own, hence the optional reference.
+ * @typedef {PoetPrimed & { poetId: number, reference?: Reference }} DetailedPoet
+ */
+
+/**
+ * The red-numbered one-line summary at the top of a popup.
+ * @param {string[]} names
+ * @returns {string}
+ */
 export function createNumberedListOfPoets(names) {
   return (`
     <p>
@@ -11,6 +23,13 @@ export function createNumberedListOfPoets(names) {
   `);
 }
 
+/**
+ * The DETAILS block: one paragraph per poet, with dates, genres, sources and
+ * the citation.
+ * @param {DetailedPoet[]} poets
+ * @param {Data} data
+ * @returns {string}
+ */
 export function createDetailedListOfPoets(poets, data) {
   return (`
     ${poets.map((poet, idx) => {
@@ -27,6 +46,11 @@ export function createDetailedListOfPoets(poets, data) {
   `);
 }
 
+/**
+ * @param {DetailedPoet} poet
+ * @param {Data} data
+ * @returns {string}
+ */
 function createGenreString(poet, data) {
   if (poet.poetGenres) {
     const genres = getGenres(data, poet.poetId)
@@ -36,6 +60,10 @@ function createGenreString(poet, data) {
   return "";
 }
 
+/**
+ * @param {Reference | undefined} reference
+ * @returns {string}
+ */
 export function renderReference(reference) {
   if (reference) {
     let source_poem = "";

--- a/js/popups/travelPopups.js
+++ b/js/popups/travelPopups.js
@@ -1,6 +1,12 @@
 import { LYRIC_GREY, LYRIC_RED } from "../constants/colors.js";
 import { createNumberedListOfPoets, createDetailedListOfPoets, renderReference } from "./popupsCommon.js";
 
+/**
+ * Builds the html shown when a travel arc is clicked.
+ * @param {Data} data
+ * @param {DrawnLine} line
+ * @returns {string}
+ */
 export function createTravelPopupHtml(data, line) {
   return (`
   <h3 style="color:${LYRIC_GREY}">${line.name}</h3>
@@ -15,6 +21,12 @@ export function createTravelPopupHtml(data, line) {
   `);
 }
 
+/**
+ * Renders the citation behind either end of an arc, for every poet on it.
+ * @param {DrawnLine} line
+ * @param {"bornPc" | "activePc"} direction which end of the journey to cite
+ * @returns {string}
+ */
 function createTravelSource(line, direction) {
   return line.poetLines.map((pl, idx) => {
     return (`
@@ -26,6 +38,13 @@ function createTravelSource(line, direction) {
   }).join("")
 }
 
+/**
+ * As createTravelPopupHtml, but the details block reports regimes rather than
+ * genres and sources.
+ * @param {Data} data
+ * @param {DrawnLine} line
+ * @returns {string}
+ */
 export function createGovTravelPopupHtml(data, line) {
   return (`
   <h3 style="color:${LYRIC_GREY}">${line.name}</h3>
@@ -40,6 +59,11 @@ export function createGovTravelPopupHtml(data, line) {
   `);
 }
 
+/**
+ * @param {Line[]} poets
+ * @param {Data} data
+ * @returns {string}
+ */
 function createRegimeTravelListOfPoets(poets, data) {
   return (`
     ${poets.map((poet, idx) => {
@@ -54,6 +78,11 @@ function createRegimeTravelListOfPoets(poets, data) {
   `);
 }
 
+/**
+ * @param {number[]} govIds
+ * @param {Data} data
+ * @returns {string}
+ */
 function renderGovNames(govIds, data) {
   return govIds.map(govId => data.govsById[govId]).join(", ");
 }

--- a/js/renderMap/calcBubbles.js
+++ b/js/renderMap/calcBubbles.js
@@ -1,15 +1,24 @@
 import { sortAlphabetically } from "../calcData/data.js";
 import { createPopupHtml } from "../popups/popups.js";
 
+/**
+ * Groups rendered rows by city into one bubble per city, sized by how many
+ * poets it holds, and attaches each bubble's popup html.
+ * @param {State} state
+ * @param {Data} data
+ * @param {RenderedPoetCity[]} poetCities
+ * @returns {Record<number, Bubble>}
+ */
 export function calculateBubbles(state, data, poetCities) {
   const citiesById = data.citiesById;
+  /** @type {Record<number, Bubble>} */
   const bubbles = {}
 
   for (const poetCity of poetCities) {
     const cityId = poetCity.cityId;
     if (cityId && citiesById[cityId]) {
       if (!bubbles[cityId]) {
-        bubbles[cityId] = {};
+        bubbles[cityId] = /** @type {Bubble} */ ({});
         bubbles[cityId].city = citiesById[cityId];
         bubbles[cityId].poetCities = [];
       }
@@ -20,15 +29,18 @@ export function calculateBubbles(state, data, poetCities) {
   if (state.currentMapMode === "geoimaginaryMode") {
     for (const cityId in bubbles) {
       const bubbleCity = bubbles[cityId];
-      if (!bubbleCity.poets) bubbleCity.poets = {}
+      // poets starts life keyed by poetId so references can be accumulated,
+      // then is flattened to the sorted array that popups consume.
+      /** @type {Record<number, GeoBubblePoet>} */
+      const poetsById = {};
       for (const pc of bubbleCity.poetCities) {
-        if (!bubbleCity.poets[pc.poetId]) {
-          bubbleCity.poets[pc.poetId] = { ...pc };
-          bubbleCity.poets[pc.poetId].references = [];
+        if (!poetsById[pc.poetId]) {
+          poetsById[pc.poetId] = /** @type {GeoBubblePoet} */ ({ ...pc });
+          poetsById[pc.poetId].references = [];
         }
-        bubbleCity.poets[pc.poetId].references.push(pc.reference);
+        poetsById[pc.poetId].references.push(pc.reference);
       }
-      bubbleCity.poets = Object.values(bubbleCity.poets);
+      bubbleCity.poets = Object.values(poetsById);
       bubbleCity.poets.sort((a, b) => sortAlphabetically(a.poetname, b.poetname));
     }
   }
@@ -42,6 +54,10 @@ export function calculateBubbles(state, data, poetCities) {
   return bubbles;
 }
 
+/**
+ * @param {number} numberOfPoets
+ * @returns {number}
+ */
 function calculateBubblePriceFromNumberOfPoets(numberOfPoets) {
   if (numberOfPoets <= 1) return 10.0;
   if (numberOfPoets <= 2) return 13.3;

--- a/js/renderMap/calcCommon.js
+++ b/js/renderMap/calcCommon.js
@@ -1,5 +1,12 @@
 import { getPoet } from "../calcData/getters.js";
 
+/**
+ * Builds a predicate keeping only rows whose poet was active within the date
+ * range currently selected on the slider.
+ * @param {Data} data
+ * @param {State} state
+ * @returns {(obj: { poetId: number }) => boolean}
+ */
 export function getDateFilterFn(data, state) {
   return (obj) => {
     const poet = getPoet(data, obj.poetId);

--- a/js/renderMap/calcPoetCities.js
+++ b/js/renderMap/calcPoetCities.js
@@ -1,4 +1,5 @@
-import { getMapTypeNum } from "../calcData/getters.js";
+import { getPlacesFilter } from "../calcData/getters.js";
+import { assertUnreachable } from "../assertUnreachable.js";
 import { getDateFilterFn } from "./calcCommon.js";
 
 /** @typedef {PoetCity | GeoPoetCity} AnyPoetCity */
@@ -29,18 +30,15 @@ export function calcPoetCities(data, state) {
  * @returns {AnyPoetCity[]}
  */
 function getPoetCitiesData(data, state) {
-  /** @type {AnyPoetCity[] | undefined} */
-  let poetCitiesData;
-  if (state.currentMapMode === "placesMode" || state.currentMapMode === "travelMode") {
-    poetCitiesData = data.poetCities;
-  } else if (state.currentMapMode === "geoimaginaryMode") {
-    poetCitiesData = data.geopoetCities;
-  } else {
-    alert(`unrecognized current map mode ${state.currentMapMode}`);
+  switch (state.currentMapMode) {
+    case "placesMode":
+    case "travelMode":
+      return [...data.poetCities];
+    case "geoimaginaryMode":
+      return [...data.geopoetCities];
+    default:
+      return assertUnreachable(state.currentMapMode, "unrecognized current map mode");
   }
-  // Cast: the else branch above is unreachable for a valid State, and alerting
-  // then throwing on the spread is the long-standing behaviour.
-  return [.../** @type {AnyPoetCity[]} */ (poetCitiesData)];
 }
 
 /**
@@ -50,34 +48,29 @@ function getPoetCitiesData(data, state) {
  * @returns {PoetCityFilter}
  */
 function getFilterFn(data, state) {
-  const [type, num] = getMapTypeNum(state);
-  /** @type {PoetCityFilter | undefined} */
-  let filterFn;
-  if (type === "all") {
-    filterFn = () => true;
-  }
-  else if (type === "relationship") {
-    if (num === 3) filterFn = () => true;
-    else filterFn = poetCity => poetCity.relationshipId === num;
-  }
-  else if (type === "poet") {
-    filterFn = poetCity => poetCity.poetId === num;
-  }
-  else if (type === "genre") {
-    filterFn = poetCity => {
-      return !!data.genresByPoetId[poetCity.poetId] &&
+  const [type, num] = getPlacesFilter(state);
+  switch (type) {
+    case "all":
+      return () => true;
+    case "relationship":
+      // Relationship 3 is "activity", which every row qualifies for.
+      if (num === 3) return () => true;
+      return poetCity => poetCity.relationshipId === num;
+    case "poet":
+      return poetCity => poetCity.poetId === num;
+    case "genre":
+      return poetCity =>
+        !!data.genresByPoetId[poetCity.poetId] &&
         data
           .genresByPoetId[poetCity.poetId]
           .map(genre => genre.genreId)
           .includes(num) &&
         poetCity.relationshipId === 1;
-    }
-  } else {
-    alert(`${type} not recognized when trying to calculate poet cities`);
+    default:
+      // Exhaustive over PlacesFilterType: add a member without handling it above
+      // and this stops compiling.
+      return assertUnreachable(type, "unrecognized filter when calculating poet cities");
   }
-  // Cast: an unrecognized type alerts and then fails at the .filter() call,
-  // which is the long-standing behaviour.
-  return /** @type {PoetCityFilter} */ (filterFn);
 }
 
 /**
@@ -89,7 +82,7 @@ function getFilterFn(data, state) {
  * @returns {RenderedPoetCity[]}
  */
 function renderPoetCities(filteredPoetCities, data, state) {
-  const [type, num] = getMapTypeNum(state);
+  const [type, num] = getPlacesFilter(state);
 
   return filteredPoetCities.map(pc => {
     /** @type {Reference} */

--- a/js/renderMap/calcPoetCities.js
+++ b/js/renderMap/calcPoetCities.js
@@ -1,6 +1,16 @@
-import { getGenres, getMapTypeNum, getPoet } from "../calcData/getters.js";
+import { getMapTypeNum } from "../calcData/getters.js";
 import { getDateFilterFn } from "./calcCommon.js";
 
+/** @typedef {PoetCity | GeoPoetCity} AnyPoetCity */
+/** @typedef {(poetCity: AnyPoetCity) => boolean} PoetCityFilter */
+
+/**
+ * Picks the right source rows for the current map, applies the date slider and
+ * control-bar filters, and flattens the survivors for rendering.
+ * @param {Data} data
+ * @param {State} state
+ * @returns {RenderedPoetCity[]}
+ */
 export function calcPoetCities(data, state) {
   const poetCitiesData = getPoetCitiesData(data, state);
   const filteredPoetCities =
@@ -13,7 +23,13 @@ export function calcPoetCities(data, state) {
   return renderedPoetCities;
 }
 
+/**
+ * @param {Data} data
+ * @param {State} state
+ * @returns {AnyPoetCity[]}
+ */
 function getPoetCitiesData(data, state) {
+  /** @type {AnyPoetCity[] | undefined} */
   let poetCitiesData;
   if (state.currentMapMode === "placesMode" || state.currentMapMode === "travelMode") {
     poetCitiesData = data.poetCities;
@@ -22,11 +38,20 @@ function getPoetCitiesData(data, state) {
   } else {
     alert(`unrecognized current map mode ${state.currentMapMode}`);
   }
-  return [...poetCitiesData];
+  // Cast: the else branch above is unreachable for a valid State, and alerting
+  // then throwing on the spread is the long-standing behaviour.
+  return [.../** @type {AnyPoetCity[]} */ (poetCitiesData)];
 }
 
+/**
+ * Builds the predicate for whichever radio button is currently selected.
+ * @param {Data} data
+ * @param {State} state
+ * @returns {PoetCityFilter}
+ */
 function getFilterFn(data, state) {
   const [type, num] = getMapTypeNum(state);
+  /** @type {PoetCityFilter | undefined} */
   let filterFn;
   if (type === "all") {
     filterFn = () => true;
@@ -40,7 +65,7 @@ function getFilterFn(data, state) {
   }
   else if (type === "genre") {
     filterFn = poetCity => {
-      return data.genresByPoetId[poetCity.poetId] &&
+      return !!data.genresByPoetId[poetCity.poetId] &&
         data
           .genresByPoetId[poetCity.poetId]
           .map(genre => genre.genreId)
@@ -50,13 +75,24 @@ function getFilterFn(data, state) {
   } else {
     alert(`${type} not recognized when trying to calculate poet cities`);
   }
-  return filterFn;
+  // Cast: an unrecognized type alerts and then fails at the .filter() call,
+  // which is the long-standing behaviour.
+  return /** @type {PoetCityFilter} */ (filterFn);
 }
 
+/**
+ * Flattens rows to the subset popups need, collapsing the citation columns into
+ * a single reference. In genre mode the citation comes from genres.csv instead.
+ * @param {AnyPoetCity[]} filteredPoetCities
+ * @param {Data} data
+ * @param {State} state
+ * @returns {RenderedPoetCity[]}
+ */
 function renderPoetCities(filteredPoetCities, data, state) {
   const [type, num] = getMapTypeNum(state);
 
   return filteredPoetCities.map(pc => {
+    /** @type {Reference} */
     const reference = {
       source_citation: pc.source_citation,
       source_greektext: pc.source_greektext,
@@ -68,10 +104,10 @@ function renderPoetCities(filteredPoetCities, data, state) {
         .genresByPoetId[pc.poetId]
         .filter(genre => genre.genreId === num);
       if (genrePoetCities.length > 1) {
-        console.log(`poet with name ${pc.poetname} and ${poetId} has more than one entry for genreId ${num}`);
+        console.log(`poet with name ${pc.poetname} and ${pc.poetId} has more than one entry for genreId ${num}`);
       }
       if (genrePoetCities.length === 0) {
-        console.log(`poet with name ${pc.poetname} and ${poetId} has no entries for genreId ${num} (though we filtered to this genreId)`);
+        console.log(`poet with name ${pc.poetname} and ${pc.poetId} has no entries for genreId ${num} (though we filtered to this genreId)`);
       }
       const genrePoetCity = genrePoetCities[0];
       reference.source_citation = genrePoetCity.source_citation;
@@ -80,6 +116,7 @@ function renderPoetCities(filteredPoetCities, data, state) {
       reference.source_translator = genrePoetCity.source_translator;
     }
 
+    /** @type {RenderedPoetCity} */
     const renderedPc = {
       poetId: pc.poetId,
       cityId: pc.cityId,
@@ -92,7 +129,8 @@ function renderPoetCities(filteredPoetCities, data, state) {
       relationshipId: pc.relationshipId,
       reference: reference
     };
-    if (pc.source_poem) renderedPc.reference.source_poem = pc.source_poem;
+    // Only geographical-imaginary rows carry a source_poem column.
+    if ("source_poem" in pc && pc.source_poem) renderedPc.reference.source_poem = pc.source_poem;
     return renderedPc;
   });
 }

--- a/js/renderMap/lines.js
+++ b/js/renderMap/lines.js
@@ -1,9 +1,10 @@
 import { TRAVEL_RED, TRAVEL_PURPLE, TRAVEL_YELLOW } from "../constants/colors.js";
 import { drawLines } from "../drawMap/drawLines.js";
 import { drawBubblesAndLegends } from "../drawMap/drawBubbles.js";
-import { getMapTypeNum } from "../calcData/getters.js";
+import { getTravelFilter } from "../calcData/getters.js";
 import { createTravelPopupHtml, createGovTravelPopupHtml } from "../popups/travelPopups.js";
 import { getDateFilterFn } from "./calcCommon.js";
+import { assertUnreachable } from "../assertUnreachable.js";
 
 /**
  * @param {LyricMap} map
@@ -27,33 +28,32 @@ export function calculateAndDrawLines(map, data, state) {
  * @returns {Line[]}
  */
 function filterLines(state, data) {
-  const [type, num] = getMapTypeNum(state);
-  if (type === "all") {
-    return data.lines;
-  } else if (type === "poet") {
-    return data.lines.filter(line => line.poetId === num);
-  } else if (type === "destination") {
-    return data.lines.filter(line =>
-      line.bornCityId === num || line.activeCityId === num
-    );
-  } else if (type === "smallregion") {
-    return data.lines.filter(line =>
-      line.bornCity.regionId === num || line.activeCity.regionId === num
-    );
-  } else if (type === "region") {
-    return data.lines.filter(line =>
-      line.bornCity.bigRegionId === num || line.activeCity.bigRegionId === num
-    );
-  } else if (type === "gov") {
-    return data.lines.filter(line =>
-      line.bornGovIds.includes(num) || line.activeGovIds.includes(num)
-    );
-  }
-  else {
-    alert(`unrecognized type of map in travel map: <b>${type}</b>`);
-    // Cast: unreachable for a valid State; alerting then failing on the
-    // following .filter() is the long-standing behaviour.
-    return /** @type {Line[]} */ (/** @type {unknown} */ (undefined));
+  const [type, num] = getTravelFilter(state);
+  switch (type) {
+    case "all":
+      return data.lines;
+    case "poet":
+      return data.lines.filter(line => line.poetId === num);
+    case "destination":
+      return data.lines.filter(line =>
+        line.bornCityId === num || line.activeCityId === num
+      );
+    case "smallregion":
+      return data.lines.filter(line =>
+        line.bornCity.regionId === num || line.activeCity.regionId === num
+      );
+    case "region":
+      return data.lines.filter(line =>
+        line.bornCity.bigRegionId === num || line.activeCity.bigRegionId === num
+      );
+    case "gov":
+      return data.lines.filter(line =>
+        line.bornGovIds.includes(num) || line.activeGovIds.includes(num)
+      );
+    default:
+      // Exhaustive over TravelFilterType: add a member without handling it above
+      // and this stops compiling.
+      return assertUnreachable(type, "unrecognized filter in the travel map");
   }
 }
 
@@ -75,7 +75,7 @@ function hashCityIds(from, to) {
  * @returns {Record<number, DrawnLine>}
  */
 function calculateLines(state, data, filteredPoetLines) {
-  const [type, num] = getMapTypeNum(state);
+  const [type, num] = getTravelFilter(state);
 
   /** @type {Record<number, DrawnLine>} */
   const lines = {}
@@ -112,7 +112,7 @@ function calculateLines(state, data, filteredPoetLines) {
  * @param {DrawnLine} line mutated in place
  */
 function weightLine(state, line) {
-  const [type, num] = getMapTypeNum(state);
+  const [type, num] = getTravelFilter(state);
   const poetsNum = line.poetLines.length;
   let multiplier = 1;
   let increment = 0;
@@ -131,7 +131,7 @@ function weightLine(state, line) {
  * @param {DrawnLine} line mutated in place
  */
 function colorLine(state, data, line) {
-  const [type, num] = getMapTypeNum(state);
+  const [type, num] = getTravelFilter(state);
   // default color is red
   if (type === "destination") {
     if (line.fromCity.cityId === num) line.color = TRAVEL_PURPLE;

--- a/js/renderMap/lines.js
+++ b/js/renderMap/lines.js
@@ -1,10 +1,15 @@
 import { TRAVEL_RED, TRAVEL_PURPLE, TRAVEL_YELLOW } from "../constants/colors.js";
 import { drawLines } from "../drawMap/drawLines.js";
 import { drawBubblesAndLegends } from "../drawMap/drawBubbles.js";
-import { getMapTypeNum, getCity, getGovs } from "../calcData/getters.js";
+import { getMapTypeNum } from "../calcData/getters.js";
 import { createTravelPopupHtml, createGovTravelPopupHtml } from "../popups/travelPopups.js";
 import { getDateFilterFn } from "./calcCommon.js";
 
+/**
+ * @param {LyricMap} map
+ * @param {Data} data
+ * @param {State} state
+ */
 export function calculateAndDrawLines(map, data, state) {
   const filteredPoetLines =
     filterLines(state, data)
@@ -15,6 +20,12 @@ export function calculateAndDrawLines(map, data, state) {
   drawBubblesAndLegends(map, travelBubbles);
 }
 
+/**
+ * Narrows every poet line down to those matching the selected radio button.
+ * @param {State} state
+ * @param {Data} data
+ * @returns {Line[]}
+ */
 function filterLines(state, data) {
   const [type, num] = getMapTypeNum(state);
   if (type === "all") {
@@ -40,21 +51,38 @@ function filterLines(state, data) {
   }
   else {
     alert(`unrecognized type of map in travel map: <b>${type}</b>`);
+    // Cast: unreachable for a valid State; alerting then failing on the
+    // following .filter() is the long-standing behaviour.
+    return /** @type {Line[]} */ (/** @type {unknown} */ (undefined));
   }
 }
 
+/**
+ * @param {number} from
+ * @param {number} to
+ * @returns {number}
+ */
 function hashCityIds(from, to) {
   return from * 1000 + to;
 }
 
+/**
+ * Merges every poet line sharing a city pair into a single drawn arc, then
+ * colours, weights and builds a popup for each.
+ * @param {State} state
+ * @param {Data} data
+ * @param {Line[]} filteredPoetLines
+ * @returns {Record<number, DrawnLine>}
+ */
 function calculateLines(state, data, filteredPoetLines) {
   const [type, num] = getMapTypeNum(state);
 
+  /** @type {Record<number, DrawnLine>} */
   const lines = {}
   for (const line of filteredPoetLines) {
     const hash = hashCityIds(line.bornCityId, line.activeCityId);
     if (!lines[hash]) {
-      lines[hash] = {};
+      lines[hash] = /** @type {DrawnLine} */ ({});
       lines[hash].fromCity = line.bornCity;
       lines[hash].toCity = line.activeCity;
       lines[hash].poetLines = [];
@@ -63,7 +91,7 @@ function calculateLines(state, data, filteredPoetLines) {
       lines[hash].name = (`${line.bornCity.infowindowName} -> ${line.activeCity.infowindowName}`).toUpperCase();
     }
     lines[hash].poetLines.push(line);
-    colorLine(state, data, lines[hash], line);
+    colorLine(state, data, lines[hash]);
     if (line.dotted) lines[hash].dotted = true;
   }
   for (const hash in lines) {
@@ -78,6 +106,11 @@ function calculateLines(state, data, filteredPoetLines) {
   return lines;
 }
 
+/**
+ * Thickens an arc in proportion to how many poets travelled it.
+ * @param {State} state
+ * @param {DrawnLine} line mutated in place
+ */
 function weightLine(state, line) {
   const [type, num] = getMapTypeNum(state);
   const poetsNum = line.poetLines.length;
@@ -90,6 +123,13 @@ function weightLine(state, line) {
   line.weight = multiplier * poetsNum + increment;
 }
 
+/**
+ * Recolours an arc when it leaves (purple) or stays within (yellow) whatever is
+ * currently selected. Default is red.
+ * @param {State} state
+ * @param {Data} data
+ * @param {DrawnLine} line mutated in place
+ */
 function colorLine(state, data, line) {
   const [type, num] = getMapTypeNum(state);
   // default color is red
@@ -107,7 +147,14 @@ function colorLine(state, data, line) {
   }
 }
 
+/**
+ * One plain bubble for every city touched by a visible line.
+ * @param {Data} data
+ * @param {Line[]} filteredPoetLines
+ * @returns {Record<number, DrawableBubble>}
+ */
 function calculateTravelBubbles(data, filteredPoetLines) {
+  /** @type {Set<number>} */
   const cityIds = new Set()
   for (const plId in filteredPoetLines) {
     const pl = filteredPoetLines[plId];
@@ -115,10 +162,11 @@ function calculateTravelBubbles(data, filteredPoetLines) {
     cityIds.add(pl.activeCityId);
   }
 
+  /** @type {Record<number, DrawableBubble>} */
   const bubbles = {};
   for (const cityId of cityIds) {
     const city = data.citiesById[cityId];
-    bubbles[cityId] = {};
+    bubbles[cityId] = /** @type {DrawableBubble} */ ({});
     bubbles[cityId].city = city;
     bubbles[cityId].price = 10;
   }

--- a/js/renderMap/updateMap.js
+++ b/js/renderMap/updateMap.js
@@ -2,6 +2,7 @@ import { calculateAndDrawLines } from "./lines.js";
 import { calcPoetCities } from "./calcPoetCities.js";
 import { calculateBubbles } from "./calcBubbles.js";
 import { drawBubblesAndLegends } from "../drawMap/drawBubbles.js";
+import { assertUnreachable } from "../assertUnreachable.js";
 
 /**
  * Clears the map and redraws it for the current mode, filter and date range.
@@ -11,14 +12,19 @@ import { drawBubblesAndLegends } from "../drawMap/drawBubbles.js";
  */
 export function updateMap(map, data, state) {
   clearMap(map);
-  if (state.currentMapMode === "placesMode" || state.currentMapMode === "geoimaginaryMode") {
-    const poetCities = calcPoetCities(data, state);
-    const bubbles = calculateBubbles(state, data, poetCities);
-    drawBubblesAndLegends(map, bubbles);
-  } else if (state.currentMapMode === "travelMode") {
-    calculateAndDrawLines(map, data, state);
-  } else {
-    alert(`unrecognized map mode ${state.currentMapMode}`);
+  switch (state.currentMapMode) {
+    case "placesMode":
+    case "geoimaginaryMode": {
+      const poetCities = calcPoetCities(data, state);
+      const bubbles = calculateBubbles(state, data, poetCities);
+      drawBubblesAndLegends(map, bubbles);
+      break;
+    }
+    case "travelMode":
+      calculateAndDrawLines(map, data, state);
+      break;
+    default:
+      assertUnreachable(state.currentMapMode, "unrecognized map mode");
   }
   // uncomment following line to run accessibility checks while playing with the map
   // runAxe();

--- a/js/renderMap/updateMap.js
+++ b/js/renderMap/updateMap.js
@@ -3,6 +3,12 @@ import { calcPoetCities } from "./calcPoetCities.js";
 import { calculateBubbles } from "./calcBubbles.js";
 import { drawBubblesAndLegends } from "../drawMap/drawBubbles.js";
 
+/**
+ * Clears the map and redraws it for the current mode, filter and date range.
+ * @param {LyricMap} map
+ * @param {Data} data
+ * @param {State} state
+ */
 export function updateMap(map, data, state) {
   clearMap(map);
   if (state.currentMapMode === "placesMode" || state.currentMapMode === "geoimaginaryMode") {
@@ -18,21 +24,23 @@ export function updateMap(map, data, state) {
   // runAxe();
 }
 
+/** @param {LyricMap} map */
 function clearMap(map) {
   map.bubbleLayerGroup.clearLayers();
   map.legendLayerGroup.clearLayers();
   map.lineLayerGroup.clearLayers();
 }
 
+// Dev helper: see the commented-out call in updateMap above.
 function runAxe() {
   axe
     .run()
-    .then(results => {
+    .then((/** @type {any} */ results) => {
       if (results.violations.length) {
         throw new Error('Accessibility issues found');
       }
     })
-    .catch(err => {
+    .catch((/** @type {any} */ err) => {
       console.error('Something bad happened:', err.message);
     });
 }

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "checkJs": true,
+    "strict": true,
+    "noEmit": true,
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "lib": [
+      "ES2022",
+      "DOM",
+      "DOM.Iterable"
+    ],
+    "allowJs": true
+  },
+  "include": [
+    "index.js",
+    "js/**/*.js",
+    "tests/**/*.js",
+    "types/**/*.d.ts"
+  ],
+  "exclude": [
+    "3rdparty",
+    "node_modules"
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,30 @@
+{
+  "name": "lyricmappingproject",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "lyricmappingproject",
+      "devDependencies": {
+        "@types/node": "^26.1.2"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -2,8 +2,12 @@
   "name": "lyricmappingproject",
   "private": true,
   "type": "module",
-  "description": "Not a build. This file exists so Node treats the .js files as the ES modules they already are, which is what lets the tests import them directly. There are no dependencies and nothing to install; the site is still plain files served as-is.",
+  "description": "No build. This file exists so Node treats the .js files as the ES modules they already are, and to pin @types/node so the tests can be typechecked. The only dependency is type declarations; nothing is bundled or compiled, and the site is still plain files served as-is.",
   "scripts": {
-    "test": "node --test tests/*.test.js"
+    "test": "node --test tests/*.test.js",
+    "typecheck": "npx -y -p typescript@5 tsc -p jsconfig.json"
+  },
+  "devDependencies": {
+    "@types/node": "^26.1.2"
   }
 }

--- a/tests/data-integrity.test.js
+++ b/tests/data-integrity.test.js
@@ -14,8 +14,8 @@ import assert from "node:assert/strict";
 import { loadRawCsvs } from "./helpers/loadData.js";
 
 const raw = loadRawCsvs();
-const id = (value) => parseInt(value);
-const filled = (value) => String(value ?? "").trim() !== "";
+const id = (/** @type {string} */ value) => parseInt(value);
+const filled = (/** @type {string | undefined} */ value) => String(value ?? "").trim() !== "";
 
 const cityIds = new Set(raw.cities.map(c => id(c.cityId)));
 const poetIds = new Set(raw.poets.map(p => id(p.poetId)));
@@ -105,11 +105,11 @@ const WORLD_BOUNDS = { minLat: 5, maxLat: 50, minLong: -10, maxLong: 55 };
 // ---------------------------------------------------------------------------
 
 describe("primary keys", () => {
-  for (const [file, key] of [["cities", "cityId"], ["poets", "poetId"], ["governments", "governmentId"]]) {
+  for (const [file, key] of /** @type {[keyof RawCsvs, string][]} */ ([["cities", "cityId"], ["poets", "poetId"], ["governments", "governmentId"]])) {
     test(`${file}.csv has unique ${key}`, () => {
       const seen = new Map();
       for (const row of raw[file]) {
-        const value = id(row[key]);
+        const value = id(/** @type {Record<string, string>} */ (/** @type {unknown} */ (row))[key]);
         assert.ok(!seen.has(value), `${key} ${value} appears twice in ${file}.csv`);
         seen.set(value, row);
       }
@@ -195,7 +195,7 @@ describe("labels agree with the ids they point at", () => {
   // A row labelled with one place but pointing at another's id draws the
   // reference in the wrong location, which is invisible without this check.
   test("no NEW cityname disagrees with the city it references", () => {
-    for (const file of ["poetCities", "geopoetCities"]) {
+    for (const file of /** @type {PoetCityCsv[]} */ (["poetCities", "geopoetCities"])) {
       for (const row of raw[file]) {
         const cityId = id(row.cityId);
         if (!filled(row.cityname) || !cityNameById.has(cityId)) continue;
@@ -317,18 +317,53 @@ describe("Greek text", () => {
     // house of Scopas, and Pliny on Telestes. Anything else in there without a
     // Greek letter is a data-entry slip.
     const LATIN_SOURCE_WORKS = new Set(["Quintilian", "Cicero", "Pliny"]);
-    for (const file of ["poetCities", "geopoetCities", "genres"]) {
-      for (const row of raw[file]) {
-        if (!filled(row.source_greektext)) continue;
-        if (/\p{Script=Greek}/u.test(row.source_greektext)) continue;
-        assert.ok(
-          LATIN_SOURCE_WORKS.has(row.source_work),
-          `${file}: ${row.poetname ?? row.genres_poetname} has a source_greektext with no Greek ` +
-          `and an unexpected source_work "${row.source_work}"`
-        );
-      }
+    // The three tables name these columns differently: geographical_imaginary_group
+    // has original_source where the others have source_work, and genres.csv keys
+    // the poet as genres_poetname.
+    for (const row of raw.poetCities) {
+      if (!filled(row.source_greektext) || /\p{Script=Greek}/u.test(row.source_greektext)) continue;
+      assert.ok(LATIN_SOURCE_WORKS.has(row.source_work),
+        `poets_cities: ${row.poetname} has non-Greek source_greektext from "${row.source_work}"`);
+    }
+    for (const row of raw.geopoetCities) {
+      if (!filled(row.source_greektext) || /\p{Script=Greek}/u.test(row.source_greektext)) continue;
+      assert.ok(LATIN_SOURCE_WORKS.has(row.original_source),
+        `geographical_imaginary: ${row.poetname} has non-Greek source_greektext from "${row.original_source}"`);
+    }
+    for (const row of raw.genres) {
+      if (!filled(row.source_greektext) || /\p{Script=Greek}/u.test(row.source_greektext)) continue;
+      assert.ok(LATIN_SOURCE_WORKS.has(row.source_work),
+        `genres: ${row.genres_poetname} has non-Greek source_greektext from "${row.source_work}"`);
     }
   });
+});
+
+describe("csv schema", () => {
+  // types/csv.d.ts declares the columns of each file, and loadRawCsvs() casts
+  // the parsed rows to those types. This test is what keeps that cast honest:
+  // rename or reorder a column in a spreadsheet and it fails here, pointing at
+  // the declaration that now needs updating.
+  /** @type {Record<keyof RawCsvs, string[]>} */
+  const EXPECTED_COLUMNS = {
+    regions: ["regionId", "bigRegionId", "regionname"],
+    cities: ["cityname", "infowindowName", "cityId", "notes", "lat", "long", "region", "regionId"],
+    poetCities: ["poetname", "poetId", "cityname", "cityId", "relationship", "relationshipId", "nativeid", "dotted", "notes", "source_work", "source_workid", "source_citation", "source_greektext", "source_translation", "source_translator", "source_notes", "source_explicit"],
+    poets: ["poetname", "poetDetailName", "poetId", "sources", "dates", "dates_source", "notes"],
+    genres: ["genres_poetname", "poetId", "genre", "genreId", "source_work", "source_workid", "source_citation", "source_greektext", "source_translation", "source_translator", "source_notes", "source_explicit", "notes", "source"],
+    geopoetCities: ["imaginaryid", "poetname", "poetId", "cityname", "cityId", "relationship", "destination", "destination_id", "speaker", "speakerid", "notes", "source_poem", "source_citation", "original_source", "source_greektext", "source_translation", "source_translator", "source_notes", "source_explicit"],
+    cityPolitics: ["city", "cityId", "government", "governmentId", "questionable?", "date", "notes"],
+    bigRegions: ["regionId", "regionname"],
+    dates: ["dates_poetname", "poetId", "date", "iso_8601", "notes"],
+    governments: ["government", "governmentId"],
+  };
+
+  for (const [name, expected] of Object.entries(EXPECTED_COLUMNS)) {
+    test(`${name} has exactly the columns types/csv.d.ts declares`, () => {
+      const rows = raw[/** @type {keyof RawCsvs} */ (name)];
+      assert.ok(rows.length > 0, `${name} is empty`);
+      assert.deepEqual(Object.keys(rows[0]), expected);
+    });
+  }
 });
 
 describe("hygiene", () => {
@@ -374,16 +409,45 @@ describe("hygiene", () => {
 // Trachinia matches pleiades:541157 to all six decimal places.
 // ---------------------------------------------------------------------------
 
-describe("known data bugs: places plotted in the wrong location", () => {
-  const cityById = (cityId) => raw.cities.find(c => id(c.cityId) === cityId);
+/**
+ * cities.csv row for an id, asserting it exists. Used by the bug tests below,
+ * where a missing row means the bug has been fixed and the test should go.
+ * @param {number} cityId
+ * @returns {RawCity}
+ */
+function cityById(cityId) {
+  const city = raw.cities.find(c => id(c.cityId) === cityId);
+  assert.ok(city, `cityId ${cityId} is no longer in cities.csv`);
+  return city;
+}
 
-  const rowsLabelled = (file, label) =>
-    raw[file].filter(row => row.cityname === label);
+/**
+ * cities.csv row for a name, asserting it exists.
+ * @param {string} cityname
+ * @returns {RawCity}
+ */
+function cityByName(cityname) {
+  const city = raw.cities.find(c => c.cityname === cityname);
+  assert.ok(city, `${cityname} is no longer in cities.csv`);
+  return city;
+}
+
+/**
+ * The single row in a join table carrying a given cityname label.
+ * @param {PoetCityCsv} file
+ * @param {string} label
+ * @returns {RawPoetCity | RawGeoPoetCity}
+ */
+function soleRowLabelled(file, label) {
+  const rows = raw[file].filter(row => row.cityname === label);
+  assert.equal(rows.length, 1, `expected exactly one row labelled ${label} in ${file}`);
+  return rows[0];
+}
+
+describe("known data bugs: places plotted in the wrong location", () => {
 
   test("BUG: Pindar's Camarina is plotted on Erythrae, in Ionia rather than Sicily", () => {
-    const rows = rowsLabelled("poetCities", "Camarina");
-    assert.equal(rows.length, 1);
-    assert.equal(id(rows[0].cityId), 254);
+    assert.equal(id(soleRowLabelled("poetCities", "Camarina").cityId), 254);
     const city = cityById(254);
     assert.equal(city.cityname, "Erythrae");
     assert.equal(city.lat, "38.382778");
@@ -397,9 +461,7 @@ describe("known data bugs: places plotted in the wrong location", () => {
   });
 
   test("BUG: Pindar's Cyrene is plotted on Phocaea, in Ionia rather than Libya", () => {
-    const rows = rowsLabelled("poetCities", "Cyrene");
-    assert.equal(rows.length, 1);
-    assert.equal(id(rows[0].cityId), 255);
+    assert.equal(id(soleRowLabelled("poetCities", "Cyrene").cityId), 255);
     const city = cityById(255);
     assert.equal(city.cityname, "Phocaea");
     assert.equal(city.lat, "38.670353");
@@ -412,19 +474,16 @@ describe("known data bugs: places plotted in the wrong location", () => {
   });
 
   test("BUG: Stesichorus' Phocis is plotted on Aetolia", () => {
-    const rows = rowsLabelled("geopoetCities", "Phocis");
-    assert.equal(rows.length, 1);
-    assert.equal(id(rows[0].cityId), 134);
+    assert.equal(id(soleRowLabelled("geopoetCities", "Phocis").cityId), 134);
     assert.equal(cityById(134).cityname, "Aetolia");
     // Stesichorus fr. 222 names both places, and both rows were given cityId 134.
     // Phocis is pleiades:541048 at 38.5557075728, 22.686575589.
-    const aetolia = rowsLabelled("geopoetCities", "Aetolia");
-    assert.equal(aetolia.length, 1, "the same fragment also refers to Aetolia itself");
-    assert.equal(id(aetolia[0].cityId), 134);
+    assert.equal(id(soleRowLabelled("geopoetCities", "Aetolia").cityId), 134,
+      "the same fragment also refers to Aetolia itself");
   });
 
   test("BUG: one Adespota reference to Thrace is plotted on Priapus", () => {
-    const thrace = rowsLabelled("geopoetCities", "Thrace");
+    const thrace = raw.geopoetCities.filter(row => row.cityname === "Thrace");
     const wrong = thrace.filter(row => id(row.cityId) === 240);
     const right = thrace.filter(row => id(row.cityId) === 129);
     assert.equal(wrong.length, 1);
@@ -438,7 +497,7 @@ describe("known data bugs: places plotted in the wrong location", () => {
 
 describe("known data bugs: malformed coordinates", () => {
   test("BUG: Claros' latitude is missing its decimal point", () => {
-    const claros = raw.cities.find(c => c.cityname === "Claros");
+    const claros = cityByName("Claros");
     assert.equal(id(claros.cityId), 226);
     assert.equal(claros.lat, "384725");
     // The longitude, 27.192987, matches pleiades:599719 to five decimals, so the
@@ -452,7 +511,7 @@ describe("known data bugs: malformed coordinates", () => {
   });
 
   test("BUG: Etruria's longitude is missing its decimal point", () => {
-    const etruria = raw.cities.find(c => c.cityname === "Etruria");
+    const etruria = cityByName("Etruria");
     assert.equal(id(etruria.cityId), 197);
     assert.equal(etruria.long, "118301");
     assert.equal(etruria.lat, "42.924252");
@@ -516,7 +575,7 @@ describe("known data bugs: incomplete or inconsistent fields", () => {
     assert.equal(incomplete.length, KNOWN_INCOMPLETE_CITATION_COUNT);
     // renderReference() prints `Citation: X: "" (trans. )` for these. This is
     // the shape of issues #313 and #329. geopoetCities and genres are clean.
-    for (const file of ["geopoetCities", "genres"]) {
+    for (const file of /** @type {CitedCsv[]} */ (["geopoetCities", "genres"])) {
       const bad = raw[file].filter(row =>
         filled(row.source_citation) &&
         !(filled(row.source_translation) && filled(row.source_translator)));
@@ -531,7 +590,9 @@ describe("known data bugs: incomplete or inconsistent fields", () => {
     // poets.csv, so this is cosmetic — but calcBubbles sorts geographical
     // imaginary poets by poetname, so a misspelling can misorder a list.
     assert.ok(misspelt.every(row => id(row.poetId) === 145));
-    assert.equal(raw.poets.find(p => id(p.poetId) === 145).poetname, "Tyrtaeus");
+    const tyrtaeus = raw.poets.find(p => id(p.poetId) === 145);
+    assert.ok(tyrtaeus);
+    assert.equal(tyrtaeus.poetname, "Tyrtaeus");
   });
 
   test("BUG: two names carry stray whitespace", () => {

--- a/tests/helpers/csv.js
+++ b/tests/helpers/csv.js
@@ -4,12 +4,18 @@
 // deliberately do not reuse that code, both to avoid vendoring it into Node and
 // so that a parser bug cannot hide a data bug from itself.
 
-// Returns an array of rows, each an array of raw string fields. Strips a
-// leading UTF-8 BOM, which regions.csv and big_regions.csv both have.
+/**
+ * Returns an array of rows, each an array of raw string fields. Strips a
+ * leading UTF-8 BOM, which regions.csv and big_regions.csv both have.
+ * @param {string} text
+ * @returns {string[][]}
+ */
 export function parseCsvRows(text) {
   if (text.charCodeAt(0) === 0xfeff) text = text.slice(1);
 
+  /** @type {string[][]} */
   const rows = [];
+  /** @type {string[]} */
   let row = [];
   let field = "";
   let inQuotes = false;
@@ -59,12 +65,15 @@ export function parseCsvRows(text) {
 /**
  * Reads a CSV into objects keyed by its header row, the same shape Papa Parse
  * produces in the browser. Fields are left as strings.
+ * @param {string} text
+ * @returns {Record<string, string>[]}
  */
 export function parseCsv(text) {
   const rows = parseCsvRows(text);
   if (rows.length === 0) return [];
   const header = rows[0];
   return rows.slice(1).map(cells => {
+    /** @type {Record<string, string>} */
     const obj = {};
     header.forEach((name, idx) => {
       obj[name] = cells[idx] ?? "";

--- a/tests/helpers/loadData.js
+++ b/tests/helpers/loadData.js
@@ -6,7 +6,10 @@ import { initializeData } from "../../js/calcData/data.js";
 
 const dataFilesDir = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "dataFiles");
 
-/** The data-bag key each CSV is loaded onto, mirroring js/calcData/parseCsvs.js. */
+/**
+ * The data-bag key each CSV is loaded onto, mirroring js/calcData/parseCsvs.js.
+ * @type {Record<keyof RawCsvs, string>}
+ */
 const FILES = {
   regions: "regions.csv",
   cities: "cities.csv",
@@ -23,13 +26,18 @@ const FILES = {
 /**
  * The CSVs exactly as they sit on disk: every field a string, nothing derived.
  * Use this for data-integrity assertions.
+ *
+ * parseCsv returns whatever columns the header row declares. The cast asserts
+ * that those columns are the ones types/csv.d.ts describes, which the "every
+ * expected column is present" test in data-integrity.test.js checks at runtime.
+ * @returns {RawCsvs}
  */
 export function loadRawCsvs() {
-  const raw = {};
+  const raw = /** @type {Record<string, unknown>} */ ({});
   for (const [key, filename] of Object.entries(FILES)) {
     raw[key] = parseCsv(readFileSync(join(dataFilesDir, filename), "utf8"));
   }
-  return raw;
+  return /** @type {RawCsvs} */ (/** @type {unknown} */ (raw));
 }
 
 /**
@@ -39,22 +47,28 @@ export function loadRawCsvs() {
  * The app reports missing lookups by calling alert() and console.log(), neither
  * of which should ever fire against good data, so both are captured and handed
  * back for assertion rather than printed.
+ * @returns {{ data: Data, alerts: string[], logs: string[] }}
  */
 export function loadInitializedData() {
-  const data = loadRawCsvs();
+  // initializeData() hydrates the raw rows in place, turning the RawCsvs shape
+  // into the Data shape js/ works with.
+  const data = /** @type {Data} */ (/** @type {unknown} */ (loadRawCsvs()));
 
+  /** @type {string[]} */
   const alerts = [];
+  /** @type {string[]} */
   const logs = [];
 
-  const realAlert = (globalThis).alert;
+  const globals = /** @type {{ alert?: (message: string) => void }} */ (globalThis);
+  const realAlert = globals.alert;
   const realLog = console.log;
-  (globalThis).alert = (message) => alerts.push(String(message));
-  console.log = (...args) => logs.push(args.join(" "));
+  globals.alert = (message) => alerts.push(String(message));
+  console.log = (/** @type {unknown[]} */ ...args) => logs.push(args.join(" "));
 
   try {
-    initializeData((data));
+    initializeData(data);
   } finally {
-    (globalThis).alert = realAlert;
+    globals.alert = realAlert;
     console.log = realLog;
   }
 
@@ -64,6 +78,8 @@ export function loadInitializedData() {
 /**
  * Ids are written inconsistently in the CSVs — "132", "132.00", "" — and the
  * app normalises them with parseInt. Tests must compare them the same way.
+ * @param {string} value
+ * @returns {number} NaN when the field is blank or unparseable
  */
 export function toId(value) {
   return parseInt(value);

--- a/tests/initializeData.test.js
+++ b/tests/initializeData.test.js
@@ -7,6 +7,10 @@ import { test, describe } from "node:test";
 import assert from "node:assert/strict";
 import { loadInitializedData } from "./helpers/loadData.js";
 import { sortAlphabetically } from "../js/calcData/data.js";
+import { PLACES_FILTER_TYPES, TRAVEL_FILTER_TYPES } from "../js/calcData/getters.js";
+import { createPlacesInterfaceHtml } from "../js/interface/placesInterface.js";
+import { createTravelInterfaceHtml } from "../js/interface/travelInterface.js";
+import { createGeoImaginaryInterfaceHtml } from "../js/interface/geoImaginaryInterface.js";
 
 const { data, alerts, logs } = loadInitializedData();
 
@@ -240,5 +244,59 @@ describe("known bugs: derived travel lines", () => {
     const tyrtaeus = data.linesByPoetId[poetIdByName("Tyrtaeus")];
     assert.ok(tyrtaeus.some((l) =>
       l.bornCity.cityname === "Sparta" && l.activeCity.cityname !== "Sparta"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The control bar is HTML strings, and a radio button's id is the only thing
+// tying a click back to a filter. The types stop a prefix being misspelt; these
+// tests stop a map offering a filter it cannot handle, which the types cannot
+// see because both builders take the same MapFilterType.
+// ---------------------------------------------------------------------------
+
+describe("control bar ids round-trip to filters", () => {
+  /** Every `${prefix}_${num}` id in a block of control bar html. */
+  const idsIn = (/** @type {string} */ html) =>
+    [...html.matchAll(/id="([^"]+)"/g)].map(match => match[1]);
+
+  const prefixesIn = (/** @type {string} */ html) =>
+    [...new Set(idsIn(html).map(id => id.split("_")[0]))].sort();
+
+  test("the places control bar offers only places filters", () => {
+    for (const prefix of prefixesIn(createPlacesInterfaceHtml(data))) {
+      assert.ok(PLACES_FILTER_TYPES.includes(/** @type {PlacesFilterType} */ (prefix)),
+        `the places control bar offers "${prefix}", which getPlacesFilter() rejects`);
+    }
+  });
+
+  test("the geographical imaginary control bar offers only places filters", () => {
+    for (const prefix of prefixesIn(createGeoImaginaryInterfaceHtml(data))) {
+      assert.ok(PLACES_FILTER_TYPES.includes(/** @type {PlacesFilterType} */ (prefix)),
+        `the geographical imaginary control bar offers "${prefix}", which getPlacesFilter() rejects`);
+    }
+  });
+
+  test("the travel control bar offers only travel filters", () => {
+    for (const prefix of prefixesIn(createTravelInterfaceHtml(data))) {
+      assert.ok(TRAVEL_FILTER_TYPES.includes(/** @type {TravelFilterType} */ (prefix)),
+        `the travel control bar offers "${prefix}", which getTravelFilter() rejects`);
+    }
+  });
+
+  test("every id parses back to the filter and number it was built from", () => {
+    const html = createPlacesInterfaceHtml(data) + createTravelInterfaceHtml(data)
+      + createGeoImaginaryInterfaceHtml(data);
+    for (const id of idsIn(html)) {
+      const [prefix, num] = id.split("_");
+      assert.ok(prefix.length > 0, `id "${id}" has no filter prefix`);
+      assert.ok(Number.isFinite(parseInt(num)), `id "${id}" has no numeric id`);
+    }
+  });
+
+  test("the default selectedId of each mode is one that mode can handle", () => {
+    // updateMapMode() sets these; they are what the map renders on first paint.
+    assert.ok(PLACES_FILTER_TYPES.includes(/** @type {PlacesFilterType} */ ("relationship")));
+    assert.ok(PLACES_FILTER_TYPES.includes(/** @type {PlacesFilterType} */ ("all")));
+    assert.ok(TRAVEL_FILTER_TYPES.includes(/** @type {TravelFilterType} */ ("all")));
   });
 });

--- a/tests/initializeData.test.js
+++ b/tests/initializeData.test.js
@@ -10,7 +10,7 @@ import { sortAlphabetically } from "../js/calcData/data.js";
 
 const { data, alerts, logs } = loadInitializedData();
 
-const poetIdByName = (name) => {
+const poetIdByName = (/** @type {string} */ name) => {
   const poet = data.poets.find((p) => p.poetname === name);
   assert.ok(poet, `no poet named ${name}`);
   return poet.poetId;
@@ -28,13 +28,25 @@ describe("initializeData runs clean", () => {
 
 describe("hydration", () => {
   test("ids and coordinates become numbers", () => {
-    for (const city of data.cities.slice(0, 20)) {
-      assert.equal(typeof city.cityId, "number");
-      if (city.lat !== "") assert.equal(typeof city.lat, "number");
+    for (const city of data.cities) {
+      assert.equal(typeof city.cityId, "number", `${city.cityname} has a non-numeric cityId`);
+      assert.equal(typeof city.lat, "number", `${city.cityname} has a non-numeric lat`);
+      assert.equal(typeof city.long, "number", `${city.cityname} has a non-numeric long`);
     }
-    for (const pc of data.poetCities.slice(0, 20)) {
+    for (const pc of data.poetCities) {
       assert.equal(typeof pc.poetId, "number");
       assert.equal(typeof pc.cityId, "number");
+    }
+  });
+
+  test("cities with no coordinates hydrate to NaN, and are skipped when drawing", () => {
+    // parseFloat("") is NaN, and drawBubbles() tests `if (bubble.city.lat && ...)`,
+    // so these two cities are simply never drawn. Asserted explicitly because
+    // `typeof NaN === "number"` makes them invisible to the check above.
+    const unplaced = data.cities.filter(city => Number.isNaN(city.lat) || Number.isNaN(city.long));
+    assert.deepEqual(unplaced.map(city => city.cityname).sort(), ["Onogloi", "Stathmi"]);
+    for (const city of unplaced) {
+      assert.ok(Number.isNaN(city.lat) && Number.isNaN(city.long), "one coordinate without the other");
     }
   });
 
@@ -46,11 +58,11 @@ describe("hydration", () => {
   });
 
   test("every lookup table is populated", () => {
-    for (const key of [
+    for (const key of /** @type {(keyof Data)[]} */ ([
       "citiesById", "poetsById", "regionsById", "genresByPoetId", "genresByGenreId",
       "govsByCityId", "govsById", "datesByPoetId",
       "linesByPoetId", "linesByBornCityId", "linesByActiveCityId"
-    ]) {
+    ])) {
       assert.ok(Object.keys(data[key]).length > 0, `${key} is empty`);
     }
   });
@@ -145,7 +157,8 @@ describe("control bar contents", () => {
   });
 
   test("every control bar list is sorted and non-empty", () => {
-    for (const key of ["travelPoets", "travelCities", "poetsWithUnknownTravel", "regionsForInterface"]) {
+    for (const key of /** @type {("travelPoets" | "travelCities" | "poetsWithUnknownTravel" | "regionsForInterface")[]} */
+      (["travelPoets", "travelCities", "poetsWithUnknownTravel", "regionsForInterface"])) {
       const list = data[key];
       assert.ok(list.length > 0, `${key} is empty`);
       const names = list.map((t) => t[1]);
@@ -211,10 +224,10 @@ describe("known bugs: derived travel lines", () => {
     // so the map draws the foreign-origin traditions and silently drops the
     // native one. This is the travel-map half of issue #332, and it is worse
     // than the popup wording: the omission cannot be seen at all.
-    for (const [name, invisible, drawn] of [
+    for (const [name, invisible, drawn] of /** @type {[string, string, string[]][]} */ ([
       ["Alcman", "Sparta", ["Sardis"]],
       ["Corinna", "Thebes", ["Tanagra"]]
-    ]) {
+    ])) {
       const lines = data.linesByPoetId[poetIdByName(name)];
       const visible = lines.filter((l) => l.bornCityId !== l.activeCityId);
       assert.deepEqual(visible.map((l) => l.bornCity.cityname).sort(), drawn,

--- a/tests/popups.test.js
+++ b/tests/popups.test.js
@@ -16,24 +16,63 @@ const { data } = loadInitializedData();
 
 const ALL_DATES = { minDate: -800, maxDate: -400 };
 
+/**
+ * @param {State["currentMapMode"]} currentMapMode
+ * @param {string} selectedId
+ * @returns {Record<number, Bubble>}
+ */
 function bubblesFor(currentMapMode, selectedId) {
-  const state = ({ currentMapMode, selectedId, ...ALL_DATES });
+  /** @type {State} */
+  const state = { currentMapMode, selectedId, ...ALL_DATES };
   return calculateBubbles(state, data, calcPoetCities(data, state));
 }
 
-const cityIdByName = (name) => {
+const cityIdByName = (/** @type {string} */ name) => {
   const city = data.cities.find((c) => c.cityname === name);
   assert.ok(city, `no city named ${name}`);
   return city.cityId;
 };
 
+/**
+ * The popup html for a city's bubble, asserting both exist. calculateBubbles()
+ * always sets popupHtml for the modes these tests exercise, but the type allows
+ * for travel mode, where bubbles are drawn without popups.
+ * @param {Record<number, Bubble>} bubbles
+ * @param {string} cityname
+ * @returns {string}
+ */
+function popupFor(bubbles, cityname) {
+  const bubble = bubbles[cityIdByName(cityname)];
+  assert.ok(bubble, `no bubble for ${cityname}`);
+  assert.ok(bubble.popupHtml, `no popup html for ${cityname}`);
+  return bubble.popupHtml;
+}
+
+/**
+ * As popupFor, for a bubble already in hand.
+ * @param {Bubble} bubble
+ * @returns {string}
+ */
+function popupOf(bubble) {
+  assert.ok(bubble.popupHtml, `no popup html for ${bubble.city.cityname}`);
+  return bubble.popupHtml;
+}
+
+/**
+ * The grouped poets on a geographical-imaginary bubble, asserting they exist.
+ * @param {Bubble} bubble
+ * @returns {GeoBubblePoet[]}
+ */
+function poetsOf(bubble) {
+  assert.ok(bubble.poets, `no grouped poets for ${bubble.city.cityname}`);
+  return bubble.poets;
+}
+
 describe("places map: origin", () => {
   const bubbles = bubblesFor("placesMode", "relationship_1");
 
   test("a birthplace bubble is titled 'POETS BORN IN <city>'", () => {
-    const sparta = bubbles[cityIdByName("Sparta")];
-    assert.ok(sparta, "no bubble for Sparta");
-    assert.match(sparta.popupHtml, /POETS BORN IN SPARTA/);
+    assert.match(popupFor(bubbles, "Sparta"), /POETS BORN IN SPARTA/);
   });
 
   test("Alcman appears under both Sparta and Sardis", () => {
@@ -41,27 +80,26 @@ describe("places map: origin", () => {
     // born, so he is currently asserted as a native of both, with no hedging.
     // When the copy changes, these two assertions are what should change.
     for (const cityname of ["Sparta", "Sardis"]) {
-      const bubble = bubbles[cityIdByName(cityname)];
-      assert.ok(bubble, `no bubble for ${cityname}`);
-      assert.match(bubble.popupHtml, /Alcman/, `Alcman missing from ${cityname}`);
-      assert.match(bubble.popupHtml, new RegExp(`POETS BORN IN ${cityname.toUpperCase()}`));
+      const html = popupFor(bubbles, cityname);
+      assert.match(html, /Alcman/, `Alcman missing from ${cityname}`);
+      assert.match(html, new RegExp(`POETS BORN IN ${cityname.toUpperCase()}`));
       // Note: /possibly/i alone would match the genre "Possibly lyric".
-      assert.doesNotMatch(bubble.popupHtml, /possibly born/i,
+      assert.doesNotMatch(html, /possibly born/i,
         `${cityname} already hedges Alcman's birth; issue #332 may have landed, so update this test`);
     }
   });
 
   test("popups carry dates, sources and the Greek text of the citation", () => {
-    const sardis = bubbles[cityIdByName("Sardis")];
-    assert.match(sardis.popupHtml, /Dates:/);
-    assert.match(sardis.popupHtml, /Source\(s\):/);
-    assert.match(sardis.popupHtml, /Citation:/);
-    assert.match(sardis.popupHtml, /Greek:/);
+    const sardis = popupFor(bubbles, "Sardis");
+    assert.match(sardis, /Dates:/);
+    assert.match(sardis, /Source\(s\):/);
+    assert.match(sardis, /Citation:/);
+    assert.match(sardis, /Greek:/);
     // Both sides are normalised defensively: the corpus is NFC (enforced by
     // data-integrity.test.js), but Greek typed into a test file can easily
     // arrive as oxia, which would render identically and never match.
     assert.ok(
-      sardis.popupHtml.normalize("NFC").includes("Ἀλκμάν".normalize("NFC")),
+      sardis.normalize("NFC").includes("Ἀλκμάν".normalize("NFC")),
       "the Suda's Greek should be quoted in the Sardis popup"
     );
   });
@@ -71,21 +109,18 @@ describe("places map: activity", () => {
   const bubbles = bubblesFor("placesMode", "relationship_3");
 
   test("a city's poets are split into natives and non-natives", () => {
-    const athens = bubbles[cityIdByName("Athens")];
-    assert.ok(athens, "no bubble for Athens");
-    assert.match(athens.popupHtml, /NATIVE LYRIC ACTIVITY IN ATHENS/);
-    assert.match(athens.popupHtml, /NON-NATIVE LYRIC ACTIVITY IN ATHENS/);
-    assert.match(athens.popupHtml, /NATIVE POETS/);
-    assert.match(athens.popupHtml, /NON-NATIVE POETS/);
+    const athens = popupFor(bubbles, "Athens");
+    assert.match(athens, /NATIVE LYRIC ACTIVITY IN ATHENS/);
+    assert.match(athens, /NON-NATIVE LYRIC ACTIVITY IN ATHENS/);
+    assert.match(athens, /NATIVE POETS/);
+    assert.match(athens, /NON-NATIVE POETS/);
   });
 
   test("every bubble produces html and a legend", () => {
     for (const bubble of Object.values(bubbles)) {
-      const b = (bubble);
-      assert.equal(typeof b.popupHtml, "string");
-      assert.ok(b.popupHtml.length > 0);
-      assert.equal(b.legend, b.city.cityname);
-      assert.ok(b.price > 0, `${b.city.cityname} has no bubble size`);
+      assert.ok(popupOf(bubble).length > 0);
+      assert.equal(bubble.legend, bubble.city.cityname);
+      assert.ok(bubble.price > 0, `${bubble.city.cityname} has no bubble size`);
     }
   });
 });
@@ -97,16 +132,16 @@ describe("geographical imaginary map", () => {
     const bubble = (Object.values(bubbles))
       .find((b) => b.poetCities.length > 1);
     assert.ok(bubble, "expected at least one city referred to more than once");
-    assert.match(bubble.popupHtml, /\d+ REFERENCES TO /);
+    assert.match(popupOf(bubble), /\d+ REFERENCES TO /);
   });
 
   test("poets are grouped, so one poet with three references is listed once", () => {
     for (const bubble of Object.values(bubbles)) {
-      const b = (bubble);
-      const poetIds = b.poets.map((p) => p.poetId);
-      assert.equal(new Set(poetIds).size, poetIds.length, `${b.city.cityname} lists a poet twice`);
-      const totalReferences = b.poets.reduce((n, p) => n + p.references.length, 0);
-      assert.equal(totalReferences, b.poetCities.length);
+      const poets = poetsOf(bubble);
+      const poetIds = poets.map((p) => p.poetId);
+      assert.equal(new Set(poetIds).size, poetIds.length, `${bubble.city.cityname} lists a poet twice`);
+      const totalReferences = poets.reduce((n, p) => n + p.references.length, 0);
+      assert.equal(totalReferences, bubble.poetCities.length);
     }
   });
 
@@ -114,8 +149,8 @@ describe("geographical imaginary map", () => {
     const single = (Object.values(bubbles))
       .find((b) => b.poetCities.length === 1);
     assert.ok(single);
-    assert.match(single.popupHtml, /1 REFERENCE TO /);
-    assert.doesNotMatch(single.popupHtml, /1 REFERENCES TO /);
+    assert.match(popupOf(single), /1 REFERENCE TO /);
+    assert.doesNotMatch(popupOf(single), /1 REFERENCES TO /);
   });
 });
 
@@ -144,14 +179,14 @@ describe("travel map", () => {
 
 describe("popup html is well formed enough to render", () => {
   test("no popup leaks 'undefined' or 'NaN' into the page", () => {
-    for (const [mode, selectedId] of [
+    for (const [mode, selectedId] of /** @type {[State["currentMapMode"], string][]} */ ([
       ["placesMode", "relationship_1"],
       ["placesMode", "relationship_3"],
       ["geoimaginaryMode", "all_1"]
-    ]) {
+    ])) {
       for (const bubble of Object.values(bubblesFor(mode, selectedId))) {
-        const html = (bubble).popupHtml;
-        const cityname = (bubble).city.cityname;
+        const html = popupOf(bubble);
+        const cityname = bubble.city.cityname;
         assert.doesNotMatch(html, /undefined/, `${mode}/${selectedId} popup for ${cityname} contains "undefined"`);
         assert.doesNotMatch(html, /NaN/, `${mode}/${selectedId} popup for ${cityname} contains "NaN"`);
       }

--- a/types/csv.d.ts
+++ b/types/csv.d.ts
@@ -1,0 +1,157 @@
+// Types for the raw CSV rows as the tests read them from disk.
+//
+// js/ works with hydrated data — ids parsed to numbers, dates negated, derived
+// lookups attached — which is what types/globals.d.ts describes. The tests also
+// read the files exactly as they sit on disk, where every field is a string and
+// only the CSV's own columns exist. Those shapes are declared here.
+//
+// The interfaces below were generated from the actual header rows, so a column
+// renamed in a spreadsheet shows up as a type error in the tests that read it.
+//
+// Like globals.d.ts, this file is never loaded by the browser and is not part
+// of the site.
+
+/** A row of dataFiles/regions.csv, exactly as parsed: every field a string. */
+interface RawRegion {
+  regionId: string;
+  bigRegionId: string;
+  regionname: string;
+}
+
+/** A row of dataFiles/cities.csv, exactly as parsed: every field a string. */
+interface RawCity {
+  cityname: string;
+  infowindowName: string;
+  cityId: string;
+  notes: string;
+  lat: string;
+  long: string;
+  region: string;
+  regionId: string;
+}
+
+/** A row of dataFiles/poets_cities.csv, exactly as parsed: every field a string. */
+interface RawPoetCity {
+  poetname: string;
+  poetId: string;
+  cityname: string;
+  cityId: string;
+  relationship: string;
+  relationshipId: string;
+  nativeid: string;
+  dotted: string;
+  notes: string;
+  source_work: string;
+  source_workid: string;
+  source_citation: string;
+  source_greektext: string;
+  source_translation: string;
+  source_translator: string;
+  source_notes: string;
+  source_explicit: string;
+}
+
+/** A row of dataFiles/poets.csv, exactly as parsed: every field a string. */
+interface RawPoet {
+  poetname: string;
+  poetDetailName: string;
+  poetId: string;
+  sources: string;
+  dates: string;
+  dates_source: string;
+  notes: string;
+}
+
+/** A row of dataFiles/genres.csv, exactly as parsed: every field a string. */
+interface RawGenre {
+  genres_poetname: string;
+  poetId: string;
+  genre: string;
+  genreId: string;
+  source_work: string;
+  source_workid: string;
+  source_citation: string;
+  source_greektext: string;
+  source_translation: string;
+  source_translator: string;
+  source_notes: string;
+  source_explicit: string;
+  notes: string;
+  source: string;
+}
+
+/** A row of dataFiles/geographical_imaginary_group.csv, exactly as parsed: every field a string. */
+interface RawGeoPoetCity {
+  imaginaryid: string;
+  poetname: string;
+  poetId: string;
+  cityname: string;
+  cityId: string;
+  relationship: string;
+  destination: string;
+  destination_id: string;
+  speaker: string;
+  speakerid: string;
+  notes: string;
+  source_poem: string;
+  source_citation: string;
+  original_source: string;
+  source_greektext: string;
+  source_translation: string;
+  source_translator: string;
+  source_notes: string;
+  source_explicit: string;
+}
+
+/** A row of dataFiles/city_politics.csv, exactly as parsed: every field a string. */
+interface RawCityPolitics {
+  city: string;
+  cityId: string;
+  government: string;
+  governmentId: string;
+  "questionable?": string;
+  date: string;
+  notes: string;
+}
+
+/** A row of dataFiles/big_regions.csv, exactly as parsed: every field a string. */
+interface RawBigRegion {
+  regionId: string;
+  regionname: string;
+}
+
+/** A row of dataFiles/dates.csv, exactly as parsed: every field a string. */
+interface RawDate {
+  dates_poetname: string;
+  poetId: string;
+  date: string;
+  iso_8601: string;
+  notes: string;
+}
+
+/** A row of dataFiles/governments.csv, exactly as parsed: every field a string. */
+interface RawGovernment {
+  government: string;
+  governmentId: string;
+}
+
+/** The ten CSVs as the tests load them from disk. */
+interface RawCsvs {
+  regions: RawRegion[];
+  cities: RawCity[];
+  poetCities: RawPoetCity[];
+  poets: RawPoet[];
+  genres: RawGenre[];
+  geopoetCities: RawGeoPoetCity[];
+  cityPolitics: RawCityPolitics[];
+  bigRegions: RawBigRegion[];
+  dates: RawDate[];
+  governments: RawGovernment[];
+}
+
+
+/** The three tables that carry source citations. */
+type CitedCsv = "poetCities" | "geopoetCities" | "genres";
+
+/** The two tables that join poets to cities. */
+type PoetCityCsv = "poetCities" | "geopoetCities";

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -214,6 +214,24 @@ interface GeoPoetCity extends PoetPrimed {
 /** A [id, displayName] pair used to build the radio buttons in the control bar. */
 type IdNameTuple = [number, string];
 
+/**
+ * The filter kinds encoded in the first half of State.selectedId, e.g. the
+ * "poet" in "poet_93".
+ *
+ * Each map offers its own set, and the two overlap rather than nest: "all" and
+ * "poet" appear on both, "genre" only on places, "gov" only on travel. Keeping
+ * them as separate unions lets getPlacesFilter() and getTravelFilter() each
+ * hand back exactly what their map can produce, so consumers switch over four
+ * or six cases with nothing impossible left to handle.
+ */
+type PlacesFilterType = "all" | "relationship" | "poet" | "genre";
+
+/** As PlacesFilterType, for the travel map. */
+type TravelFilterType = "all" | "poet" | "destination" | "smallregion" | "region" | "gov";
+
+/** Any filter kind, whichever map produced it. */
+type MapFilterType = PlacesFilterType | TravelFilterType;
+
 /** One poet's attested movement from one birthplace to one place of activity. */
 interface Line extends PoetPrimed {
   poetId: number;

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -1,0 +1,343 @@
+// Type declarations for Mapping Greek Lyric.
+//
+// This file is NEVER loaded by the browser and is NOT part of the site. It exists
+// only so that editors and `npx tsc -p jsconfig.json` can check the plain ES modules
+// in js/. Deleting it does not affect the running site in any way.
+//
+// Everything here is declared globally, so the .js files can write
+// `@param {City} city` without any import boilerplate.
+
+// ---------------------------------------------------------------------------
+// Third-party globals, loaded via <script> tags in index.html.
+// Typed loosely on purpose: pinning them would mean taking on dependencies
+// (@types/leaflet etc.), and the Leaflet plugins we use (geodesic, curve,
+// polylineDecorator) have no published types anyway.
+// ---------------------------------------------------------------------------
+
+declare const L: any;
+declare const Papa: any;
+declare const noUiSlider: any;
+declare const axe: any;
+
+/** A Leaflet LayerGroup, narrowed to the methods this project calls. */
+interface LeafletLayerGroup {
+  clearLayers(): void;
+  addLayer(layer: any): void;
+}
+
+/**
+ * The Leaflet map, narrowed to the methods this project calls, plus the three
+ * layer groups initializeMap() attaches to it.
+ */
+interface LyricMap {
+  on(event: string, handler: () => void): void;
+  getZoom(): number;
+  addLayer(layer: any): void;
+  bubbleLayerGroup: LeafletLayerGroup;
+  legendLayerGroup: LeafletLayerGroup;
+  lineLayerGroup: LeafletLayerGroup;
+}
+
+// ---------------------------------------------------------------------------
+// CSV-backed entities.
+//
+// Papa Parse hands back every field as a string. initializeData() then mutates
+// the id/lat/long fields in place into numbers. The types below describe the
+// HYDRATED shape, i.e. what the rest of the codebase actually sees; the raw
+// pre-hydration arrays are cast to any[] inside initializeData().
+// ---------------------------------------------------------------------------
+
+/** A row of dataFiles/cities.csv. */
+interface City {
+  cityname: string;
+  infowindowName: string;
+  cityId: number;
+  notes: string;
+  lat: number;
+  long: number;
+  region: string;
+  regionId: number;
+  /** Added by addBigRegionIdToCities(); absent for cities with no mapped region. */
+  bigRegionId?: number;
+}
+
+/** A row of dataFiles/regions.csv. */
+interface Region {
+  regionId: number;
+  bigRegionId: number;
+  regionname: string;
+}
+
+/** A row of dataFiles/big_regions.csv. */
+interface BigRegion {
+  regionId: number;
+  regionname: string;
+}
+
+/** A row of dataFiles/governments.csv. */
+interface Government {
+  government: string;
+  governmentId: number;
+}
+
+/** A row of dataFiles/city_politics.csv: one city's regime at one date. */
+interface CityPolitics {
+  city: string;
+  cityId: number;
+  government: string;
+  governmentId: number;
+  "questionable?": string;
+  /** Negative for BCE, e.g. -600. */
+  date: number;
+  notes: string;
+}
+
+/** A row of dataFiles/dates.csv. */
+interface PoetDate {
+  dates_poetname: string;
+  poetId: number;
+  /** Negative for BCE, e.g. -600. */
+  date: number;
+  iso_8601: string;
+  notes: string;
+}
+
+/** A row of dataFiles/poets.csv. */
+interface Poet {
+  poetname: string;
+  poetDetailName: string;
+  poetId: number;
+  sources: string;
+  dates: string;
+  dates_source: string;
+  notes: string;
+  /**
+   * Added by addDatesToPoets() from dates.csv, and required here even though
+   * that function can only set it for poets that have rows in dates.csv.
+   *
+   * This is a claim about the data, not something the code guarantees: a poet
+   * with no dates would silently vanish from the map, because getDateFilterFn()
+   * compares against these. The claim is enforced by the "every poet on the map
+   * has a min and max date" test in tests/initializeData.test.js. If that test
+   * is ever deleted, these should go back to being optional.
+   */
+  minDate: number;
+  /** See minDate. */
+  maxDate: number;
+}
+
+/** A row of dataFiles/genres.csv. */
+interface Genre {
+  genres_poetname: string;
+  poetId: number;
+  genre: string;
+  genreId: number;
+  source_work: string;
+  source_workid: string;
+  source_citation: string;
+  source_greektext: string;
+  source_translation: string;
+  source_translator: string;
+  source_notes: string;
+  source_explicit: string;
+  notes: string;
+  source: string;
+}
+
+/**
+ * Poet metadata copied onto poet-city rows and travel lines by
+ * primeObjWithPoetData(), so popups can render without a second lookup.
+ */
+interface PoetPrimed {
+  poetDetailName: string;
+  poetDates: string;
+  poetSources: string;
+  poetGenres: string;
+}
+
+/** A row of dataFiles/poets_cities.csv, after hydration and priming. */
+interface PoetCity extends PoetPrimed {
+  poetname: string;
+  poetId: number;
+  cityname: string;
+  cityId: number;
+  /** Human-readable form of relationshipId; often blank in the CSV. */
+  relationship: string;
+  /** 1 = born, 2 = died, 3 = performed. Prefer this over `relationship`. */
+  relationshipId: number;
+  nativeid: string;
+  /** The literal string "dotted", or "". Marks an inferred connection. */
+  dotted: string;
+  notes: string;
+  source_work: string;
+  source_workid: string;
+  source_citation: string;
+  source_greektext: string;
+  source_translation: string;
+  source_translator: string;
+  source_notes: string;
+  source_explicit: string;
+}
+
+/** A row of dataFiles/geographical_imaginary_group.csv, after hydration and priming. */
+interface GeoPoetCity extends PoetPrimed {
+  imaginaryid: number;
+  poetname: string;
+  poetId: number;
+  cityname: string;
+  cityId: number;
+  relationship: string;
+  /**
+   * Not a column in geographical_imaginary_group.csv, so always undefined here.
+   * Declared so code can read it off either kind of row.
+   */
+  relationshipId?: number;
+  destination: string;
+  destination_id: string;
+  speaker: string;
+  speakerid: string;
+  notes: string;
+  source_poem: string;
+  source_citation: string;
+  original_source: string;
+  source_greektext: string;
+  source_translation: string;
+  source_translator: string;
+  source_notes: string;
+  source_explicit: string;
+}
+
+// ---------------------------------------------------------------------------
+// Derived structures, built at runtime.
+// ---------------------------------------------------------------------------
+
+/** A [id, displayName] pair used to build the radio buttons in the control bar. */
+type IdNameTuple = [number, string];
+
+/** One poet's attested movement from one birthplace to one place of activity. */
+interface Line extends PoetPrimed {
+  poetId: number;
+  bornCityId: number;
+  activeCityId: number;
+  bornPc: PoetCity;
+  activePc: PoetCity;
+  dotted: boolean;
+  bornCity: City;
+  activeCity: City;
+  bornGovIds: number[];
+  activeGovIds: number[];
+}
+
+/** The citation block rendered at the bottom of a popup. */
+interface Reference {
+  source_citation: string;
+  source_greektext: string;
+  source_translation: string;
+  source_translator: string;
+  source_poem?: string;
+}
+
+/**
+ * A poet-city row flattened for rendering: the subset of fields popups need,
+ * with the citation collapsed into a single `reference`.
+ */
+interface RenderedPoetCity extends PoetPrimed {
+  poetId: number;
+  cityId: number;
+  cityname: string;
+  poetname: string;
+  /** Undefined for geographical-imaginary rows, which have no relationship. */
+  relationshipId?: number;
+  reference: Reference;
+}
+
+/** A poet grouped inside a geographical-imaginary bubble, with all their citations. */
+interface GeoBubblePoet extends RenderedPoetCity {
+  references: Reference[];
+}
+
+/**
+ * The minimum a circle needs to be drawn on the map. Travel mode builds these
+ * directly; places and geographical-imaginary modes build the richer Bubble.
+ */
+interface DrawableBubble {
+  city: City;
+  /** Legacy name for bubble radius weighting. */
+  price: number;
+  popupHtml?: string;
+  legend?: string;
+}
+
+/** A circle drawn on the map for one city, with the rows behind its popup. */
+interface Bubble extends DrawableBubble {
+  poetCities: RenderedPoetCity[];
+  /** Only populated in geoimaginaryMode. */
+  poets?: GeoBubblePoet[];
+}
+
+/** One drawn arc, merging every Line that shares the same city pair. */
+interface DrawnLine {
+  fromCity: City;
+  toCity: City;
+  poetLines: Line[];
+  dotted: boolean;
+  color: string;
+  name: string;
+  /** Set by weightLine() before the arc is drawn. */
+  weight: number;
+  /** Set by calculateLines() before the arc is drawn. */
+  popupHtml: string;
+}
+
+/** Which of the three maps is showing, and the current filters. */
+interface State {
+  currentMapMode: "placesMode" | "travelMode" | "geoimaginaryMode";
+  /** Negative for BCE. */
+  minDate: number;
+  /** Negative for BCE. */
+  maxDate: number;
+  /** The checked radio button's id, e.g. "poet_93" or "relationship_1". */
+  selectedId: string;
+}
+
+/**
+ * The single mutable bag of everything. parseCsvs() fills the raw arrays;
+ * initializeData() hydrates them and adds every derived lookup below.
+ */
+interface Data {
+  // straight from CSV
+  cities: City[];
+  regions: Region[];
+  bigRegions: BigRegion[];
+  governments: Government[];
+  cityPolitics: CityPolitics[];
+  dates: PoetDate[];
+  poets: Poet[];
+  genres: Genre[];
+  poetCities: PoetCity[];
+  geopoetCities: GeoPoetCity[];
+
+  // lookups
+  citiesById: Record<number, City>;
+  poetsById: Record<number, Poet>;
+  regionsById: Record<number, Region>;
+  genresByPoetId: Record<number, Genre[]>;
+  genresByGenreId: Record<number, string>;
+  govsByCityId: Record<number, CityPolitics[]>;
+  govsById: Record<number, string>;
+  datesByPoetId: Record<number, number[]>;
+
+  // travel
+  lines: Line[];
+  linesByPoetId: Record<number, Line[]>;
+  linesByBornCityId: Record<number, Line[]>;
+  linesByActiveCityId: Record<number, Line[]>;
+
+  // control-bar contents
+  genreIdsWithName: [string, string][];
+  geoImaginaryPoets: IdNameTuple[];
+  travelPoets: IdNameTuple[];
+  travelCities: IdNameTuple[];
+  poetsWithUnknownTravel: IdNameTuple[];
+  regionsForInterface: IdNameTuple[];
+}


### PR DESCRIPTION
Adds types to the site source **and to the tests**, checked by TypeScript in `--noEmit` mode, then uses them to replace the codebase's unreachable-branch casts with real exhaustiveness checks.

Stacked on #334, which is merged, so this diff is just the types.

```sh
npm ci && npm run typecheck     # tsc exits 0
npm test                        # 82 tests, and needs no install
```

Two commits, reviewable in order:

1. **Add JSDoc types and a TypeScript check** — the declarations, the annotations, and the bugs they surfaced
2. **Replace unreachable-branch casts with exhaustiveness checks** — using those types to delete seven casts

---

## No build, and that stays true

No bundler, no compile step, nothing generated. Every shipped file remains a plain ES module the browser loads directly, and **deleting `jsconfig.json` and `types/` would leave the site byte-for-byte functional** — the types are comments.

- `types/globals.d.ts` — the hydrated shapes `js/` works with: `Line`, `Bubble`, `DrawnLine`, `State`, `Data`, the filter unions, and loose declarations for the Leaflet / Papa Parse / noUiSlider / axe globals
- `types/csv.d.ts` — the raw CSV row shapes the tests read, **generated from the actual header rows**
- JSDoc annotations across `index.js`, `js/` and `tests/`

Both declaration files are global, so source files write `@param {City} city` with no import boilerplate.

## The one dependency

Typechecking the tests requires `@types/node`. It is **type declarations, not code**: nothing from `node_modules` is imported, served or deployed, `node_modules` is gitignored, and `index.html` references none of it. GitHub Pages serves the same plain files it does today.

The test suite still runs with **zero install** — verified on a clean checkout with no `node_modules`. CI deliberately runs the tests *before* `npm ci` to keep that honest.

---

## Exhaustiveness instead of casts

Six places ended an if/else chain with an `alert` and then fell through, leaving TypeScript to be *told* by a cast what the code already knew. Two were doing real work:

```js
return [.../** @type {AnyPoetCity[]} */ (poetCitiesData)];
return /** @type {Line[]} */ (/** @type {unknown} */ (undefined));
```

`js/assertUnreachable.js` takes `never`, so TypeScript **verifies** the branch is dead rather than being told. At runtime it alerts and throws — which is what these branches did in effect anyway, except they failed a line or two later with a message pointing somewhere else. All six sites are now switches ending in `default:`.

### Modelling the filters as the two sets they are

The two switches on the control bar's filter kind needed a type first: `getMapTypeNum()` split `selectedId` and handed back the prefix as a bare `string`, so nothing downstream could be exhaustive.

The filters are two **overlapping** sets, not nested ones — `all` and `poet` appear on both maps — so `Exclude`/`Extract` isn't the tool; they're defined directly:

```ts
type PlacesFilterType = "all" | "relationship" | "poet" | "genre";
type TravelFilterType = "all" | "poet" | "destination" | "smallregion" | "region" | "gov";
```

`getPlacesFilter()` and `getTravelFilter()` each validate against their own map's set, so `getFilterFn` is exhaustive over four cases and `filterLines` over six, **with no branch for a filter their map cannot produce**.

### Closing the loop back to the HTML

Those prefixes are minted as bare string literals in **twelve places** across the three interface builders, interpolated into a radio button's `id`, and read back off the DOM — so nothing connected them to the parsing, and a misspelling would have compiled fine. `createInputFromTuple` and the new `createFilterInput` now take a typed prefix.

Which map may offer which filter is **not** something the types can see, since both builders take the same `MapFilterType`. Five tests assert each control bar only emits ids its own map can parse.

### Verified, per layer

| perturbation | caught by |
|---|---|
| unhandled member added to `PlacesFilterType` | tsc — `calcPoetCities.js` only |
| unhandled member added to `TravelFilterType` | tsc — `lines.js` only |
| places control bar emitting `gov` | tsc clean *(expected)*, control bar test fails |
| a ninth filter added to neither switch | tsc, naming both files |

**Seven casts removed.**

---

## A type that states an invariant, with a test that proves it

`Poet.minDate` / `Poet.maxDate` are declared **required**, though `addDatesToPoets()` can only set them for poets present in `dates.csv`. The alternative was fallbacks at the single place that reads them:

```js
const maxDate = poet.maxDate ?? -Infinity;   // for a case that never occurs
```

which reads as though undated poets were an expected condition. They are not — such a poet silently vanishes from the map. So the type states the invariant and the test suite enforces it. As a result `getDateFilterFn` keeps its original one-line body, and **`calcCommon.js` is unchanged apart from a comment**.

## Five latent bugs

Three in `js/`:

1. **`calcPoetCities.js`** referenced a bare `poetId` in two `console.log` calls where `pc.poetId` was meant — a real `ReferenceError` waiting for any poet with the wrong number of rows for a selected genre.
2. **`popups.js`** passed a second argument to `createNumberedListOfPoets`, which takes one. Harmless at runtime, but it concealed drift between call sites — and the pending fix for #332 adds real parameters at exactly those call sites.
3. **`lines.js`** passed a fourth argument to `colorLine`, which takes three. Silently dropped.

Two more came from typechecking the tests, and both had made a test **quietly weaker than it looked**:

4. `initializeData.test.js` guarded a coordinate assertion with `city.lat !== ""`. After hydration `lat` is a `number`, so the guard was **always true**, and since `typeof NaN === "number"` blank coordinates passed unnoticed. It also only checked the first 20 of 230 cities. Now checks all of them, with a second test pinning Onogloi and Stathmi as the two cities with no coordinates.
5. `data-integrity.test.js` read `row.source_work` across all three cited tables, but `geographical_imaginary_group.csv` names that column **`original_source`** — so the check did nothing for those rows. It passed only because all three non-Greek testimonia happen to sit in `poets_cities`.

## Keeping the CSV types honest

`loadRawCsvs()` casts parsed rows to the `types/csv.d.ts` shapes. A `csv schema` test asserts each file's columns exactly match what is declared — rename a column in a spreadsheet and it fails there, naming the file. Verified by renaming `cityId` in a scratch copy.

## Everything else is a comment

The only other executable change in `js/` is `index.js` seeding `state.selectedId` with the value `updateMapMode` already assigns for the default places mode. Every remaining line of the `js/` diff is JSDoc.

## Verification

- `tsc` exits 0 across `js/`, `index.js` and `tests/`
- **82 tests pass**, and still pass on a clean checkout with no `node_modules`
- exercised in a browser, every map mode and filter kind: places 204 bubbles, origin 110, genre 30, travel 697 arcs, political system 182, destination 79, small region 248, geographical imaginary 336, plus the credits/home essay toggle — no console errors