### PR TITLE
Build bubbles and arcs complete, instead of filling in empty ones

### DIFF
--- a/js/calcData/data.js
+++ b/js/calcData/data.js
@@ -73,8 +73,19 @@ export function initializeData(data) {
   createTravelPoets(data);
   createTravelCities(data);
   createRegionsForInterface(data);
-  data.poetCities.forEach(pc => primeObjWithPoetData(pc, data));
-  data.geopoetCities.forEach(pc => primeObjWithPoetData(pc, data));
+  // Assigned onto the rows, not built into them, which is the one place this
+  // commit leaves a type ahead of the object it describes.
+  //
+  // A travel line could be built complete because createLines() makes it. These
+  // rows are made by Papa Parse and mutated in place ever since, and createLines
+  // has already captured these exact objects as bornPc and activePc, so handing
+  // back primed copies would leave those references pointing at the originals.
+  //
+  // Until this runs, then, a PoetCity is missing the four PoetPrimed fields its
+  // type says it has. The "every row is primed with its poet's display data"
+  // test in tests/initializeData.test.js is what currently holds that together.
+  data.poetCities.forEach(pc => Object.assign(pc, poetPrimedData(data, pc.poetId)));
+  data.geopoetCities.forEach(pc => Object.assign(pc, poetPrimedData(data, pc.poetId)));
   sortPoetCities(data, data.poetCities);
   sortPoetCities(data, data.geopoetCities);
 }
@@ -92,28 +103,38 @@ function sortPoetCities(data, poetCities) {
 }
 
 /**
- * Copies a poet's display name, dates, sources and genres onto a row (or a
- * travel line) so popups can render without a second lookup.
- * @param {{ poetId: number, poetname?: string } & Partial<PoetPrimed>} obj
+ * A poet's display name, dates, sources and genres, to be copied onto a row (or
+ * a travel line) so popups can render without a second lookup.
+ *
+ * Returned rather than assigned, so a travel line can be built with these fields
+ * already on it instead of existing briefly without them.
  * @param {Data} data
+ * @param {number} poetId
+ * @returns {PoetPrimed}
  */
-function primeObjWithPoetData(obj, data) {
-  const poet = getPoet(data, obj.poetId);
+function poetPrimedData(data, poetId) {
+  const poet = getPoet(data, poetId);
 
-  obj.poetDetailName = "";
-  if (poet.poetDetailName) obj.poetDetailName = poet.poetDetailName;
-  else alert(`Poet ${obj.poetname} with poetId ${obj.poetId} lacks a details name`);
+  let poetDetailName = "";
+  if (poet.poetDetailName) poetDetailName = poet.poetDetailName;
+  else alert(`Poet ${poet.poetname} with poetId ${poetId} lacks a details name`);
 
-  obj.poetDates = "";
-  if (poet.dates) obj.poetDates = poet.dates;
-  else console.log(`Poet ${obj.poetname} with poetId ${obj.poetId} lacks dates`);
+  let poetDates = "";
+  if (poet.dates) poetDates = poet.dates;
+  else console.log(`Poet ${poet.poetname} with poetId ${poetId} lacks dates`);
 
-  obj.poetSources = "";
-  if (poet.sources) obj.poetSources = poet.sources;
-  else console.log(`Poet ${obj.poetname} with poetId ${obj.poetId} lacks sources`);
+  let poetSources = "";
+  if (poet.sources) poetSources = poet.sources;
+  else console.log(`Poet ${poet.poetname} with poetId ${poetId} lacks sources`);
 
-  const genres = getGenres(data, obj.poetId);
-  obj.poetGenres = genres.map(genre => genre.genre).join(", ");
+  return {
+    poetDetailName,
+    poetDates,
+    poetSources,
+    poetGenres: getGenres(data, poetId)
+      .map(genre => genre.genre)
+      .join(", ")
+  };
 }
 
 /**
@@ -318,7 +339,6 @@ function createLines(data) {
           const dotted = bornPc.dotted === "dotted" || activePc.dotted === "dotted";
           const fromCity = getCity(data, bornPc.cityId);
           const toCity = getCity(data, activePc.cityId);
-          const poet = getPoet(data, poetId);
           const poetDates = data.datesByPoetId[poetId];
           const bornGovIds = [
             ...new Set(
@@ -336,8 +356,8 @@ function createLines(data) {
                 .flatMap(govId => convertMixedGovIds(govId))
             )
           ];
-          // The PoetPrimed fields are filled in by primeObjWithPoetData below.
-          const line = /** @type {Line} */ ({
+          /** @type {Line} */
+          const line = {
             poetId: poetId,
             bornCityId: bornPc.cityId,
             activeCityId: activePc.cityId,
@@ -346,11 +366,10 @@ function createLines(data) {
             dotted: dotted,
             bornCity: fromCity,
             activeCity: toCity,
-            poetDetailName: poet.poetDetailName,
             bornGovIds: bornGovIds,
-            activeGovIds: activeGovIds
-          });
-          primeObjWithPoetData(line, data);
+            activeGovIds: activeGovIds,
+            ...poetPrimedData(data, poetId)
+          };
           data.lines.push(line);
         }
       }

