### PR TITLE
Look the genre up once, so the impossible case cannot be written

### DIFF
--- a/js/renderMap/calcPoetCities.js
+++ b/js/renderMap/calcPoetCities.js
@@ -1,4 +1,4 @@
-import { getPlacesFilter } from "../calcData/getters.js";
+import { getGenres, getPlacesFilter } from "../calcData/getters.js";
 import { assertUnreachable } from "../assertUnreachable.js";
 import { getDateFilterFn } from "./calcCommon.js";
 
@@ -13,12 +13,28 @@ import { getDateFilterFn } from "./calcCommon.js";
  * @returns {RenderedPoetCity[]}
  */
 export function calcPoetCities(data, state) {
-  const poetCitiesData = getPoetCitiesData(data, state);
-  const filteredPoetCities = poetCitiesData.filter(getDateFilterFn(data, state)).filter(getFilterFn(data, state));
+  const [type, num] = getPlacesFilter(state);
+  const dated = getPoetCitiesData(data, state).filter(getDateFilterFn(data, state));
 
-  const renderedPoetCities = renderPoetCities(filteredPoetCities, data, state);
+  if (type === "genre") return renderGenreRows(dated, data, num);
 
-  return renderedPoetCities;
+  return dated.filter(getFilterFn(type, num)).map(poetCity => renderPoetCity(poetCity));
+}
+
+/**
+ * Filters and renders together, so the entry that qualifies a row is the one
+ * that supplies its citation.
+ * @param {AnyPoetCity[]} poetCities
+ * @param {Data} data
+ * @param {number} genreId
+ * @returns {RenderedPoetCity[]}
+ */
+function renderGenreRows(poetCities, data, genreId) {
+  return poetCities.flatMap(poetCity => {
+    if (poetCity.relationshipId !== 1) return [];
+    const genre = getGenres(data, poetCity.poetId).find(candidate => candidate.genreId === genreId);
+    return genre ? [renderPoetCity(poetCity, genre)] : [];
+  });
 }
 
 /**
@@ -39,13 +55,13 @@ function getPoetCitiesData(data, state) {
 }
 
 /**
- * Builds the predicate for whichever radio button is currently selected.
- * @param {Data} data
- * @param {State} state
+ * Builds the predicate for the selected radio button. Genre is excluded from
+ * the type because renderGenreRows handles it.
+ * @param {Exclude<PlacesFilterType, "genre">} type
+ * @param {number} num
  * @returns {PoetCityFilter}
  */
