### PR TITLE
Make the type annotations checked rather than asserted

### DIFF
--- a/js/calcData/data.js
+++ b/js/calcData/data.js
@@ -201,14 +201,11 @@ function createGenresByGenreId(data) {
  * @returns {IdNameTuple[]}
  */
 function createAlphabetizedListOfPoetsFromIds(poetIds, data) {
-  return Array
+  /** @type {IdNameTuple[]} */
+  const tuples = Array
     .from(poetIds)
-    .map(poetId => {
-      const poet = getPoet(data, poetId);
-      const poetDetailName = poet.poetDetailName;
-      return /** @type {IdNameTuple} */ ([poetId, poetDetailName]);
-    })
-    .sort((a, b) => sortAlphabetically(a[1], b[1]));
+    .map(poetId => [poetId, getPoet(data, poetId).poetDetailName]);
+  return tuples.sort((a, b) => sortAlphabetically(a[1], b[1]));
 }
 
 /** @param {Data} data */
@@ -275,13 +272,11 @@ function createTravelCities(data) {
   const cityIds = new Set(
     data.lines.flatMap(line => [line.bornCityId, line.activeCityId])
   );
-  data.travelCities = Array
+  /** @type {IdNameTuple[]} */
+  const tuples = Array
     .from(cityIds)
-    .map(cityId => {
-      const city = getCity(data, cityId);
-      return /** @type {IdNameTuple} */ ([cityId, city.cityname]);
-    })
-    .sort((a, b) => sortAlphabetically(a[1], b[1]));
+    .map(cityId => [cityId, getCity(data, cityId).cityname]);
+  data.travelCities = tuples.sort((a, b) => sortAlphabetically(a[1], b[1]));
 }
 
 /** @param {Data} data */
@@ -301,10 +296,11 @@ function createRegionsForInterface(data) {
     20, // Thrace
     28 // Troad
   ];
-  data.regionsForInterface = data.regions
+  /** @type {IdNameTuple[]} */
+  const tuples = data.regions
     .filter(region => !regionIdsToOmit.includes(region.regionId))
-    .map(region => /** @type {IdNameTuple} */ ([region.regionId, region.regionname]))
-    .sort((a, b) => sortAlphabetically(a[1], b[1]));
+    .map(region => [region.regionId, region.regionname]);
+  data.regionsForInterface = tuples.sort((a, b) => sortAlphabetically(a[1], b[1]));
 }
 
 /**
@@ -427,10 +423,11 @@ function createGenreIdsWithNames(data) {
     "1", // Diaskeue
     "31" // Possibly lyric
   ]
-  data.genreIdsWithName =
-    Object
-      .keys(data.genresByGenreId)
-      .map((id) => /** @type {[string, string]} */ ([id, data.genresByGenreId[Number(id)]]))
-      .filter(kv => !genresToOmit.includes(kv[0]))
-      .sort((a, b) => sortAlphabetically(a[1], b[1]));
+  /** @type {[string, string][]} */
+  const tuples = Object
+    .keys(data.genresByGenreId)
+    .map((id) => [id, data.genresByGenreId[Number(id)]]);
+  data.genreIdsWithName = tuples
+    .filter(kv => !genresToOmit.includes(kv[0]))
+    .sort((a, b) => sortAlphabetically(a[1], b[1]));
 }