--- a/js/popups/popups.js
+++ b/js/popups/popups.js
@@ -8,7 +8,7 @@ import { createNumberedListOfPoets, createDetailedListOfPoets, renderReference }
  * places / geographical-imaginary maps is showing.
  * @param {State} state
  * @param {Data} data
- * @param {Bubble} bubble
+ * @param {BubbleContents} bubble
  * @returns {string}
  */
 export function createPopupHtml(state, data, bubble) {
@@ -32,7 +32,7 @@ export function createPopupHtml(state, data, bubble) {
 /**
  * The ACTIVITY popup, which splits a city's poets into natives and incomers.
  * @param {Data} data
- * @param {Bubble} bubble
+ * @param {BubbleContents} bubble
  * @returns {string}
  */
 function createActivePopupHtml(data, bubble) {
@@ -89,7 +89,7 @@ function createActivePopupHtml(data, bubble) {
 /**
  * @param {State} state
  * @param {Data} data
- * @param {Bubble} bubble
+ * @param {BubbleContents} bubble
  * @param {PlacesFilterType} type
  * @param {number} num
  * @returns {string}
@@ -106,7 +106,7 @@ function createHeader(state, data, bubble, type, num) {
 /**
  * @param {State} state
  * @param {Data} data
- * @param {Bubble} bubble
+ * @param {BubbleContents} bubble
  * @param {PlacesFilterType} type
  * @param {number} num
  * @returns {string}
@@ -162,7 +162,7 @@ function createDetailedGeoListOfPoets(poets) {
  * @param {State} state
  * @param {Data} data
  * @param {string} cityname already upper-cased
- * @param {Bubble} bubble
+ * @param {BubbleContents} bubble
  * @param {PlacesFilterType} type
  * @param {number} num
  * @returns {string}
@@ -213,7 +213,7 @@ function createPlacesModeTitle(data, cityname, type, num) {
 /**
  * @param {State} state
  * @param {Data} data
- * @param {Bubble} bubble
+ * @param {BubbleContents} bubble
  * @param {PlacesFilterType} type
  * @param {number} num
  * @returns {string}

--- a/js/popups/travelPopups.js
+++ b/js/popups/travelPopups.js
@@ -4,7 +4,7 @@ import { createNumberedListOfPoets, createDetailedListOfPoets, renderReference }
 /**
  * Builds the html shown when a travel arc is clicked.
  * @param {Data} data
- * @param {DrawnLine} line
+ * @param {TravelArc} line
  * @returns {string}
  */
 export function createTravelPopupHtml(data, line) {
@@ -23,7 +23,7 @@ export function createTravelPopupHtml(data, line) {
 
 /**
  * Renders the citation behind either end of an arc, for every poet on it.
- * @param {DrawnLine} line
+ * @param {TravelArc} line
  * @param {"bornPc" | "activePc"} direction which end of the journey to cite
  * @returns {string}
  */
@@ -44,7 +44,7 @@ function createTravelSource(line, direction) {
  * As createTravelPopupHtml, but the details block reports regimes rather than
  * genres and sources.
  * @param {Data} data
- * @param {DrawnLine} line
+ * @param {TravelArc} line
  * @returns {string}
  */
 export function createGovTravelPopupHtml(data, line) {

--- a/js/renderMap/calcBubbles.js
+++ b/js/renderMap/calcBubbles.js
@@ -10,48 +10,63 @@ import { createPopupHtml } from "../popups/popups.js";
  * @returns {Record<number, Bubble>}
  */
 export function calculateBubbles(state, data, poetCities) {
-  const citiesById = data.citiesById;
   /** @type {Record<number, Bubble>} */
   const bubbles = {};
 
+  for (const [key, rows] of Object.entries(groupRowsByCity(data, poetCities))) {
+    const cityId = Number(key);
+    // The contents are assembled first because the popup is rendered from them,
+    // and from nothing that is added alongside it. That ordering is what lets a
+    // bubble be built complete instead of filled in field by field.
+    /** @type {BubbleContents} */
+    const contents = { city: data.citiesById[cityId], poetCities: rows };
+    if (state.currentMapMode === "geoimaginaryMode") contents.poets = groupRowsByPoet(rows);
+
+    bubbles[cityId] = {
+      ...contents,
+      price: calculateBubblePriceFromNumberOfPoets(rows.length),
+      popupHtml: createPopupHtml(state, data, contents),
+      legend: contents.city.cityname
+    };
+  }
+
+  return bubbles;
+}
+
+/**
+ * Buckets rows by the city they point at, dropping any that name a city missing
+ * from cities.csv.
+ * @param {Data} data
+ * @param {RenderedPoetCity[]} poetCities
+ * @returns {Record<number, RenderedPoetCity[]>}
+ */
+function groupRowsByCity(data, poetCities) {
+  /** @type {Record<number, RenderedPoetCity[]>} */
+  const rowsByCity = {};
   for (const poetCity of poetCities) {
     const cityId = poetCity.cityId;
-    if (cityId && citiesById[cityId]) {
-      if (!bubbles[cityId]) {
-        bubbles[cityId] = /** @type {Bubble} */ ({});
-        bubbles[cityId].city = citiesById[cityId];
-        bubbles[cityId].poetCities = [];
-      }
-      bubbles[cityId].poetCities.push(poetCity);
-    }
+    if (!cityId || !data.citiesById[cityId]) continue;
+    if (!rowsByCity[cityId]) rowsByCity[cityId] = [];
+    rowsByCity[cityId].push(poetCity);
   }
+  return rowsByCity;
+}
 
-  if (state.currentMapMode === "geoimaginaryMode") {
-    for (const cityId in bubbles) {
-      const bubbleCity = bubbles[cityId];
-      // poets starts life keyed by poetId so references can be accumulated,
-      // then is flattened to the sorted array that popups consume.
-      /** @type {Record<number, GeoBubblePoet>} */
-      const poetsById = {};
-      for (const pc of bubbleCity.poetCities) {
-        if (!poetsById[pc.poetId]) {
-          poetsById[pc.poetId] = /** @type {GeoBubblePoet} */ ({ ...pc });
-          poetsById[pc.poetId].references = [];
-        }
-        poetsById[pc.poetId].references.push(pc.reference);
-      }
-      bubbleCity.poets = Object.values(poetsById);
-      bubbleCity.poets.sort((a, b) => sortAlphabetically(a.poetname, b.poetname));
-    }
+/**
+ * Collapses one city's rows to one entry per poet, carrying every citation that
+ * poet made to it. Geographical imaginary only, where a poet often names the
+ * same place several times.
+ * @param {RenderedPoetCity[]} rows
+ * @returns {GeoBubblePoet[]}
+ */
+function groupRowsByPoet(rows) {
+  /** @type {Record<number, GeoBubblePoet>} */
+  const poetsById = {};
+  for (const row of rows) {
+    if (!poetsById[row.poetId]) poetsById[row.poetId] = { ...row, references: [] };
+    poetsById[row.poetId].references.push(row.reference);
   }
-
-  for (const cityId in bubbles) {
-    const bubble = bubbles[cityId];
-    bubble.price = calculateBubblePriceFromNumberOfPoets(bubble.poetCities.length);
-    bubble.popupHtml = createPopupHtml(state, data, bubble);
-    bubble.legend = bubble.city.cityname;
-  }
-  return bubbles;
+  return Object.values(poetsById).sort((a, b) => sortAlphabetically(a.poetname, b.poetname));
 }
 
 /**

--- a/js/renderMap/lines.js
+++ b/js/renderMap/lines.js
@@ -71,69 +71,110 @@ function hashCityIds(from, to) {
 function calculateLines(data, type, num, filteredPoetLines) {
   /** @type {Record<number, DrawnLine>} */
   const lines = {};
-  for (const line of filteredPoetLines) {
-    const hash = hashCityIds(line.bornCityId, line.activeCityId);
-    if (!lines[hash]) {
-      lines[hash] = /** @type {DrawnLine} */ ({});
-      lines[hash].fromCity = line.bornCity;
-      lines[hash].toCity = line.activeCity;
-      lines[hash].poetLines = [];
-      lines[hash].dotted = false;
-      lines[hash].color = TRAVEL_RED;
-      lines[hash].name = `${line.bornCity.infowindowName} -> ${line.activeCity.infowindowName}`.toUpperCase();
-    }
-    lines[hash].poetLines.push(line);
-    colorLine(type, num, lines[hash]);
-    if (line.dotted) lines[hash].dotted = true;
+
+  for (const [key, poetLines] of Object.entries(groupLinesByCityPair(filteredPoetLines))) {
+    const { bornCity: fromCity, activeCity: toCity } = poetLines[0];
+    // The arc is assembled first because the popup is rendered from it, and from
+    // nothing that is added alongside it. That ordering is what lets an arc be
+    // built complete instead of filled in field by field.
+    /** @type {TravelArc} */
+    const arc = {
+      fromCity,
+      toCity,
+      poetLines,
+      dotted: poetLines.some(line => line.dotted),
+      color: arcColor(type, num, fromCity, poetLines),
+      name: `${fromCity.infowindowName} -> ${toCity.infowindowName}`.toUpperCase(),
+      weight: arcWeight(type, poetLines.length)
+    };
+
+    lines[Number(key)] = {
+      ...arc,
+      popupHtml: type === "gov" ? createGovTravelPopupHtml(data, arc) : createTravelPopupHtml(data, arc)
+    };
   }
-  for (const hash in lines) {
-    const line = lines[hash];
-    weightLine(type, line);
-    if (type === "gov") {
-      line.popupHtml = createGovTravelPopupHtml(data, line);
-    } else {
-      line.popupHtml = createTravelPopupHtml(data, line);
-    }
-  }
+
   return lines;
 }
 
 /**
- * Thickens an arc in proportion to how many poets travelled it.
- * @param {TravelFilterType} type
- * @param {DrawnLine} line mutated in place
+ * Buckets poet lines by the city pair they run between, which is what an arc
+ * merges.
+ * @param {Line[]} filteredPoetLines
+ * @returns {Record<number, Line[]>}
  */
-function weightLine(type, line) {
-  const poetsNum = line.poetLines.length;
-  let multiplier = 1;
-  let increment = 0;
-  if (type === "destination" || type === "smallregion" || type === "poet") {
-    multiplier = 2;
-    increment = 1;
+function groupLinesByCityPair(filteredPoetLines) {
+  /** @type {Record<number, Line[]>} */
+  const linesByCityPair = {};
+  for (const line of filteredPoetLines) {
+    const hash = hashCityIds(line.bornCityId, line.activeCityId);
+    if (!linesByCityPair[hash]) linesByCityPair[hash] = [];
+    linesByCityPair[hash].push(line);
   }
-  line.weight = multiplier * poetsNum + increment;
+  return linesByCityPair;
 }
 
 /**
- * Recolours an arc when it leaves (purple) or stays within (yellow) whatever is
- * currently selected. Default is red.
+ * Thickens an arc in proportion to how many poets travelled it, and doubles it
+ * for the filters that leave only a handful of arcs on the map, where a weight
+ * of 1 would be all but invisible.
+ *
+ * Exhaustive rather than defaulting to the thin case, so a seventh travel filter
+ * has to say which of the two it is instead of quietly getting the thin one.
+ * @param {TravelFilterType} type
+ * @param {number} poetsNum
+ * @returns {number}
+ */
+function arcWeight(type, poetsNum) {
+  switch (type) {
+    case "poet":
+    case "destination":
+    case "smallregion":
+      return 2 * poetsNum + 1;
+    case "all":
+    case "region":
+    case "gov":
+      return poetsNum;
+    default:
+      return assertUnreachable(type, "unrecognized filter when weighting a travel arc");
+  }
+}
+
+/**
+ * Purple when an arc leaves whatever is currently selected, yellow when it both
+ * leaves and arrives within it, red otherwise.
+ *
+ * As filterLines above, exhaustive over TravelFilterType. Red was previously the
+ * fallthrough at the end of an if-chain, which meant ALL and POET got it by
+ * saying nothing — and so would any filter added later, silently.
  * @param {TravelFilterType} type
  * @param {number} num
- * @param {DrawnLine} line mutated in place
+ * @param {City} fromCity
+ * @param {Line[]} poetLines
+ * @returns {string}
  */
-function colorLine(type, num, line) {
-  // default color is red
-  if (type === "destination") {
-    if (line.fromCity.cityId === num) line.color = TRAVEL_PURPLE;
-  } else if (type === "smallregion") {
-    if (line.fromCity.regionId === num) line.color = TRAVEL_PURPLE;
-  } else if (type === "region") {
-    if (line.fromCity.bigRegionId === num) line.color = TRAVEL_PURPLE;
-  } else if (type === "gov") {
-    const bornGovIds = line.poetLines.flatMap(pl => pl.bornGovIds).filter(govId => govId === num);
-    const activeGovIds = line.poetLines.flatMap(pl => pl.activeGovIds).filter(govId => govId === num);
-    if (bornGovIds.length && activeGovIds.length) line.color = TRAVEL_YELLOW;
-    else if (bornGovIds.length) line.color = TRAVEL_PURPLE;
+function arcColor(type, num, fromCity, poetLines) {
+  switch (type) {
+    case "all":
+    case "poet":
+      // Neither picks out a place, so there is no leaving or arriving to show.
+      return TRAVEL_RED;
+    case "destination":
+      return fromCity.cityId === num ? TRAVEL_PURPLE : TRAVEL_RED;
+    case "smallregion":
+      return fromCity.regionId === num ? TRAVEL_PURPLE : TRAVEL_RED;
+    case "region":
+      return fromCity.bigRegionId === num ? TRAVEL_PURPLE : TRAVEL_RED;
+    case "gov": {
+      // Read across the whole arc, not one line: several poets can share a
+      // journey, and any of them born under the selected regime colours it.
+      const bornUnder = poetLines.some(line => line.bornGovIds.includes(num));
+      const activeUnder = poetLines.some(line => line.activeGovIds.includes(num));
+      if (bornUnder && activeUnder) return TRAVEL_YELLOW;
+      return bornUnder ? TRAVEL_PURPLE : TRAVEL_RED;
+    }
+    default:
+      return assertUnreachable(type, "unrecognized filter when colouring a travel arc");
   }
 }
 
@@ -146,19 +187,15 @@ function colorLine(type, num, line) {
 function calculateTravelBubbles(data, filteredPoetLines) {
   /** @type {Set<number>} */
   const cityIds = new Set();
-  for (const plId in filteredPoetLines) {
-    const pl = filteredPoetLines[plId];
-    cityIds.add(pl.bornCityId);
-    cityIds.add(pl.activeCityId);
+  for (const line of filteredPoetLines) {
+    cityIds.add(line.bornCityId);
+    cityIds.add(line.activeCityId);
   }
 
   /** @type {Record<number, DrawableBubble>} */
   const bubbles = {};
   for (const cityId of cityIds) {
-    const city = data.citiesById[cityId];
-    bubbles[cityId] = /** @type {DrawableBubble} */ ({});
-    bubbles[cityId].city = city;
-    bubbles[cityId].price = 10;
+    bubbles[cityId] = { city: data.citiesById[cityId], price: 10 };
   }
 
   return bubbles;

--- a/js/renderMap/lines.js
+++ b/js/renderMap/lines.js
@@ -29,7 +29,7 @@ export function calculateAndDrawLines(map, data, state) {
  * @param {number} num
  * @returns {Line[]}
  */
-function filterLines(data, type, num) {
+export function filterLines(data, type, num) {
   switch (type) {
     case "all":
       return data.lines;
@@ -68,7 +68,7 @@ function hashCityIds(from, to) {
  * @param {Line[]} filteredPoetLines
  * @returns {Record<number, DrawnLine>}
  */
-function calculateLines(data, type, num, filteredPoetLines) {
+export function calculateLines(data, type, num, filteredPoetLines) {
   /** @type {Record<number, DrawnLine>} */
   const lines = {};
 

--- a/tests/lines.test.js
+++ b/tests/lines.test.js
@@ -1,0 +1,191 @@
+// Behaviour of the travel map's arcs, driven through the real pipeline.
+//
+// filterLines() and calculateLines() are pure, so Node can build the exact arcs
+// the browser draws and assert on how they merge, what colour they take and how
+// thick they are. As in popups.test.js, nothing is stubbed: the CSVs go in and
+// the arcs come out.
+//
+// Colour and weight had no coverage at all before this file, which made them the
+// riskiest part of any change to lines.js — both are plainly visible on the map
+// and neither was asserted anywhere.
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { loadInitializedData } from "./helpers/loadData.js";
+import { filterLines, calculateLines } from "../js/renderMap/lines.js";
+import { getDateFilterFn } from "../js/renderMap/calcCommon.js";
+import { TRAVEL_RED, TRAVEL_PURPLE, TRAVEL_YELLOW } from "../js/constants/colors.js";
+
+const { data } = loadInitializedData();
+
+/** The whole slider range, i.e. what the map shows before anything is dragged. */
+const ALL_DATES = { minDate: -800, maxDate: -400 };
+
+/** governments.csv ids, as the political system control bar offers them. */
+const DEMOCRACY = 3;
+const TYRANNY = 2;
+
+/**
+ * The arcs the travel map draws for one control bar selection, assembled the
+ * same way calculateAndDrawLines() assembles them.
+ * @param {TravelFilterType} type
+ * @param {number} num
+ * @returns {DrawnLine[]}
+ */
+function arcsFor(type, num) {
+  /** @type {State} */
+  const state = { currentMapMode: "travelMode", selectedId: `${type}_${num}`, ...ALL_DATES };
+  const poetLines = filterLines(data, type, num).filter(getDateFilterFn(data, state));
+  return Object.values(calculateLines(data, type, num, poetLines));
+}
+
+/**
+ * @param {DrawnLine[]} arcs
+ * @param {string} name e.g. "THEBES -> ATHENS"
+ * @returns {DrawnLine}
+ */
+function arcNamed(arcs, name) {
+  const matching = arcs.filter(arc => arc.name === name);
+  assert.equal(matching.length, 1, `expected exactly one "${name}" arc, found ${matching.length}`);
+  return matching[0];
+}
+
+const cityIdByName = (/** @type {string} */ cityname) => {
+  const city = data.cities.find(c => c.cityname === cityname);
+  assert.ok(city, `no city named ${cityname}`);
+  return city.cityId;
+};
+
+describe("arcs merge the poets who made the same journey", () => {
+  const arcs = arcsFor("all", 1);
+
+  test("three poets going from Thebes to Athens draw one arc, not three", () => {
+    const arc = arcNamed(arcs, "THEBES -> ATHENS");
+    assert.deepEqual(arc.poetLines.map(line => line.poetDetailName).sort(), ["Khairis", "Pindar", "Pronomus"]);
+  });
+
+  test("one poet's uncertain journey dots the whole arc", () => {
+    // Bacchylides' line to Athens is marked dotted in poets_cities.csv and
+    // Simonides' is not. They share an arc, so the arc is drawn dotted: the
+    // hedge belongs to one of the two, but the map cannot say so.
+    const arc = arcNamed(arcs, "IOULIS (CEOS) -> ATHENS");
+    assert.deepEqual(arc.poetLines.map(line => `${line.poetDetailName}:${line.dotted}`).sort(), [
+      "Bacchylides:true",
+      "Simonides:false"
+    ]);
+    assert.ok(arc.dotted);
+  });
+
+  test("an arc no one hedged is drawn solid", () => {
+    assert.equal(arcNamed(arcs, "THEBES -> ATHENS").dotted, false);
+  });
+
+  test("an arc is named from origin to destination", () => {
+    for (const arc of arcs) {
+      assert.equal(arc.name, `${arc.fromCity.infowindowName} -> ${arc.toCity.infowindowName}`.toUpperCase());
+    }
+  });
+
+  test("the whole slider range drops nothing, so every line above reaches the map", () => {
+    // The other tests here read as claims about the corpus rather than about the
+    // date filter, which is only true while the full range keeps everything.
+    const drawn = arcs.reduce((count, arc) => count + arc.poetLines.length, 0);
+    assert.equal(drawn, data.lines.length);
+  });
+});
+
+describe("arc colour", () => {
+  test("nothing is picked out until something is selected", () => {
+    for (const arc of arcsFor("all", 1)) assert.equal(arc.color, TRAVEL_RED);
+  });
+
+  test("selecting a city marks the journeys out of it, not the ones into it", () => {
+    const athens = cityIdByName("Athens");
+    const arcs = arcsFor("destination", athens);
+    for (const arc of arcs) {
+      const expected = arc.fromCity.cityId === athens ? TRAVEL_PURPLE : TRAVEL_RED;
+      assert.equal(arc.color, expected, `${arc.name} is the wrong way round for a journey out of Athens`);
+    }
+    // Both directions are on the map, so the loop above is actually deciding.
+    assert.ok(
+      arcs.some(arc => arc.color === TRAVEL_PURPLE),
+      "no arc leaves Athens"
+    );
+    assert.ok(
+      arcs.some(arc => arc.color === TRAVEL_RED),
+      "no arc arrives at Athens"
+    );
+  });
+
+  test("selecting a small region marks the journeys out of it", () => {
+    const attica = data.citiesById[cityIdByName("Athens")].regionId;
+    const arcs = arcsFor("smallregion", attica);
+    for (const arc of arcs) {
+      const expected = arc.fromCity.regionId === attica ? TRAVEL_PURPLE : TRAVEL_RED;
+      assert.equal(arc.color, expected, `${arc.name} is the wrong way round for a journey out of Attica`);
+    }
+    assert.ok(arcs.some(arc => arc.color === TRAVEL_PURPLE) && arcs.some(arc => arc.color === TRAVEL_RED));
+  });
+
+  test("under a political system, yellow stays within it, purple leaves it, red arrives in it", () => {
+    const arcs = arcsFor("gov", DEMOCRACY);
+    assert.equal(arcNamed(arcs, "ATHENS -> SALAMIS").color, TRAVEL_YELLOW, "democracy to democracy");
+    assert.equal(arcNamed(arcs, "ATHENS -> DELOS").color, TRAVEL_PURPLE, "out of a democracy");
+    assert.equal(arcNamed(arcs, "THEBES -> ATHENS").color, TRAVEL_RED, "into a democracy");
+  });
+
+  test("the same three cases under tyranny", () => {
+    const arcs = arcsFor("gov", TYRANNY);
+    assert.equal(arcNamed(arcs, "MYTILENE -> LEUCAS").color, TRAVEL_YELLOW, "tyranny to tyranny");
+    assert.equal(arcNamed(arcs, "CHIOS -> ATHENS").color, TRAVEL_PURPLE, "out of a tyranny");
+    assert.equal(arcNamed(arcs, "THEBES -> SYRACUSE").color, TRAVEL_RED, "into a tyranny");
+  });
+});
+
+describe("arc weight", () => {
+  test("an arc is as thick as the number of poets who travelled it", () => {
+    for (const arc of arcsFor("all", 1)) assert.equal(arc.weight, arc.poetLines.length);
+  });
+
+  test("the poet, city and small region filters draw thicker, so a lone journey still reads", () => {
+    // Those three usually leave only a handful of arcs on the map, where a
+    // weight of 1 would be all but invisible.
+    /** @type {[TravelFilterType, number][]} */
+    const SPARSE = [
+      ["destination", cityIdByName("Athens")],
+      ["smallregion", data.citiesById[cityIdByName("Athens")].regionId],
+      ["poet", data.travelPoets[0].id]
+    ];
+    for (const [type, num] of SPARSE) {
+      const arcs = arcsFor(type, num);
+      assert.ok(arcs.length > 0, `${type}_${num} draws nothing`);
+      for (const arc of arcs) assert.equal(arc.weight, 2 * arc.poetLines.length + 1, `${type}: ${arc.name}`);
+    }
+  });
+
+  test("Thebes to Athens carries three poets, so it is drawn at 3 and, picked out, at 7", () => {
+    assert.equal(arcNamed(arcsFor("all", 1), "THEBES -> ATHENS").weight, 3);
+    assert.equal(arcNamed(arcsFor("destination", cityIdByName("Athens")), "THEBES -> ATHENS").weight, 7);
+  });
+});
+
+describe("arc popups", () => {
+  test("the political system filter reports regimes, every other filter reports sources", () => {
+    const gov = arcsFor("gov", DEMOCRACY)[0].popupHtml;
+    assert.match(gov, /Regime \(data from Hansen and Nielsen\)/);
+    assert.doesNotMatch(gov, /Source\(s\)/);
+
+    const all = arcsFor("all", 1)[0].popupHtml;
+    assert.match(all, /Source\(s\)/);
+    assert.doesNotMatch(all, /Regime/);
+  });
+
+  test("every arc gets a popup citing both ends of the journey", () => {
+    for (const arc of arcsFor("all", 1)) {
+      assert.match(arc.popupHtml, /ORIGIN SOURCE/, `${arc.name} popup has no origin`);
+      assert.match(arc.popupHtml, /ACTIVITY SOURCE/, `${arc.name} popup has no destination`);
+      assert.doesNotMatch(arc.popupHtml, /undefined/, `${arc.name} popup contains "undefined"`);
+      assert.doesNotMatch(arc.popupHtml, /NaN/, `${arc.name} popup contains "NaN"`);
+    }
+  });
+});

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -297,24 +297,38 @@ interface DrawableBubble {
   legend?: string;
 }
 
-/** A circle drawn on the map for one city, with the rows behind its popup. */
-interface Bubble extends DrawableBubble {
+/**
+ * The rows behind one city's bubble. Split from Bubble because it is all the
+ * popup is rendered from, which is what lets calculateBubbles() build a whole
+ * Bubble in one go rather than filling an empty one in field by field.
+ */
+interface BubbleContents {
+  city: City;
   poetCities: RenderedPoetCity[];
   /** Only populated in geoimaginaryMode. */
   poets?: GeoBubblePoet[];
 }
 
-/** One drawn arc, merging every Line that shares the same city pair. */
-interface DrawnLine {
+/** A circle drawn on the map for one city, with the rows behind its popup. */
+interface Bubble extends BubbleContents, DrawableBubble {}
+
+/**
+ * One drawn arc, merging every Line that shares the same city pair, before its
+ * popup is rendered. As BubbleContents, this is everything the popup is built
+ * from, so the DrawnLine below can be built complete.
+ */
+interface TravelArc {
   fromCity: City;
   toCity: City;
   poetLines: Line[];
   dotted: boolean;
   color: string;
   name: string;
-  /** Set by weightLine() before the arc is drawn. */
   weight: number;
-  /** Set by calculateLines() before the arc is drawn. */
+}
+
+/** A TravelArc with its popup rendered, ready to draw. */
+interface DrawnLine extends TravelArc {
   popupHtml: string;
 }
 


### PR DESCRIPTION
First of five PRs tightening the types added last week, each one closing off a state the type system currently lets you express. They stack in this order:

1. **this PR** — objects that are typed complete before they are
2. `Data` built rather than mutated into existence
3. places and geographical-imaginary filters, which are not the same set
4. `State`, where the map mode and the filter are independent fields
5. `Bubble.poets`, optional but mandatory in one mode

## The bad state

Four places cast `{}` to a type whose every field is required, then filled the fields in:

```js
calcBubbles.js  /** @type {Bubble} */ ({})
calcBubbles.js  /** @type {DrawableBubble} */ ({})
lines.js        /** @type {DrawnLine} */ ({})
data.js         /** @type {Line} */ ({})
```

Between the cast and the last assignment the object is typed as complete and is not. The cast is the only reason it compiled.

## The fix

All four were already two-phase in practice — `calculateLines()` set `weight` and `popupHtml` in a second loop over the same object — so this makes the phases explicit and builds each object once, whole.

`Bubble` and `DrawnLine` are split in two to say which fields the popup is rendered from. `BubbleContents` and `TravelArc` are exactly what `createPopupHtml()` and `createTravelPopupHtml()` read; the full type is that plus the popup. The popup builders take the smaller type, so the ordering that makes one-shot construction possible is stated in the types rather than implied by the order of assignments.

Falling out of the same change:

- `colorLine()`/`weightLine()` mutated an arc in place; now `arcColor()`/`arcWeight()`, which return. `colorLine()` was called once per line as each group accumulated, recomputing the same answer up to N times per arc.
- `primeObjWithPoetData()` likewise returns rather than assigns. CSV rows are hydrated in place so they keep an `Object.assign`, but a travel line no longer exists briefly without its poet fields, and no longer sets `poetDetailName` twice.
- `calculateTravelBubbles()` iterated an array with `for...in`.

## Second commit: tests for what was refactored

Arc colour and weight were asserted **nowhere**, which made them the riskiest part of this change — I had to verify them by hand against `master`. That check now lives in the repo as `tests/lines.test.js` (15 tests), driving the same pipeline `calculateAndDrawLines()` drives, in the manner `popups.test.js` already uses for bubbles. `filterLines()` and `calculateLines()` are exported for that.

Anchored on cases read off the real CSVs rather than off the implementation: Thebes → Athens merges Pronomus, Khairis and Pindar into one arc; Bacchylides' hedged line dots the arc he shares with Simonides, who is not hedged; Athens → Salamis is democracy to democracy, Athens → Delos leaves a democracy, Thebes → Athens arrives in one, with the same three cases under tyranny.

Confirmed to have teeth against six mutations of `lines.js` — dropping the thickening, testing yellow after purple, reversing the destination filter, `some` → `every` for dotted, reading the wrong end of the journey under a regime filter, and swapping origin and destination in the name. Every one is caught.

## Verification

No behaviour change, checked against `master` rather than assumed:

- every arc's colour, weight, dotted flag and name across all 182 filters the travel control bar can produce — **1073 arcs, 0 differences**
- every bubble's popup html, price, legend and grouped poets across six views, key order included — **348 bubbles, 0 differences**
- `data.lines`, the primed rows, `poetsWithUnknownTravel`, and the alert/log output of `initializeData()` — **identical**

Tests (97), lint, format and the browser smoke test all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