-function getFilterFn(data, state) {
-  const [type, num] = getPlacesFilter(state);
+function getFilterFn(type, num) {
   switch (type) {
     case "all":
       return () => true;
@@ -55,69 +71,40 @@ function getFilterFn(data, state) {
       return poetCity => poetCity.relationshipId === num;
     case "poet":
       return poetCity => poetCity.poetId === num;
-    case "genre":
-      return poetCity =>
-        !!data.genresByPoetId[poetCity.poetId] &&
-        data.genresByPoetId[poetCity.poetId].map(genre => genre.genreId).includes(num) &&
-        poetCity.relationshipId === 1;
     default:
-      // Exhaustive over PlacesFilterType: add a member without handling it above
-      // and this stops compiling.
       return assertUnreachable(type, "unrecognized filter when calculating poet cities");
   }
 }
 
 /**
- * Flattens rows to the subset popups need, collapsing the citation columns into
- * a single reference. In genre mode the citation comes from genres.csv instead.
- * @param {AnyPoetCity[]} filteredPoetCities
- * @param {Data} data
- * @param {State} state
- * @returns {RenderedPoetCity[]}
+ * Flattens one row for rendering, collapsing the citation columns into a
+ * single reference.
+ * @param {AnyPoetCity} poetCity
+ * @param {Genre} [genre] supplies the citation instead, in genre mode
+ * @returns {RenderedPoetCity}
  */
-function renderPoetCities(filteredPoetCities, data, state) {
-  const [type, num] = getPlacesFilter(state);
+function renderPoetCity(poetCity, genre) {
+  const source = genre ?? poetCity;
+  /** @type {Reference} */
+  const reference = {
+    source_citation: source.source_citation,
+    source_greektext: source.source_greektext,
+    source_translation: source.source_translation,
+    source_translator: source.source_translator
+  };
+  // Only geographical-imaginary rows carry a source_poem column.
+  if ("source_poem" in poetCity && poetCity.source_poem) reference.source_poem = poetCity.source_poem;
 
-  return filteredPoetCities.map(pc => {
-    /** @type {Reference} */
-    const reference = {
-      source_citation: pc.source_citation,
-      source_greektext: pc.source_greektext,
-      source_translation: pc.source_translation,
-      source_translator: pc.source_translator
-    };
-    if (type === "genre") {
-      const genrePoetCities = data.genresByPoetId[pc.poetId].filter(genre => genre.genreId === num);
-      if (genrePoetCities.length > 1) {
-        console.log(`poet with name ${pc.poetname} and ${pc.poetId} has more than one entry for genreId ${num}`);
-      }
-      if (genrePoetCities.length === 0) {
-        console.log(
-          `poet with name ${pc.poetname} and ${pc.poetId} has no entries for genreId ${num} (though we filtered to this genreId)`
-        );
-      }
-      const genrePoetCity = genrePoetCities[0];
-      reference.source_citation = genrePoetCity.source_citation;
-      reference.source_greektext = genrePoetCity.source_greektext;
-      reference.source_translation = genrePoetCity.source_translation;
-      reference.source_translator = genrePoetCity.source_translator;
-    }
-
-    /** @type {RenderedPoetCity} */
-    const renderedPc = {
-      poetId: pc.poetId,
-      cityId: pc.cityId,
-      cityname: pc.cityname,
-      poetname: pc.poetname,
-      poetDetailName: pc.poetDetailName,
-      poetDates: pc.poetDates,
-      poetGenres: pc.poetGenres,
-      poetSources: pc.poetSources,
-      relationshipId: pc.relationshipId,
-      reference: reference
-    };
-    // Only geographical-imaginary rows carry a source_poem column.
-    if ("source_poem" in pc && pc.source_poem) renderedPc.reference.source_poem = pc.source_poem;
-    return renderedPc;
-  });
+  return {
+    poetId: poetCity.poetId,
+    cityId: poetCity.cityId,
+    cityname: poetCity.cityname,
+    poetname: poetCity.poetname,
+    poetDetailName: poetCity.poetDetailName,
+    poetDates: poetCity.poetDates,
+    poetGenres: poetCity.poetGenres,
+    poetSources: poetCity.poetSources,
+    relationshipId: poetCity.relationshipId,
+    reference: reference
+  };
 }


### PR DESCRIPTION
`renderPoetCities` logged — and then carried straight on into a crash — for a case that could not happen:

```js
if (genrePoetCities.length === 0) {
  console.log(`... has no entries for genreId ${num} (though we filtered to this genreId)`);
}
const genrePoetCity = genrePoetCities[0];   // TypeError, one line later
```

The parenthetical was right. `getFilterFn` had already required the poet to have an entry for that genre, so by the time `renderPoetCities` ran the match was guaranteed.

## Why the branch existed

The lookup happened **twice** — once to decide whether to keep the row, once to find the citation — and nothing tied the two together. So the second one had to defend against a state the first had already ruled out.

Genre mode now selects and renders in one pass:

```js
function renderGenreRows(poetCities, data, genreId) {
  return poetCities.flatMap(poetCity => {
    if (poetCity.relationshipId !== 1) return [];
    const genre = getGenres(data, poetCity.poetId).find(candidate => candidate.genreId === genreId);
    return genre ? [renderPoetCity(poetCity, genre)] : [];
  });
}
```

The entry that qualifies a row is the same one that supplies its citation. **There is no second lookup left to fail** — which is stronger than a check: the branch isn't merely unreachable, it's unwriteable.

## The sibling branch too

The `length > 1` warning is also gone. No poet has more than one entry for the same genre — the data has **zero** such rows — and taking the first was the behaviour either way.

## Two things fell out

`getFilterFn` now takes `Exclude<PlacesFilterType, "genre">` rather than the whole union, so genre cannot reach it and it needs no branch saying so. This is the `Exclude` you asked about a few PRs ago — it fits here, where one case genuinely moves elsewhere, in a way it didn't fit the overlapping places/travel filter sets.

And with the genre case gone it turned out to need no access to `Data` at all — which the typechecker pointed out rather than me noticing.

## Verified identical

Rendered all sixteen genre views before and after, comparing cities and popup lengths:

```
all 16 genre views, city lists and popup lengths
  IDENTICAL before and after the restructure
  genres compared: 16 | total bubbles: 142
```

Plus 82 tests, 23 browser tests, tsc, oxlint and Prettier all pass.