--- a/js/calcData/data.js
+++ b/js/calcData/data.js
@@ -198,14 +198,13 @@ function createGenresByGenreId(data) {
 /**
  * @param {Iterable<number>} poetIds
  * @param {Data} data
- * @returns {IdNameTuple[]}
+ * @returns {FilterOption[]}
  */
 function createAlphabetizedListOfPoetsFromIds(poetIds, data) {
-  /** @type {IdNameTuple[]} */
-  const tuples = Array
+  return Array
     .from(poetIds)
-    .map(poetId => [poetId, getPoet(data, poetId).poetDetailName]);
-  return tuples.sort((a, b) => sortAlphabetically(a[1], b[1]));
+    .map(poetId => ({ id: poetId, name: getPoet(data, poetId).poetDetailName }))
+    .sort((a, b) => sortAlphabetically(a.name, b.name));
 }
 
 /** @param {Data} data */
@@ -228,18 +227,18 @@ function createGeoImaginaryPoets(data) {
 
   // put sappho / alcaeus at end of array
   const sappAlcPoetId = 157;
-  putPoetIdAtEndOfPoetIdNameTuples(data.geoImaginaryPoets, sappAlcPoetId);
+  putPoetIdAtEnd(data.geoImaginaryPoets, sappAlcPoetId);
 }
 
 /**
- * @param {IdNameTuple[]} array mutated in place
+ * @param {FilterOption[]} array mutated in place
  * @param {number} poetId
  */
-function putPoetIdAtEndOfPoetIdNameTuples(array, poetId) {
+function putPoetIdAtEnd(array, poetId) {
   /** @type {number | undefined} */
   let foundIdx;
   for (let idx = 0; idx < array.length; idx++) {
-    if (array[idx][0] === poetId) {
+    if (array[idx].id === poetId) {
       foundIdx = idx;
       break;
     }
@@ -272,11 +271,10 @@ function createTravelCities(data) {
   const cityIds = new Set(
     data.lines.flatMap(line => [line.bornCityId, line.activeCityId])
   );
-  /** @type {IdNameTuple[]} */
-  const tuples = Array
+  data.travelCities = Array
     .from(cityIds)
-    .map(cityId => [cityId, getCity(data, cityId).cityname]);
-  data.travelCities = tuples.sort((a, b) => sortAlphabetically(a[1], b[1]));
+    .map(cityId => ({ id: cityId, name: getCity(data, cityId).cityname }))
+    .sort((a, b) => sortAlphabetically(a.name, b.name));
 }
 
 /** @param {Data} data */
@@ -296,11 +294,10 @@ function createRegionsForInterface(data) {
     20, // Thrace
     28 // Troad
   ];
-  /** @type {IdNameTuple[]} */
-  const tuples = data.regions
+  data.regionsForInterface = data.regions
     .filter(region => !regionIdsToOmit.includes(region.regionId))
-    .map(region => [region.regionId, region.regionname]);
-  data.regionsForInterface = tuples.sort((a, b) => sortAlphabetically(a[1], b[1]));
+    .map(region => ({ id: region.regionId, name: region.regionname }))
+    .sort((a, b) => sortAlphabetically(a.name, b.name));
 }
 
 /**
@@ -330,7 +327,7 @@ function createLines(data) {
     if (poet.bornPcs.length === 0 || poet.activePcs.length === 0) {
       const poet = getPoet(data, poetId);
       const poetDetailName = poet.poetDetailName
-      data.poetsWithUnknownTravel.push([poetId, poetDetailName]);
+      data.poetsWithUnknownTravel.push({ id: poetId, name: poetDetailName });
     } else {
       for (const bornPc of poet.bornPcs) {
         for (const activePc of poet.activePcs) {
@@ -371,7 +368,7 @@ function createLines(data) {
       }
     }
   }
-  data.poetsWithUnknownTravel.sort((a, b) => sortAlphabetically(a[1], b[1]));
+  data.poetsWithUnknownTravel.sort((a, b) => sortAlphabetically(a.name, b.name));
 }
 
 /**
@@ -420,14 +417,12 @@ function keyLines(data) {
 /** @param {Data} data */
 function createGenreIdsWithNames(data) {
   const genresToOmit = [
-    "1", // Diaskeue
-    "31" // Possibly lyric
+    1, // Diaskeue
+    31 // Possibly lyric
   ]
-  /** @type {[string, string][]} */
-  const tuples = Object
+  data.genreIdsWithName = Object
     .keys(data.genresByGenreId)
-    .map((id) => [id, data.genresByGenreId[Number(id)]]);
-  data.genreIdsWithName = tuples
-    .filter(kv => !genresToOmit.includes(kv[0]))
-    .sort((a, b) => sortAlphabetically(a[1], b[1]));
+    .map(id => ({ id: Number(id), name: data.genresByGenreId[Number(id)] }))
+    .filter(genre => !genresToOmit.includes(genre.id))
+    .sort((a, b) => sortAlphabetically(a.name, b.name));
 }

--- a/js/calcData/getters.js
+++ b/js/calcData/getters.js
@@ -44,14 +44,12 @@ export function getGovs(data, cityId) {
 }
 
 /** The filters the places and geographical imaginary control bars offer. */
-export const PLACES_FILTER_TYPES = /** @type {PlacesFilterType[]} */ ([
-  "all", "relationship", "poet", "genre"
-]);
+/** @type {PlacesFilterType[]} */
+export const PLACES_FILTER_TYPES = ["all", "relationship", "poet", "genre"];
 
 /** The filters the travel control bar offers. */
-export const TRAVEL_FILTER_TYPES = /** @type {TravelFilterType[]} */ ([
-  "all", "poet", "destination", "smallregion", "region", "gov"
-]);
+/** @type {TravelFilterType[]} */
+export const TRAVEL_FILTER_TYPES = ["all", "poet", "destination", "smallregion", "region", "gov"];
 
 /**
  * Splits state.selectedId (e.g. "poet_93") into its filter type and numeric id,

--- a/js/interface/commonInterface.js
+++ b/js/interface/commonInterface.js
@@ -8,13 +8,13 @@
 // Which prefixes each map is allowed to emit is checked by the control bar tests.
 
 /**
- * Builds one control-bar radio button from an [id, label] pair.
- * @param {[number | string, string]} tuple
+ * Builds one control-bar radio button from a filter option.
+ * @param {FilterOption} option
  * @param {MapFilterType} prefix
  * @returns {string}
  */
-export function createInputFromTuple(tuple, prefix) {
-  return createFilterInput(prefix, tuple[0], tuple[1]);
+export function createInputFromOption(option, prefix) {
+  return createFilterInput(prefix, option.id, option.name);
 }
 
 /**

--- a/js/interface/geoImaginaryInterface.js
+++ b/js/interface/geoImaginaryInterface.js
@@ -1,4 +1,4 @@
-import { createFilterInput, createInputFromTuple } from "./commonInterface.js";
+import { createFilterInput, createInputFromOption } from "./commonInterface.js";
 
 /**
  * The control bar for the geographical-imaginary map.
@@ -22,7 +22,7 @@ export function createGeoImaginaryInterfaceHtml(data) {
         POETIC WORLD OF: 
       </div>
       ${data.geoImaginaryPoets
-      .map(poetIdWithName => createInputFromTuple(poetIdWithName, "poet"))
+      .map(poet => createInputFromOption(poet, "poet"))
       .join("")
     }
     </fieldset>

--- a/js/interface/placesInterface.js
+++ b/js/interface/placesInterface.js
@@ -1,4 +1,4 @@
-import { createFilterInput, createInputFromTuple } from "./commonInterface.js";
+import { createFilterInput, createInputFromOption } from "./commonInterface.js";
 
 /**
  * The control bar for the places map: origin/activity, poets with no known
@@ -24,7 +24,7 @@ export function createPlacesInterfaceHtml(data) {
           POETS WITH UNKNOWN TRAVELS:
         </div>
         ${data.poetsWithUnknownTravel
-      .map(poetIdWithName => createInputFromTuple(poetIdWithName, "poet"))
+      .map(poet => createInputFromOption(poet, "poet"))
       .join("")
     }
       </fieldset>
@@ -36,7 +36,7 @@ export function createPlacesInterfaceHtml(data) {
           GENRE:
         </div>
         ${data.genreIdsWithName
-      .map(genreIdWithName => createInputFromTuple(genreIdWithName, "genre"))
+      .map(genre => createInputFromOption(genre, "genre"))
       .join("")
     }
       </fieldset>

--- a/js/interface/travelInterface.js
+++ b/js/interface/travelInterface.js
@@ -1,6 +1,16 @@
 import { createFilterInput, createInputFromTuple } from "./commonInterface.js";
 import { TRAVEL_RED, TRAVEL_PURPLE, TRAVEL_YELLOW } from "../constants/colors.js";
 
+/** The regimes offered by the political system filter, in display order. */
+/** @type {[number, string][]} */
+const GOVERNMENTS = [
+  [3, "Democracy"],
+  [4, "Kingship"],
+  [7, "Mixed"],
+  [1, "Oligarchy"],
+  [2, "Tyranny"]
+];
+
 /**
  * The control bar for the travel map: poet, city, region, small region and
  * political system.
@@ -75,13 +85,7 @@ export function createTravelInterfaceHtml(data) {
       POLITICAL SYSTEM 
       (<span style="color:${TRAVEL_RED};">to</span>/<span style="color:${TRAVEL_PURPLE};">from</span>/<span style="color:${TRAVEL_YELLOW};">within</span>):
     </div>
-    ${/** @type {[number, string][]} */ ([
-      [3, "Democracy"],
-      [4, "Kingship"],
-      [7, "Mixed"],
-      [1, "Oligarchy"],
-      [2, "Tyranny"]
-    ]).map(tuple => createInputFromTuple(tuple, "gov")).join("")}
+    ${GOVERNMENTS.map(tuple => createInputFromTuple(tuple, "gov")).join("")}
     <div class="picker-label" style="cursor: auto">[Mapping in Progress]</label>		
   </fieldset>
 </div>

--- a/js/interface/travelInterface.js
+++ b/js/interface/travelInterface.js
@@ -1,14 +1,14 @@
-import { createFilterInput, createInputFromTuple } from "./commonInterface.js";
+import { createFilterInput, createInputFromOption } from "./commonInterface.js";
 import { TRAVEL_RED, TRAVEL_PURPLE, TRAVEL_YELLOW } from "../constants/colors.js";
 
 /** The regimes offered by the political system filter, in display order. */
-/** @type {[number, string][]} */
+/** @type {FilterOption[]} */
 const GOVERNMENTS = [
-  [3, "Democracy"],
-  [4, "Kingship"],
-  [7, "Mixed"],
-  [1, "Oligarchy"],
-  [2, "Tyranny"]
+  { id: 3, name: "Democracy" },
+  { id: 4, name: "Kingship" },
+  { id: 7, name: "Mixed" },
+  { id: 1, name: "Oligarchy" },
+  { id: 2, name: "Tyranny" }
 ];
 
 /**
@@ -34,7 +34,7 @@ export function createTravelInterfaceHtml(data) {
         POET: 
       </div>
       ${data.travelPoets
-      .map(poetIdWithName => createInputFromTuple(poetIdWithName, "poet"))
+      .map(poet => createInputFromOption(poet, "poet"))
       .join("")
     }
     </fieldset>
@@ -47,7 +47,7 @@ export function createTravelInterfaceHtml(data) {
       (<span style="color:${TRAVEL_RED};">to</span>/<span style="color:${TRAVEL_PURPLE};">from</span>):
     </div>
     ${data.travelCities
-      .map(cityIdWithName => createInputFromTuple(cityIdWithName, "destination"))
+      .map(city => createInputFromOption(city, "destination"))
       .join("")
     }
   </fieldset>
@@ -60,7 +60,7 @@ export function createTravelInterfaceHtml(data) {
       (<span style="color:${TRAVEL_RED};">to</span>/<span style="color:${TRAVEL_PURPLE};">from</span>):
     </div>
     ${data.bigRegions
-      .map(region => createInputFromTuple([region.regionId, region.regionname], "region"))
+      .map(region => createInputFromOption({ id: region.regionId, name: region.regionname }, "region"))
       .join("")
     }
   </fieldset>
@@ -73,7 +73,7 @@ export function createTravelInterfaceHtml(data) {
       (<span style="color:${TRAVEL_RED};">to</span>/<span style="color:${TRAVEL_PURPLE};">from</span>):
     </div>
     ${data.regionsForInterface
-      .map(regionTuple => createInputFromTuple(regionTuple, "smallregion"))
+      .map(region => createInputFromOption(region, "smallregion"))
       .join("")
     }
   </fieldset>
@@ -85,7 +85,7 @@ export function createTravelInterfaceHtml(data) {
       POLITICAL SYSTEM 
       (<span style="color:${TRAVEL_RED};">to</span>/<span style="color:${TRAVEL_PURPLE};">from</span>/<span style="color:${TRAVEL_YELLOW};">within</span>):
     </div>
-    ${GOVERNMENTS.map(tuple => createInputFromTuple(tuple, "gov")).join("")}
+    ${GOVERNMENTS.map(government => createInputFromOption(government, "gov")).join("")}
     <div class="picker-label" style="cursor: auto">[Mapping in Progress]</label>		
   </fieldset>
 </div>

--- a/tests/data-integrity.test.js
+++ b/tests/data-integrity.test.js
@@ -24,6 +24,14 @@ const regionIds = new Set(raw.regions.map(r => id(r.regionId)));
 const bigRegionIds = new Set(raw.bigRegions.map(r => id(r.regionId)));
 const cityNameById = new Map(raw.cities.map(c => [id(c.cityId), c.cityname]));
 
+/** The join tables that carry a cityname label. */
+/** @type {PoetCityCsv[]} */
+const POET_CITY_CSVS = ["poetCities", "geopoetCities"];
+
+/** The cited tables with no known incomplete citations. */
+/** @type {CitedCsv[]} */
+const CLEAN_CITED_CSVS = ["geopoetCities", "genres"];
+
 // ---------------------------------------------------------------------------
 // Exceptions for data that is currently broken. See "known data bugs" at the
 // bottom of this file for what each one actually is.
@@ -105,7 +113,9 @@ const WORLD_BOUNDS = { minLat: 5, maxLat: 50, minLong: -10, maxLong: 55 };
 // ---------------------------------------------------------------------------
 
 describe("primary keys", () => {
-  for (const [file, key] of /** @type {[keyof RawCsvs, string][]} */ ([["cities", "cityId"], ["poets", "poetId"], ["governments", "governmentId"]])) {
+  /** @type {[keyof RawCsvs, string][]} */
+  const KEYED_FILES = [["cities", "cityId"], ["poets", "poetId"], ["governments", "governmentId"]];
+  for (const [file, key] of KEYED_FILES) {
     test(`${file}.csv has unique ${key}`, () => {
       const seen = new Map();
       for (const row of raw[file]) {
@@ -195,7 +205,7 @@ describe("labels agree with the ids they point at", () => {
   // A row labelled with one place but pointing at another's id draws the
   // reference in the wrong location, which is invisible without this check.
   test("no NEW cityname disagrees with the city it references", () => {
-    for (const file of /** @type {PoetCityCsv[]} */ (["poetCities", "geopoetCities"])) {
+    for (const file of POET_CITY_CSVS) {
       for (const row of raw[file]) {
         const cityId = id(row.cityId);
         if (!filled(row.cityname) || !cityNameById.has(cityId)) continue;
@@ -575,7 +585,7 @@ describe("known data bugs: incomplete or inconsistent fields", () => {
     assert.equal(incomplete.length, KNOWN_INCOMPLETE_CITATION_COUNT);
     // renderReference() prints `Citation: X: "" (trans. )` for these. This is
     // the shape of issues #313 and #329. geopoetCities and genres are clean.
-    for (const file of /** @type {CitedCsv[]} */ (["geopoetCities", "genres"])) {
+    for (const file of CLEAN_CITED_CSVS) {
       const bad = raw[file].filter(row =>
         filled(row.source_citation) &&
         !(filled(row.source_translation) && filled(row.source_translator)));

--- a/tests/initializeData.test.js
+++ b/tests/initializeData.test.js
@@ -62,11 +62,13 @@ describe("hydration", () => {
   });
 
   test("every lookup table is populated", () => {
-    for (const key of /** @type {(keyof Data)[]} */ ([
+    /** @type {(keyof Data)[]} */
+    const LOOKUP_TABLES = [
       "citiesById", "poetsById", "regionsById", "genresByPoetId", "genresByGenreId",
       "govsByCityId", "govsById", "datesByPoetId",
       "linesByPoetId", "linesByBornCityId", "linesByActiveCityId"
-    ])) {
+    ];
+    for (const key of LOOKUP_TABLES) {
       assert.ok(Object.keys(data[key]).length > 0, `${key} is empty`);
     }
   });
@@ -228,10 +230,12 @@ describe("known bugs: derived travel lines", () => {
     // so the map draws the foreign-origin traditions and silently drops the
     // native one. This is the travel-map half of issue #332, and it is worse
     // than the popup wording: the omission cannot be seen at all.
-    for (const [name, invisible, drawn] of /** @type {[string, string, string[]][]} */ ([
+    /** @type {[string, string, string[]][]} */
+    const CASES = [
       ["Alcman", "Sparta", ["Sardis"]],
       ["Corinna", "Thebes", ["Tanagra"]]
-    ])) {
+    ];
+    for (const [name, invisible, drawn] of CASES) {
       const lines = data.linesByPoetId[poetIdByName(name)];
       const visible = lines.filter((l) => l.bornCityId !== l.activeCityId);
       assert.deepEqual(visible.map((l) => l.bornCity.cityname).sort(), drawn,

--- a/tests/initializeData.test.js
+++ b/tests/initializeData.test.js
@@ -133,7 +133,7 @@ describe("travel lines", () => {
   test("poets with a birthplace but nowhere to go are listed as unknown travel", () => {
     assert.ok(data.poetsWithUnknownTravel.length > 0);
     const travelling = new Set(data.lines.map((l) => l.poetId));
-    for (const [poetId] of data.poetsWithUnknownTravel) {
+    for (const { id: poetId } of data.poetsWithUnknownTravel) {
       assert.ok(!travelling.has(poetId), `poetId ${poetId} both travels and has unknown travel`);
     }
   });
@@ -152,14 +152,14 @@ describe("control bar contents", () => {
   test("Pindar and Bacchylides are excluded from the geographical imaginary", () => {
     // Their geographical imaginary is a pilot of one poem each (Olympian 1 and
     // Ode 17), so they are deliberately kept out of the poet list. See issue #326.
-    const names = data.geoImaginaryPoets.map((t) => t[1]);
+    const names = data.geoImaginaryPoets.map(poet => poet.name);
     assert.ok(!names.includes("Pindar"));
     assert.ok(!names.includes("Bacchylides"));
   });
 
   test("Sappho or Alcaeus sorts last, after the individually named poets", () => {
     const last = data.geoImaginaryPoets[data.geoImaginaryPoets.length - 1];
-    assert.match(last[1], /Sappho/);
+    assert.match(last.name, /Sappho/);
   });
 
   test("every control bar list is sorted and non-empty", () => {
@@ -167,23 +167,23 @@ describe("control bar contents", () => {
       (["travelPoets", "travelCities", "poetsWithUnknownTravel", "regionsForInterface"])) {
       const list = data[key];
       assert.ok(list.length > 0, `${key} is empty`);
-      const names = list.map((t) => t[1]);
+      const names = list.map(option => option.name);
       assert.deepEqual(names, [...names].sort(sortAlphabetically), `${key} is not sorted`);
     }
   });
 
   test("the geographical imaginary poets are sorted apart from Sappho/Alcaeus at the end", () => {
-    const names = data.geoImaginaryPoets.map((t) => t[1]);
+    const names = data.geoImaginaryPoets.map(poet => poet.name);
     assert.ok(names.length > 0);
     const allButLast = names.slice(0, -1);
     assert.deepEqual(allButLast, [...allButLast].sort(sortAlphabetically));
   });
 
   test("every control bar entry points at something real", () => {
-    for (const [poetId] of [...data.travelPoets, ...data.geoImaginaryPoets, ...data.poetsWithUnknownTravel]) {
+    for (const { id: poetId } of [...data.travelPoets, ...data.geoImaginaryPoets, ...data.poetsWithUnknownTravel]) {
       assert.ok(data.poetsById[poetId], `control bar offers unknown poetId ${poetId}`);
     }
-    for (const [cityId] of data.travelCities) {
+    for (const { id: cityId } of data.travelCities) {
       assert.ok(data.citiesById[cityId], `control bar offers unknown cityId ${cityId}`);
     }
   });

--- a/tests/popups.test.js
+++ b/tests/popups.test.js
@@ -179,11 +179,13 @@ describe("travel map", () => {
 
 describe("popup html is well formed enough to render", () => {
   test("no popup leaks 'undefined' or 'NaN' into the page", () => {
-    for (const [mode, selectedId] of /** @type {[State["currentMapMode"], string][]} */ ([
+    /** @type {[State["currentMapMode"], string][]} */
+    const VIEWS = [
       ["placesMode", "relationship_1"],
       ["placesMode", "relationship_3"],
       ["geoimaginaryMode", "all_1"]
-    ])) {
+    ];
+    for (const [mode, selectedId] of VIEWS) {
       for (const bubble of Object.values(bubblesFor(mode, selectedId))) {
         const html = popupOf(bubble);
         const cityname = bubble.city.cityname;

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -211,8 +211,19 @@ interface GeoPoetCity extends PoetPrimed {
 // Derived structures, built at runtime.
 // ---------------------------------------------------------------------------
 
-/** A [id, displayName] pair used to build the radio buttons in the control bar. */
-type IdNameTuple = [number, string];
+/**
+ * One option in the control bar: the id it filters by, and the label shown.
+ *
+ * An object rather than an [id, name] tuple. TypeScript widens an array literal
+ * to `(number | string)[]` unless it is given a contextual tuple type, so every
+ * place that built one needed an annotation to say so — and a tuple of two
+ * same-typed values could still be filled in the wrong order silently. Named
+ * fields infer correctly on their own and cannot be transposed.
+ */
+interface FilterOption {
+  id: number;
+  name: string;
+}
 
 /**
  * The filter kinds encoded in the first half of State.selectedId, e.g. the
@@ -352,10 +363,10 @@ interface Data {
   linesByActiveCityId: Record<number, Line[]>;
 
   // control-bar contents
-  genreIdsWithName: [string, string][];
-  geoImaginaryPoets: IdNameTuple[];
-  travelPoets: IdNameTuple[];
-  travelCities: IdNameTuple[];
-  poetsWithUnknownTravel: IdNameTuple[];
-  regionsForInterface: IdNameTuple[];
+  genreIdsWithName: FilterOption[];
+  geoImaginaryPoets: FilterOption[];
+  travelPoets: FilterOption[];
+  travelCities: FilterOption[];
+  poetsWithUnknownTravel: FilterOption[];
+  regionsForInterface: FilterOption[];
 }


### PR DESCRIPTION
Follow-up to #335. **No behaviour change** — this only changes how the types are written, so that TypeScript actually checks them.

## The problem

Thirteen places wrote a type in the parenthesised JSDoc form:

```js
for (const file of /** @type {PoetCityCsv[]} */ (["poetCities", "geopoetCities"])) {
```

That is a type **assertion**, not an annotation. TypeScript allows it because the target is a subtype of the inferred `string[]`, and then checks nothing inside the literal. The declaration form *is* checked:

```js
/** @type {PoetCityCsv[]} */
const POET_CITY_CSVS = ["poetCities", "geopoetCities"];
```

Same typo in both forms, only one is reported:

```
demo.js(8,30): error TS2820: Type '"geopoetCitiez"' is not assignable to type 'PoetCityCsv'.
                             Did you mean '"geopoetCities"'?
```

## What changed

All thirteen converted. Where the literal was inline it is hoisted to a named const, which reads better anyway — `travelInterface.js` gains a `GOVERNMENTS` table, `data-integrity.test.js` a `POET_CITY_CSVS` and `CLEAN_CITED_CSVS`.

Four were inside `.map()` callbacks, where hoisting doesn't apply. Those annotate the result array instead, so the expected element type flows into the callback and the tuple is checked on the way out:

```js
/** @type {IdNameTuple[]} */
const tuples = Array.from(poetIds).map(poetId => [poetId, getPoet(data, poetId).poetDetailName]);
```

## Why it mattered

The two most consequential were `PLACES_FILTER_TYPES` and `TRAVEL_FILTER_TYPES` in `getters.js` — the arrays `getPlacesFilter()` and `getTravelFilter()` validate against. A misspelling there would have compiled and then **rejected a legitimate filter at runtime**, alerting the user on a click that should have worked. Exactly the failure #335 set out to make impossible.

## Verification

Three errors introduced in a scratch copy, **all of which compiled cleanly before this PR**:

| introduced | now caught |
|---|---|
| `"realtionship"` in `PLACES_FILTER_TYPES` | `TS2820 … Did you mean '"relationship"'?` |
| `"geopoetCitiez"` in a test's table list | `TS2820 … Did you mean '"geopoetCities"'?` |
| `IdNameTuple` built in reverse order | `TS2322: Type '[string, number][]' is not assignable to type 'IdNameTuple[]'` |

- `tsc` exits 0
- 82 tests pass
- map renders with every mode and filter: places 204 bubbles, travel 697 arcs, political system 182 with all five regime buttons present, region 191, geographical imaginary 336 — no console errors