### PR TITLE
Stop leaking a zoom handler per redraw, and fail loudly on a missing data file

### DIFF
--- a/js/calcData/parseCsvs.js
+++ b/js/calcData/parseCsvs.js
@@ -2,7 +2,7 @@
  * @param {string} file raw CSV text
  * @returns {Promise<{ data: any[] }>}
  */
-async function papaParsePromise(file) {
+function papaParsePromise(file) {
   return new Promise(function (complete, error) {
     Papa.parse(file, { header: true, complete, error });
   });
@@ -12,9 +12,9 @@ async function papaParsePromise(file) {
  * Loads every CSV in dataFiles/ onto the shared data bag. Papa Parse yields
  * every field as a string; initializeData() hydrates the numeric ones.
  * @param {Data} data
- * @returns {Promise<any[]>}
+ * @returns {Promise<void[]>}
  */
-export async function parseCsvs(data) {
+export function parseCsvs(data) {
   return Promise.all([
     parseCsv(data, "regions", "./dataFiles/regions.csv"),
     parseCsv(data, "cities", "./dataFiles/cities.csv"),
@@ -33,10 +33,18 @@ export async function parseCsvs(data) {
  * @param {Data} data
  * @param {keyof Data} parameter which key on the data bag to populate
  * @param {string} filename
+ * @returns {Promise<void>}
  */
 async function parseCsv(data, parameter, filename) {
-  return fetch(filename)
-    .then(file => file.text())
-    .then(fileText => papaParsePromise(fileText))
-    .then(papaParsed => (data[parameter] = papaParsed.data));
+  const response = await fetch(filename);
+  // fetch resolves for a 404, so without this the error page is parsed as CSV
+  // and the map draws nothing, with no indication why.
+  if (!response.ok) {
+    const message = `could not load ${filename}: ${response.status} ${response.statusText}`;
+    alert(message);
+    throw new Error(message);
+  }
+  const csv = await response.text();
+  const parsed = await papaParsePromise(csv);
+  data[parameter] = parsed.data;
 }

--- a/js/drawMap/drawBubbles.js
+++ b/js/drawMap/drawBubbles.js
@@ -1,20 +1,31 @@
 import { LYRIC_WHITE, LYRIC_RED } from "../constants/colors.js";
 
+/** What is on the map now, read by the single zoomend handler below. */
+let drawn = /** @type {{ circles: any[], bubbles: Record<number, DrawableBubble> }} */ ({
+  circles: [],
+  bubbles: {}
+});
+let listeningToZoom = false;
+
 /**
  * Draws every city circle and its label, and re-sizes them on zoom.
  * @param {LyricMap} map
  * @param {Record<number, DrawableBubble>} bubbles
  */
 export function drawBubblesAndLegends(map, bubbles) {
-  const drawnBubbles = drawBubbles(map, bubbles);
+  drawn = { circles: drawBubbles(map, bubbles), bubbles };
   drawLegends(map, bubbles);
 
-  map.on("zoomend", function () {
+  // Bound once. Binding per redraw leaked a handler on every filter change, each
+  // holding circles that had since been cleared off the map.
+  if (listeningToZoom) return;
+  listeningToZoom = true;
+  map.on("zoomend", () => {
     const zoom = map.getZoom();
-    for (const bubble of drawnBubbles) {
-      bubble.setRadius(calculateBubbleSize(zoom, bubble._price));
+    for (const circle of drawn.circles) {
+      circle.setRadius(calculateBubbleSize(zoom, circle._price));
     }
-    drawLegends(map, bubbles);
+    drawLegends(map, drawn.bubbles);
   });
 }
 

--- a/js/popups/popups.js
+++ b/js/popups/popups.js
@@ -18,9 +18,9 @@ export function createPopupHtml(state, data, bubble) {
       // Relationship 3 is "activity", which gets its own native/non-native split.
       return type === "relationship" && num === 3
         ? createActivePopupHtml(data, bubble)
-        : createPlacesPopupHtml(state, data, bubble);
+        : createPlacesPopupHtml(state, data, bubble, type, num);
     case "geoimaginaryMode":
-      return createGeoImaginaryPopupHtml(state, data, bubble);
+      return createGeoImaginaryPopupHtml(state, data, bubble, type, num);
     case "travelMode":
       // The travel map draws arcs and builds its popups in travelPopups.js.
       throw new Error("createPopupHtml is not used by the travel map");
@@ -90,11 +90,13 @@ function createActivePopupHtml(data, bubble) {
  * @param {State} state
  * @param {Data} data
  * @param {Bubble} bubble
+ * @param {PlacesFilterType} type
+ * @param {number} num
  * @returns {string}
  */
-function createHeader(state, data, bubble) {
+function createHeader(state, data, bubble, type, num) {
   const cityname = bubble.city.infowindowName.toUpperCase();
-  const title = createTitle(state, data, cityname, bubble);
+  const title = createTitle(state, data, cityname, bubble, type, num);
   return `
     <h3 style="color:${LYRIC_GREY}">${cityname}</h3>
     <h5 style="color:${LYRIC_GREY}">${title}</h5>
@@ -105,12 +107,14 @@ function createHeader(state, data, bubble) {
  * @param {State} state
  * @param {Data} data
  * @param {Bubble} bubble
+ * @param {PlacesFilterType} type
+ * @param {number} num
  * @returns {string}
  */
-function createPlacesPopupHtml(state, data, bubble) {
+function createPlacesPopupHtml(state, data, bubble, type, num) {
   const poetCities = bubble.poetCities;
   return `
-    ${createHeader(state, data, bubble)}
+    ${createHeader(state, data, bubble, type, num)}
     ${createNumberedListOfPoets(poetCities.map(pc => pc.poetDetailName))}
     <h4 style="color:${LYRIC_GREY}">DETAILS</h4>
     ${createDetailedListOfPoets(poetCities, data)}
@@ -159,12 +163,14 @@ function createDetailedGeoListOfPoets(poets) {
  * @param {Data} data
  * @param {string} cityname already upper-cased
  * @param {Bubble} bubble
+ * @param {PlacesFilterType} type
+ * @param {number} num
  * @returns {string}
  */
-function createTitle(state, data, cityname, bubble) {
+function createTitle(state, data, cityname, bubble, type, num) {
   switch (state.currentMapMode) {
     case "placesMode":
-      return createPlacesModeTitle(state, data, cityname);
+      return createPlacesModeTitle(data, cityname, type, num);
     case "geoimaginaryMode": {
       const referenceStr = bubble.poetCities.length === 1 ? "REFERENCE" : "REFERENCES";
       return `${bubble.poetCities.length} ${referenceStr} TO ${cityname}`;
@@ -177,13 +183,13 @@ function createTitle(state, data, cityname, bubble) {
 }
 
 /**
- * @param {State} state
  * @param {Data} data
  * @param {string} cityname already upper-cased
+ * @param {PlacesFilterType} type
+ * @param {number} num
  * @returns {string}
  */
-function createPlacesModeTitle(state, data, cityname) {
-  const [type, num] = getPlacesFilter(state);
+function createPlacesModeTitle(data, cityname, type, num) {
   switch (type) {
     case "relationship":
       // Relationship 3 is "activity", which never reaches here: it is handled
@@ -208,13 +214,15 @@ function createPlacesModeTitle(state, data, cityname) {
  * @param {State} state
  * @param {Data} data
  * @param {Bubble} bubble
+ * @param {PlacesFilterType} type
+ * @param {number} num
  * @returns {string}
  */
-function createGeoImaginaryPopupHtml(state, data, bubble) {
+function createGeoImaginaryPopupHtml(state, data, bubble, type, num) {
   // calcBubbles always populates poets in geoimaginaryMode.
   const poets = /** @type {GeoBubblePoet[]} */ (bubble.poets);
   return `
-    ${createHeader(state, data, bubble)}
+    ${createHeader(state, data, bubble, type, num)}
     ${createGeoHeaderListOfPoets(poets)}
     <h4 style="color:${LYRIC_GREY}">DETAILS</h4>
     ${createDetailedGeoListOfPoets(poets)}

--- a/js/renderMap/lines.js
+++ b/js/renderMap/lines.js
@@ -12,8 +12,11 @@ import { assertUnreachable } from "../assertUnreachable.js";
  * @param {State} state
  */
 export function calculateAndDrawLines(map, data, state) {
-  const filteredPoetLines = filterLines(state, data).filter(getDateFilterFn(data, state));
-  const calculatedLines = calculateLines(state, data, filteredPoetLines);
+  // Parsed once here and threaded down. Re-deriving it inside colorLine and
+  // weightLine meant splitting state.selectedId a few hundred times per redraw.
+  const [type, num] = getTravelFilter(state);
+  const filteredPoetLines = filterLines(data, type, num).filter(getDateFilterFn(data, state));
+  const calculatedLines = calculateLines(data, type, num, filteredPoetLines);
   const travelBubbles = calculateTravelBubbles(data, filteredPoetLines);
   drawLines(map, calculatedLines);
   drawBubblesAndLegends(map, travelBubbles);
@@ -21,12 +24,12 @@ export function calculateAndDrawLines(map, data, state) {
 
 /**
  * Narrows every poet line down to those matching the selected radio button.
- * @param {State} state
  * @param {Data} data
+ * @param {TravelFilterType} type
+ * @param {number} num
  * @returns {Line[]}
  */
-function filterLines(state, data) {
-  const [type, num] = getTravelFilter(state);
+function filterLines(data, type, num) {
   switch (type) {
     case "all":
       return data.lines;
@@ -59,14 +62,13 @@ function hashCityIds(from, to) {
 /**
  * Merges every poet line sharing a city pair into a single drawn arc, then
  * colours, weights and builds a popup for each.
- * @param {State} state
  * @param {Data} data
+ * @param {TravelFilterType} type
+ * @param {number} num
  * @param {Line[]} filteredPoetLines
  * @returns {Record<number, DrawnLine>}
  */
-function calculateLines(state, data, filteredPoetLines) {
-  const [type] = getTravelFilter(state);
-
+function calculateLines(data, type, num, filteredPoetLines) {
   /** @type {Record<number, DrawnLine>} */
   const lines = {};
   for (const line of filteredPoetLines) {
@@ -81,12 +83,12 @@ function calculateLines(state, data, filteredPoetLines) {
       lines[hash].name = `${line.bornCity.infowindowName} -> ${line.activeCity.infowindowName}`.toUpperCase();
     }
     lines[hash].poetLines.push(line);
-    colorLine(state, lines[hash]);
+    colorLine(type, num, lines[hash]);
     if (line.dotted) lines[hash].dotted = true;
   }
   for (const hash in lines) {
     const line = lines[hash];
-    weightLine(state, line);
+    weightLine(type, line);
     if (type === "gov") {
       line.popupHtml = createGovTravelPopupHtml(data, line);
     } else {
@@ -98,11 +100,10 @@ function calculateLines(state, data, filteredPoetLines) {
 
 /**
  * Thickens an arc in proportion to how many poets travelled it.
- * @param {State} state
+ * @param {TravelFilterType} type
  * @param {DrawnLine} line mutated in place
  */
-function weightLine(state, line) {
-  const [type] = getTravelFilter(state);
+function weightLine(type, line) {
   const poetsNum = line.poetLines.length;
   let multiplier = 1;
   let increment = 0;
@@ -116,11 +117,11 @@ function weightLine(state, line) {
 /**
  * Recolours an arc when it leaves (purple) or stays within (yellow) whatever is
  * currently selected. Default is red.
- * @param {State} state
+ * @param {TravelFilterType} type
+ * @param {number} num
  * @param {DrawnLine} line mutated in place
  */
-function colorLine(state, line) {
-  const [type, num] = getTravelFilter(state);
+function colorLine(type, num, line) {
   // default color is red
   if (type === "destination") {
     if (line.fromCity.cityId === num) line.color = TRAVEL_PURPLE;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "node --test tests/*.test.js",
     "test:browser": "node --test tests/browser/*.test.js",
-    "lint": "npx -y oxlint@1 --deny-warnings -A all -D correctness -D eqeqeq -D no-var -D prefer-const -D no-self-compare -D no-template-curly-in-string js/ tests/ index.js",
+    "lint": "npx -y oxlint@1 --deny-warnings -A all -D correctness -D eqeqeq -D no-var -D prefer-const -D no-self-compare -D no-template-curly-in-string -D require-await js/ tests/ index.js",
     "format": "npx -y prettier@3 --write .",
     "format:check": "npx -y prettier@3 --check .",
     "typecheck": "npx -y -p typescript@5 tsc -p jsconfig.json"

--- a/tests/browser/smoke.test.js
+++ b/tests/browser/smoke.test.js
@@ -55,6 +55,29 @@ before(async () => {
   browser = await chromium.launch();
   page = await browser.newPage({ viewport: { width: 1280, height: 900 } });
 
+  // Count zoomend registrations, to catch the handler-per-redraw leak coming back.
+  await page.addInitScript(() => {
+    const browserWindow = /** @type {any} */ (window);
+    browserWindow.__zoomendRegistrations = 0;
+    /** @type {any} */
+    let leaflet;
+    Object.defineProperty(window, "L", {
+      configurable: true,
+      get: () => leaflet,
+      set: (/** @type {any} */ value) => {
+        leaflet = value;
+        if (value?.Map?.prototype && !value.Map.prototype.__counted) {
+          const on = value.Map.prototype.on;
+          value.Map.prototype.on = function (/** @type {any} */ type, /** @type {any[]} */ ...rest) {
+            if (typeof type === "string" && type.includes("zoomend")) browserWindow.__zoomendRegistrations++;
+            return on.call(this, type, ...rest);
+          };
+          value.Map.prototype.__counted = true;
+        }
+      }
+    });
+  });
+
   // Keep the test hermetic: serve a stub for the basemap tiles and the YouTube
   // embed rather than reaching the network. Fulfilled rather than aborted, so
   // that a blocked request does not itself log a console error and defeat the
@@ -322,5 +345,17 @@ describe("geographical imaginary: specific views", () => {
   test("Alcman's poetic world is 32 places", async () => {
     await select("poet_93");
     assert.equal(await drawnPaths(), 64); // 32 x 2
+  });
+});
+
+describe("redrawing does not leak", () => {
+  test("zoomend is bound once, however many times the map is redrawn", async () => {
+    await mode("placesMode");
+    const before = await page.evaluate(() => /** @type {any} */ (window).__zoomendRegistrations);
+    for (let i = 0; i < 6; i++) await select(i % 2 ? "relationship_1" : "relationship_3");
+    await mode("travelMode");
+    await mode("geoimaginaryMode");
+    await mode("placesMode");
+    assert.equal(await page.evaluate(() => /** @type {any} */ (window).__zoomendRegistrations), before);
   });
 });


### PR DESCRIPTION
Three things found by reading the redraw path, not by anything breaking.

## 1. A `zoomend` handler leaked on every redraw

`drawBubblesAndLegends` bound a fresh listener each call — and it runs on every filter change, mode switch and slider move. Nothing removed them.

```
after initial render     handlers=  2   one zoomend = 0.7ms
after 10 filter changes  handlers= 11   one zoomend = 2.1ms
after 30 filter changes  handlers= 31   one zoomend = 4.1ms
```

Linear growth, ~0.12ms per leaked handler. Worse than the cost: **each stale closure holds circles already cleared off the map** and calls `setRadius` on them, then redraws every legend again. So one zoom did N legend rebuilds, where N is how long you'd been clicking.

Now bound once, reading what is currently drawn. A browser test asserts the registration count doesn't move across ten redraws — **reverting the fix takes it from 2 to 35**.

## 2. A missing data file failed silently

`parseCsv` trusted `fetch`, which resolves for a 404. So a missing CSV got parsed as CSV — the 404 error page, in practice — and the app carried on with nothing in it:

```
before:  bubbles drawn: 0
         TypeError: Cannot read properties of undefined (reading 'cityname')
         did anything tell the user?  no

after:   alert: could not load ./dataFiles/cities.csv: 404 Not Found
         did anything tell the user?  yes
```

A blank map with a console error nobody has open is the worst available failure for a site that has to survive a decade of deploys and hosting moves.

## 3. The filter was re-parsed ~331 times per redraw

`getTravelFilter` splits `state.selectedId` and searches an array. It was called four levels down — in `colorLine` once per poet-line (170) and `weightLine` once per arc (159). Parsed once in `calculateAndDrawLines` and threaded through, as the places filter now is through the popups.

Not a perf problem at this size; the point is that four functions were re-deriving what the caller already knew.

## Also: two pointless `async` keywords

Raised in review, and correct. `papaParsePromise` and `parseCsvs` were declared `async` with **no `await` in either** — they already returned promises, so the keyword did nothing. The new error handling had also left a nested `await papaParsePromise(await response.text())`, which is two operations pretending to be one.

Both cleaned up, and **oxlint's `require-await` is now enabled** so the `async` cannot drift back:

```
js/calcData/parseCsvs.js:5:16: error eslint(require-await): Async function has no `await` expression.
lint exit: 1
```

`await` was kept over a `.then` chain deliberately: this is a linear pipeline, `await` gives better V8 stack traces, and a guard clause reads better than a `throw` buried in a callback.

## No rendering change

35 places and geographical-imaginary views — every genre, both relationship filters, a sample of poets — comparing city lists and popup lengths:

```
IDENTICAL — 35 views, 627 bubbles, popup lengths matched
```

Plus 82 tests, 24 browser tests, tsc, lint and format all pass.

## Skipped

The nits from the review: `for...in` over an array in `calculateTravelBubbles`, `hashCityIds`' undocumented `< 1000` assumption, the `price`/`_price` misnomer, and the 43 lines of bibliography inside a JS template literal.