### PR TITLE
Add linting to CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,10 +1,15 @@
 name: check
 
-# Runs the tests, then typechecks both the site source and the tests.
+# Runs the tests, lints, then typechecks both the site source and the tests.
 #
-# Nothing is bundled or compiled. The tests run with no install at all; the
-# typecheck needs @types/node, which is the project's only dependency and is
-# type declarations rather than code.
+# Nothing is bundled or compiled. The tests and the linter run with no install
+# at all; the typecheck needs @types/node, the project's only dependency, which
+# is type declarations rather than code.
+#
+# Most of what a linter would tell us comes from the typechecker instead —
+# jsconfig.json turns on noUnusedLocals, noUnusedParameters, noImplicitReturns
+# and noFallthroughCasesInSwitch. oxlint covers the few things a typechecker
+# cannot see, such as == versus ===.
 
 on:
   push:
@@ -28,6 +33,9 @@ jobs:
       # needs nothing but Node.
       - name: Tests
         run: node --test tests/*.test.js
+
+      - name: Lint
+        run: npm run lint
 
       - name: Install type declarations
         run: npm ci

--- a/js/interface/interface.js
+++ b/js/interface/interface.js
@@ -13,7 +13,7 @@ import { assertUnreachable } from "../assertUnreachable.js";
 export function addPoetsEventListener(map, data, state) {
   /** @type {HTMLElement} */ (document.querySelector('#poetsSelector')).addEventListener('click', () => {
     const currentSelected = /** @type {HTMLInputElement} */ (document.querySelector('div.buttonContainer input:checked')).id;
-    if (state.selectedId != currentSelected) {
+    if (state.selectedId !== currentSelected) {
       state.selectedId = currentSelected;
       updateMap(map, data, state);
     }
@@ -29,7 +29,7 @@ export function addPoetsEventListener(map, data, state) {
 export function addMapModeEventListener(map, data, state) {
   /** @type {HTMLElement} */ (document.querySelector('#mapModeSelector')).addEventListener('click', () => {
     const currentSelected = /** @type {HTMLInputElement} */ (document.querySelector('fieldset input:checked')).id;
-    if (state.currentMapMode != currentSelected) {
+    if (state.currentMapMode !== currentSelected) {
       state.currentMapMode = /** @type {State["currentMapMode"]} */ (currentSelected);
       updateMapMode(map, data, state);
     }

--- a/js/popups/popups.js
+++ b/js/popups/popups.js
@@ -1,5 +1,6 @@
 import { LYRIC_GREY, LYRIC_RED } from "../constants/colors.js";
 import { getPlacesFilter } from "../calcData/getters.js";
+import { assertUnreachable } from "../assertUnreachable.js";
 import { createNumberedListOfPoets, createDetailedListOfPoets, renderReference } from "./popupsCommon.js";
 
 /**
@@ -8,29 +9,33 @@ import { createNumberedListOfPoets, createDetailedListOfPoets, renderReference }
  * @param {State} state
  * @param {Data} data
  * @param {Bubble} bubble
- * @returns {string | undefined}
+ * @returns {string}
  */
 export function createPopupHtml(state, data, bubble) {
   const [type, num] = getPlacesFilter(state);
-  if (state.currentMapMode === "placesMode") {
-    if (type === "relationship" && num === 3) {
-      return createActivePopupHtml(state, data, bubble);
-    } else {
-      return createPlacesPopupHtml(state, data, bubble);
-    }
-  } else if (state.currentMapMode === "geoimaginaryMode") {
-    return createGeoImaginaryPopupHtml(state, data, bubble);
+  switch (state.currentMapMode) {
+    case "placesMode":
+      // Relationship 3 is "activity", which gets its own native/non-native split.
+      return type === "relationship" && num === 3
+        ? createActivePopupHtml(data, bubble)
+        : createPlacesPopupHtml(state, data, bubble);
+    case "geoimaginaryMode":
+      return createGeoImaginaryPopupHtml(state, data, bubble);
+    case "travelMode":
+      // The travel map draws arcs and builds its popups in travelPopups.js.
+      throw new Error("createPopupHtml is not used by the travel map");
+    default:
+      return assertUnreachable(state.currentMapMode, "unrecognized map mode");
   }
 }
 
 /**
  * The ACTIVITY popup, which splits a city's poets into natives and incomers.
- * @param {State} state
  * @param {Data} data
  * @param {Bubble} bubble
  * @returns {string}
  */
-function createActivePopupHtml(state, data, bubble) {
+function createActivePopupHtml(data, bubble) {
   const cityname = bubble.city.infowindowName.toUpperCase();
   const poetCities = bubble.poetCities;
   /** @type {RenderedPoetCity[]} */
@@ -114,10 +119,9 @@ function createPlacesPopupHtml(state, data, bubble) {
 
 /**
  * @param {GeoBubblePoet[]} poets
- * @param {Data} data
  * @returns {string}
  */
-function createGeoHeaderListOfPoets(poets, data) {
+function createGeoHeaderListOfPoets(poets) {
   return (`
     <p>
     ${poets.map((poet, idx) => {
@@ -131,10 +135,9 @@ function createGeoHeaderListOfPoets(poets, data) {
 
 /**
  * @param {GeoBubblePoet[]} poets
- * @param {Data} data
  * @returns {string}
  */
-function createDetailedGeoListOfPoets(poets, data) {
+function createDetailedGeoListOfPoets(poets) {
   return (`
     ${poets.map((poet, idx) => {
     return (`
@@ -153,14 +156,20 @@ function createDetailedGeoListOfPoets(poets, data) {
  * @param {Data} data
  * @param {string} cityname already upper-cased
  * @param {Bubble} bubble
- * @returns {string | undefined}
+ * @returns {string}
  */
 function createTitle(state, data, cityname, bubble) {
-  if (state.currentMapMode === "placesMode") {
-    return createPlacesModeTitle(state, data, cityname);
-  } else if (state.currentMapMode === "geoimaginaryMode") {
-    const referenceStr = bubble.poetCities.length === 1 ? "REFERENCE" : "REFERENCES";
-    return `${bubble.poetCities.length} ${referenceStr} TO ${cityname}`
+  switch (state.currentMapMode) {
+    case "placesMode":
+      return createPlacesModeTitle(state, data, cityname);
+    case "geoimaginaryMode": {
+      const referenceStr = bubble.poetCities.length === 1 ? "REFERENCE" : "REFERENCES";
+      return `${bubble.poetCities.length} ${referenceStr} TO ${cityname}`;
+    }
+    case "travelMode":
+      throw new Error("createTitle is not used by the travel map");
+    default:
+      return assertUnreachable(state.currentMapMode, "unrecognized map mode");
   }
 }
 
@@ -168,17 +177,27 @@ function createTitle(state, data, cityname, bubble) {
  * @param {State} state
  * @param {Data} data
  * @param {string} cityname already upper-cased
- * @returns {string | undefined}
+ * @returns {string}
  */
 function createPlacesModeTitle(state, data, cityname) {
   const [type, num] = getPlacesFilter(state);
-  if (type === "relationship" && num === 1) {
-    return `POETS BORN IN ${cityname}`;
-  } else if (type === "poet") {
-    return `POET ACTIVE IN ${cityname}`;
-  } else if (type === "genre") {
-    const genrename = data.genresByGenreId[num].toUpperCase();
-    return `POET BORN IN ${cityname} AND ASSOCIATED WITH ${genrename}`
+  switch (type) {
+    case "relationship":
+      // Relationship 3 is "activity", which never reaches here: it is handled
+      // by createActivePopupHtml, which writes its own headings.
+      return `POETS BORN IN ${cityname}`;
+    case "poet":
+      return `POET ACTIVE IN ${cityname}`;
+    case "genre": {
+      const genrename = data.genresByGenreId[num].toUpperCase();
+      return `POET BORN IN ${cityname} AND ASSOCIATED WITH ${genrename}`;
+    }
+    case "all":
+      // Offered by the geographical imaginary control bar, which titles its
+      // popups in createTitle rather than here.
+      throw new Error("the places map has no ALL filter");
+    default:
+      return assertUnreachable(type, "unrecognized places filter");
   }
 }
 
@@ -193,8 +212,8 @@ function createGeoImaginaryPopupHtml(state, data, bubble) {
   const poets = /** @type {GeoBubblePoet[]} */ (bubble.poets);
   return (`
     ${createHeader(state, data, bubble)}
-    ${createGeoHeaderListOfPoets(poets, data)}
+    ${createGeoHeaderListOfPoets(poets)}
     <h4 style="color:${LYRIC_GREY}">DETAILS</h4>
-    ${createDetailedGeoListOfPoets(poets, data)}
+    ${createDetailedGeoListOfPoets(poets)}
   `);
 }

--- a/js/renderMap/lines.js
+++ b/js/renderMap/lines.js
@@ -75,7 +75,7 @@ function hashCityIds(from, to) {
  * @returns {Record<number, DrawnLine>}
  */
 function calculateLines(state, data, filteredPoetLines) {
-  const [type, num] = getTravelFilter(state);
+  const [type] = getTravelFilter(state);
 
   /** @type {Record<number, DrawnLine>} */
   const lines = {}
@@ -91,7 +91,7 @@ function calculateLines(state, data, filteredPoetLines) {
       lines[hash].name = (`${line.bornCity.infowindowName} -> ${line.activeCity.infowindowName}`).toUpperCase();
     }
     lines[hash].poetLines.push(line);
-    colorLine(state, data, lines[hash]);
+    colorLine(state, lines[hash]);
     if (line.dotted) lines[hash].dotted = true;
   }
   for (const hash in lines) {
@@ -112,7 +112,7 @@ function calculateLines(state, data, filteredPoetLines) {
  * @param {DrawnLine} line mutated in place
  */
 function weightLine(state, line) {
-  const [type, num] = getTravelFilter(state);
+  const [type] = getTravelFilter(state);
   const poetsNum = line.poetLines.length;
   let multiplier = 1;
   let increment = 0;
@@ -127,10 +127,9 @@ function weightLine(state, line) {
  * Recolours an arc when it leaves (purple) or stays within (yellow) whatever is
  * currently selected. Default is red.
  * @param {State} state
- * @param {Data} data
  * @param {DrawnLine} line mutated in place
  */
-function colorLine(state, data, line) {
+function colorLine(state, line) {
   const [type, num] = getTravelFilter(state);
   // default color is red
   if (type === "destination") {

--- a/js/renderMap/updateMap.js
+++ b/js/renderMap/updateMap.js
@@ -26,8 +26,8 @@ export function updateMap(map, data, state) {
     default:
       assertUnreachable(state.currentMapMode, "unrecognized map mode");
   }
-  // uncomment following line to run accessibility checks while playing with the map
-  // runAxe();
+  // axe-core is loaded globally by index.html, so accessibility can be checked
+  // from the devtools console at any point: await axe.run()
 }
 
 /** @param {LyricMap} map */
@@ -35,18 +35,4 @@ function clearMap(map) {
   map.bubbleLayerGroup.clearLayers();
   map.legendLayerGroup.clearLayers();
   map.lineLayerGroup.clearLayers();
-}
-
-// Dev helper: see the commented-out call in updateMap above.
-function runAxe() {
-  axe
-    .run()
-    .then((/** @type {any} */ results) => {
-      if (results.violations.length) {
-        throw new Error('Accessibility issues found');
-      }
-    })
-    .catch((/** @type {any} */ err) => {
-      console.error('Something bad happened:', err.message);
-    });
 }

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -11,7 +11,11 @@
       "DOM",
       "DOM.Iterable"
     ],
-    "allowJs": true
+    "allowJs": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
   },
   "include": [
     "index.js",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "description": "No build. This file exists so Node treats the .js files as the ES modules they already are, and to pin @types/node so the tests can be typechecked. The only dependency is type declarations; nothing is bundled or compiled, and the site is still plain files served as-is.",
   "scripts": {
     "test": "node --test tests/*.test.js",
+    "lint": "npx -y oxlint@1 --deny-warnings -A all -D correctness -D eqeqeq -D no-var -D prefer-const -D no-self-compare -D no-template-curly-in-string js/ tests/ index.js",
     "typecheck": "npx -y -p typescript@5 tsc -p jsconfig.json"
   },
   "devDependencies": {


### PR DESCRIPTION
Two layers, because most of what a linter would report here the **typechecker can report better, and for free**.

```sh
npm run lint       # oxlint, no install
npm run typecheck  # now with four lint-like flags
```

## Layer 1: typechecker flags — no new dependency

`jsconfig.json` gains `noUnusedLocals`, `noUnusedParameters`, `noImplicitReturns` and `noFallthroughCasesInSwitch`. No new tool, no new config file, nothing to rot.

On this codebase it found **ten** things — including three `noImplicitReturns` that **no lint rule can see without type information**, and two unused parameters a linter misses because ESLint's default `args: after-used` only reports parameters after the last used one.

For comparison, oxlint's default `correctness` category found **five**, all of which were a subset of these ten.

## Layer 2: oxlint — for what a typechecker cannot see

A single Rust binary fetched by `npx`, exactly as TypeScript already is, so it adds **nothing to `node_modules`** and the test suite still runs with no install at all.

The rule set is opted into explicitly rather than taking a preset:

```
-A all -D correctness -D eqeqeq -D no-var -D prefer-const
       -D no-self-compare -D no-template-curly-in-string
```

That is deliberate. Run with every category on, oxlint reports **hundreds** of things on this repo — kebab-case filenames, magic numbers, comment capitalisation, `sort-keys`, `func-style` — none of which are bugs, and several of which would mean renaming every file in `js/`.

## The ten findings, fixed

**Three functions fell off the end** and returned `undefined` for a mode or filter that never reaches them — `createPopupHtml`, `createTitle`, `createPlacesModeTitle`. Now switches that name the impossible case and throw, or end in `assertUnreachable`. Their return types drop `| undefined`.

**Four unused parameters** — `createActivePopupHtml` took a `State` it never read, `colorLine` a `Data` it never read, and the two geographical-imaginary list builders a `Data` they never read.

**Two unused locals** — `calculateLines` and `weightLine` destructured a `num` they never used.

**One dead function** — `runAxe` had been dead since its only call site was commented out. Removed, with a note that axe-core is loaded globally so `await axe.run()` works from the devtools console.

Plus the two `!=` in `interface.js`, now `!==`.

## Verified both ways

Both checks pass. Both also **fail when the problems are reintroduced** in a scratch copy:

```
js/interface/interface.js:16:26: error eslint(eqeqeq): Expected !== and instead saw !=
js/calcData/getters.js:70:3:    error eslint(no-var): Unexpected var, use let or const instead
lint exit code: 1
```

82 tests pass, and the map was driven through every mode, filter and popup style:

| | |
|---|---|
| activity | 204 bubbles, native/non-native split intact |
| origin | 110, titled `POETS BORN IN MELOS` |
| genre | titled `… ASSOCIATED WITH DITHYRAMB` |
| geographical imaginary | 336, titled `1 REFERENCE TO MELOS` |
| travel | 697 arcs |
| tyranny | 182, still recoloured purple / yellow / red by `colorLine` |