### PR TITLE
Give the geographical imaginary map its own filter type

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,13 +5,12 @@ import { initializeMap } from "./js/drawMap/initializeMap.js";
 import { initializeSlider } from "./js/interface/slider.js";
 import { createEssay, initializeCloseEssayClicks } from "./js/essay/essay.js";
 
-function main() {
+async function main() {
   createEssay("home");
   initializeCloseEssayClicks();
 
   const map = initializeMap();
-  // Starts empty; parseCsvs fills the raw arrays and initializeData derives the rest.
-  const data = /** @type {Data} */ ({});
+  const data = initializeData(await parseCsvs());
   /** @type {State} */
   const state = {
     currentMapMode: "placesMode",
@@ -20,15 +19,11 @@ function main() {
     selectedId: "relationship_3"
   };
 
-  parseCsvs(data).then(() => {
-    initializeData(data);
+  addMapModeEventListener(map, data, state);
+  addPoetsEventListener(map, data, state);
 
-    addMapModeEventListener(map, data, state);
-    addPoetsEventListener(map, data, state);
-
-    updateMapMode(map, data, state);
-    initializeSlider(map, data, state);
-  });
+  updateMapMode(map, data, state);
+  initializeSlider(map, data, state);
 }
 
 main();

--- a/js/calcData/data.js
+++ b/js/calcData/data.js
@@ -73,8 +73,19 @@ export function initializeData(data) {
   createTravelPoets(data);
   createTravelCities(data);
   createRegionsForInterface(data);
-  data.poetCities.forEach(pc => primeObjWithPoetData(pc, data));
-  data.geopoetCities.forEach(pc => primeObjWithPoetData(pc, data));
+  // Assigned onto the rows, not built into them, which is the one place this
+  // commit leaves a type ahead of the object it describes.
+  //
+  // A travel line could be built complete because createLines() makes it. These
+  // rows are made by Papa Parse and mutated in place ever since, and createLines
+  // has already captured these exact objects as bornPc and activePc, so handing
+  // back primed copies would leave those references pointing at the originals.
+  //
+  // Until this runs, then, a PoetCity is missing the four PoetPrimed fields its
+  // type says it has. The "every row is primed with its poet's display data"
+  // test in tests/initializeData.test.js is what currently holds that together.
+  data.poetCities.forEach(pc => Object.assign(pc, poetPrimedData(data, pc.poetId)));
+  data.geopoetCities.forEach(pc => Object.assign(pc, poetPrimedData(data, pc.poetId)));
   sortPoetCities(data, data.poetCities);
   sortPoetCities(data, data.geopoetCities);
 }
@@ -92,28 +103,38 @@ function sortPoetCities(data, poetCities) {
 }
 
 /**
- * Copies a poet's display name, dates, sources and genres onto a row (or a
- * travel line) so popups can render without a second lookup.
- * @param {{ poetId: number, poetname?: string } & Partial<PoetPrimed>} obj
+ * A poet's display name, dates, sources and genres, to be copied onto a row (or
+ * a travel line) so popups can render without a second lookup.
+ *
+ * Returned rather than assigned, so a travel line can be built with these fields
+ * already on it instead of existing briefly without them.
  * @param {Data} data
+ * @param {number} poetId
+ * @returns {PoetPrimed}
  */
-function primeObjWithPoetData(obj, data) {
-  const poet = getPoet(data, obj.poetId);
+function poetPrimedData(data, poetId) {
+  const poet = getPoet(data, poetId);
 
-  obj.poetDetailName = "";
-  if (poet.poetDetailName) obj.poetDetailName = poet.poetDetailName;
-  else alert(`Poet ${obj.poetname} with poetId ${obj.poetId} lacks a details name`);
+  let poetDetailName = "";
+  if (poet.poetDetailName) poetDetailName = poet.poetDetailName;
+  else alert(`Poet ${poet.poetname} with poetId ${poetId} lacks a details name`);
 
-  obj.poetDates = "";
-  if (poet.dates) obj.poetDates = poet.dates;
-  else console.log(`Poet ${obj.poetname} with poetId ${obj.poetId} lacks dates`);
+  let poetDates = "";
+  if (poet.dates) poetDates = poet.dates;
+  else console.log(`Poet ${poet.poetname} with poetId ${poetId} lacks dates`);
 
-  obj.poetSources = "";
-  if (poet.sources) obj.poetSources = poet.sources;
-  else console.log(`Poet ${obj.poetname} with poetId ${obj.poetId} lacks sources`);
+  let poetSources = "";
+  if (poet.sources) poetSources = poet.sources;
+  else console.log(`Poet ${poet.poetname} with poetId ${poetId} lacks sources`);
 
-  const genres = getGenres(data, obj.poetId);
-  obj.poetGenres = genres.map(genre => genre.genre).join(", ");
+  return {
+    poetDetailName,
+    poetDates,
+    poetSources,
+    poetGenres: getGenres(data, poetId)
+      .map(genre => genre.genre)
+      .join(", ")
+  };
 }
 
 /**
@@ -318,7 +339,6 @@ function createLines(data) {
           const dotted = bornPc.dotted === "dotted" || activePc.dotted === "dotted";
           const fromCity = getCity(data, bornPc.cityId);
           const toCity = getCity(data, activePc.cityId);
-          const poet = getPoet(data, poetId);
           const poetDates = data.datesByPoetId[poetId];
           const bornGovIds = [
             ...new Set(
@@ -336,8 +356,8 @@ function createLines(data) {
                 .flatMap(govId => convertMixedGovIds(govId))
             )
           ];
-          // The PoetPrimed fields are filled in by primeObjWithPoetData below.
-          const line = /** @type {Line} */ ({
+          /** @type {Line} */
+          const line = {
             poetId: poetId,
             bornCityId: bornPc.cityId,
             activeCityId: activePc.cityId,
@@ -346,11 +366,10 @@ function createLines(data) {
             dotted: dotted,
             bornCity: fromCity,
             activeCity: toCity,
-            poetDetailName: poet.poetDetailName,
             bornGovIds: bornGovIds,
-            activeGovIds: activeGovIds
-          });
-          primeObjWithPoetData(line, data);
+            activeGovIds: activeGovIds,
+            ...poetPrimedData(data, poetId)
+          };
           data.lines.push(line);
         }
       }

--- a/js/calcData/data.js
+++ b/js/calcData/data.js
@@ -1,103 +1,196 @@
 import { getPoet, getCity, getGenres, getGovs } from "./getters.js";
 
 /**
- * Hydrates the raw CSV rows in place (ids and coordinates become numbers, dates
- * become negative years) and builds every derived lookup the map needs.
- * @param {Data} data
+ * Hydrates the raw CSV rows (ids and coordinates become numbers, dates become
+ * negative years) and builds everything the map draws from.
+ *
+ * Assembled and returned rather than written into a bag the caller supplies.
+ * The three stages below are a real dependency order — the lookups are
+ * regroupings of the CSVs, and the travel lines and control bar lists are
+ * derived through those lookups — so each is complete before the next reads it,
+ * and no half-built Data is ever visible.
+ * @param {RawCsvs} raw
+ * @returns {Data}
  */
-export function initializeData(data) {
-  // Papa Parse hands back every field as a string. These arrays are aliased as
-  // any[] for the hydration pass below; everywhere else in the codebase they
-  // are the hydrated types declared in types/globals.d.ts.
-  /** @type {any[]} */ const rawGenres = data.genres;
-  /** @type {any[]} */ const rawCities = data.cities;
-  /** @type {any[]} */ const rawCityPolitics = data.cityPolitics;
-  /** @type {any[]} */ const rawPoetCities = data.poetCities;
-  /** @type {any[]} */ const rawGeopoetCities = data.geopoetCities;
-  /** @type {any[]} */ const rawRegions = data.regions;
-  /** @type {any[]} */ const rawDates = data.dates;
-  /** @type {any[]} */ const rawGovernments = data.governments;
+export function initializeData(raw) {
+  const csvs = hydrate(raw);
+  const lookups = createLookups(csvs);
 
-  rawGenres.forEach(genre => (genre.genreId = parseInt(genre.genreId)));
-  rawCities.forEach(city => (city.cityId = parseInt(city.cityId)));
-  rawCities.forEach(city => (city.regionId = parseInt(city.regionId)));
-  rawCities.forEach(city => (city.lat = parseFloat(city.lat)));
-  rawCities.forEach(city => (city.long = parseFloat(city.long)));
-  rawCityPolitics.forEach(city => (city.cityId = parseInt(city.cityId)));
-  rawCityPolitics.forEach(city => (city.governmentId = parseInt(city.governmentId)));
-  rawCityPolitics.forEach(cp => (cp.date = -1 * parseInt(cp.date)));
-  rawPoetCities.forEach(poetCity => (poetCity.relationshipId = parseInt(poetCity.relationshipId)));
-  rawPoetCities.forEach(poetCity => (poetCity.poetId = parseInt(poetCity.poetId)));
-  rawPoetCities.forEach(poetCity => (poetCity.cityId = parseInt(poetCity.cityId)));
-  rawGeopoetCities.forEach(poetCity => (poetCity.poetId = parseInt(poetCity.poetId)));
-  rawGeopoetCities.forEach(poetCity => (poetCity.imaginaryid = parseInt(poetCity.imaginaryid)));
-  rawGeopoetCities.forEach(poetCity => (poetCity.cityId = parseInt(poetCity.cityId)));
-  rawRegions.forEach(region => (region.regionId = parseInt(region.regionId)));
-  rawRegions.forEach(region => (region.bigRegionId = parseInt(region.bigRegionId)));
-  rawDates.forEach(date => {
-    date.poetId = parseInt(date.poetId);
-    date.date = -1 * parseInt(date.date);
-  });
-  rawGovernments.forEach(gov => (gov.governmentId = parseInt(gov.governmentId)));
+  // Two passes that write back onto the CSV rows, because a row is what the
+  // rest of the code passes around: a city gains its big region, a poet the
+  // range of dates attested for them.
+  addBigRegionIdToCities(csvs, lookups);
+  addDatesToPoets(lookups);
 
-  // create useful maps by key
-  data.citiesById = {};
-  for (const city of data.cities) {
-    data.citiesById[city.cityId] = city;
-  }
-  data.poetsById = {};
-  for (const poet of data.poets) {
-    data.poetsById[poet.poetId] = poet;
-  }
-  data.genresByPoetId = {};
-  for (const genre of data.genres) {
-    if (!data.genresByPoetId[genre.poetId]) {
-      data.genresByPoetId[genre.poetId] = [];
-    }
-    data.genresByPoetId[genre.poetId].push(genre);
-  }
-  data.regionsById = {};
-  for (const region of data.regions) {
-    data.regionsById[region.regionId] = region;
-  }
-  addBigRegionIdToCities(data);
-  addDatesToPoets(data);
+  const derived = derive(csvs, lookups);
 
-  createGovsByCityId(data);
-  createGovsById(data);
-  createGenresByGenreId(data);
-  createGenreIdsWithNames(data);
-  createGeoImaginaryPoets(data);
-  createLines(data);
-  keyLines(data);
-  createTravelPoets(data);
-  createTravelCities(data);
-  createRegionsForInterface(data);
-  // Assigned onto the rows, not built into them, which is the one place this
-  // commit leaves a type ahead of the object it describes.
+  // Assigned onto the rows, not built into them, which is the one place left
+  // where a type runs ahead of the object it describes: until this line, a
+  // PoetCity is missing the four PoetPrimed fields its type says it has.
   //
   // A travel line could be built complete because createLines() makes it. These
-  // rows are made by Papa Parse and mutated in place ever since, and createLines
-  // has already captured these exact objects as bornPc and activePc, so handing
+  // rows are made by Papa Parse and mutated in place ever since, and derive()
+  // above has captured these exact objects as bornPc and activePc, so handing
   // back primed copies would leave those references pointing at the originals.
   //
-  // Until this runs, then, a PoetCity is missing the four PoetPrimed fields its
-  // type says it has. The "every row is primed with its poet's display data"
-  // test in tests/initializeData.test.js is what currently holds that together.
-  data.poetCities.forEach(pc => Object.assign(pc, poetPrimedData(data, pc.poetId)));
-  data.geopoetCities.forEach(pc => Object.assign(pc, poetPrimedData(data, pc.poetId)));
-  sortPoetCities(data, data.poetCities);
-  sortPoetCities(data, data.geopoetCities);
+  // Last, and in this order: createLines() reads poetCities in file order, so
+  // sorting them any earlier would reorder the poets on every travel arc. The
+  // "every row is primed with its poet's display data" test in
+  // tests/initializeData.test.js is what holds the claim above together.
+  for (const pc of [...csvs.poetCities, ...csvs.geopoetCities]) {
+    Object.assign(pc, poetPrimedData(lookups, pc.poetId));
+  }
+  sortPoetCities(lookups, csvs.poetCities);
+  sortPoetCities(lookups, csvs.geopoetCities);
+
+  return { ...csvs, ...lookups, ...derived };
 }
 
 /**
- * @param {Data} data
- * @param {(PoetCity | GeoPoetCity)[]} poetCities
+ * Papa Parse hands back every field as a string. This parses the numeric ones in
+ * place and hands the rows back under their hydrated types, which is the only
+ * form the rest of the codebase ever sees.
+ *
+ * The one cast is that reinterpretation itself: these are the same objects,
+ * described by RawCsvs going in and by Csvs coming out.
+ * @param {RawCsvs} raw
+ * @returns {Csvs}
  */
-function sortPoetCities(data, poetCities) {
+function hydrate(raw) {
+  /** @type {Record<keyof RawCsvs, any[]>} */
+  const rows = raw;
+
+  rows.genres.forEach(genre => (genre.genreId = parseInt(genre.genreId)));
+  rows.cities.forEach(city => (city.cityId = parseInt(city.cityId)));
+  rows.cities.forEach(city => (city.regionId = parseInt(city.regionId)));
+  rows.cities.forEach(city => (city.lat = parseFloat(city.lat)));
+  rows.cities.forEach(city => (city.long = parseFloat(city.long)));
+  rows.cityPolitics.forEach(city => (city.cityId = parseInt(city.cityId)));
+  rows.cityPolitics.forEach(city => (city.governmentId = parseInt(city.governmentId)));
+  rows.cityPolitics.forEach(cp => (cp.date = -1 * parseInt(cp.date)));
+  rows.poetCities.forEach(poetCity => (poetCity.relationshipId = parseInt(poetCity.relationshipId)));
+  rows.poetCities.forEach(poetCity => (poetCity.poetId = parseInt(poetCity.poetId)));
+  rows.poetCities.forEach(poetCity => (poetCity.cityId = parseInt(poetCity.cityId)));
+  rows.geopoetCities.forEach(poetCity => (poetCity.poetId = parseInt(poetCity.poetId)));
+  rows.geopoetCities.forEach(poetCity => (poetCity.imaginaryid = parseInt(poetCity.imaginaryid)));
+  rows.geopoetCities.forEach(poetCity => (poetCity.cityId = parseInt(poetCity.cityId)));
+  rows.regions.forEach(region => (region.regionId = parseInt(region.regionId)));
+  rows.regions.forEach(region => (region.bigRegionId = parseInt(region.bigRegionId)));
+  rows.dates.forEach(date => {
+    date.poetId = parseInt(date.poetId);
+    date.date = -1 * parseInt(date.date);
+  });
+  rows.governments.forEach(gov => (gov.governmentId = parseInt(gov.governmentId)));
+
+  return rows;
+}
+
+/**
+ * The by-id regroupings of the CSVs. Each reads one CSV and nothing else, so
+ * they are all built together, before anything that needs them.
+ * @param {Csvs} csvs
+ * @returns {Lookups}
+ */
+function createLookups(csvs) {
+  return {
+    citiesById: keyById(csvs.cities, city => city.cityId),
+    poetsById: keyById(csvs.poets, poet => poet.poetId),
+    regionsById: keyById(csvs.regions, region => region.regionId),
+    genresByPoetId: groupById(csvs.genres, genre => genre.poetId, identity),
+    genresByGenreId: createGenresByGenreId(csvs.genres),
+    govsByCityId: groupById(csvs.cityPolitics, cityPolitics => cityPolitics.cityId, identity),
+    govsById: keyById(
+      csvs.governments,
+      gov => gov.governmentId,
+      gov => gov.government
+    ),
+    datesByPoetId: groupById(
+      csvs.dates,
+      date => date.poetId,
+      date => date.date
+    )
+  };
+}
+
+/**
+ * The travel lines and the control bar lists. Built in the order they were
+ * before, so that anything they report about bad data is still reported in the
+ * same order.
+ * @param {Csvs} csvs
+ * @param {Lookups} lookups
+ * @returns {Derived}
+ */
+function derive(csvs, lookups) {
+  const genreIdsWithName = createGenreIdsWithNames(lookups);
+  const geoImaginaryPoets = createGeoImaginaryPoets(csvs, lookups);
+  const { lines, poetsWithUnknownTravel } = createLines(csvs, lookups);
+
+  return {
+    genreIdsWithName,
+    geoImaginaryPoets,
+    lines,
+    poetsWithUnknownTravel,
+    linesByPoetId: groupById(lines, line => line.poetId, identity),
+    linesByBornCityId: groupById(lines, line => line.bornCityId, identity),
+    linesByActiveCityId: groupById(lines, line => line.activeCityId, identity),
+    travelPoets: createTravelPoets(lines, lookups),
+    travelCities: createTravelCities(lines, lookups),
+    regionsForInterface: createRegionsForInterface(csvs)
+  };
+}
+
+/**
+ * @template T
+ * @param {T} value
+ * @returns {T}
+ */
+function identity(value) {
+  return value;
+}
+
+/**
+ * The last row wins, as it did when these were written out one loop at a time.
+ * @template T, V
+ * @param {T[]} rows
+ * @param {(row: T) => number} idOf
+ * @param {(row: T) => V} [valueOf] defaults to the row itself
+ * @returns {Record<number, V>}
+ */
+function keyById(rows, idOf, valueOf) {
+  /** @type {Record<number, V>} */
+  const byId = {};
+  for (const row of rows) {
+    byId[idOf(row)] = valueOf ? valueOf(row) : /** @type {any} */ (row);
+  }
+  return byId;
+}
+
+/**
+ * @template T, V
+ * @param {T[]} rows
+ * @param {(row: T) => number} idOf
+ * @param {(row: T) => V} valueOf
+ * @returns {Record<number, V[]>}
+ */
+function groupById(rows, idOf, valueOf) {
+  /** @type {Record<number, V[]>} */
+  const byId = {};
+  for (const row of rows) {
+    const id = idOf(row);
+    if (!byId[id]) byId[id] = [];
+    byId[id].push(valueOf(row));
+  }
+  return byId;
+}
+
+/**
+ * @param {Lookups} lookups
+ * @param {(PoetCity | GeoPoetCity)[]} poetCities mutated in place
+ */
+function sortPoetCities(lookups, poetCities) {
   poetCities.sort((a, b) => {
-    const poetA = getPoet(data, a.poetId);
-    const poetB = getPoet(data, b.poetId);
+    const poetA = getPoet(lookups, a.poetId);
+    const poetB = getPoet(lookups, b.poetId);
     return sortAlphabetically(poetA.poetname, poetB.poetname);
   });
 }
@@ -108,12 +201,12 @@ function sortPoetCities(data, poetCities) {
  *
  * Returned rather than assigned, so a travel line can be built with these fields
  * already on it instead of existing briefly without them.
- * @param {Data} data
+ * @param {Lookups} lookups
  * @param {number} poetId
  * @returns {PoetPrimed}
  */
-function poetPrimedData(data, poetId) {
-  const poet = getPoet(data, poetId);
+function poetPrimedData(lookups, poetId) {
+  const poet = getPoet(lookups, poetId);
 
   let poetDetailName = "";
   if (poet.poetDetailName) poetDetailName = poet.poetDetailName;
@@ -131,7 +224,7 @@ function poetPrimedData(data, poetId) {
     poetDetailName,
     poetDates,
     poetSources,
-    poetGenres: getGenres(data, poetId)
+    poetGenres: getGenres(lookups, poetId)
       .map(genre => genre.genre)
       .join(", ")
   };
@@ -152,58 +245,45 @@ export function sortAlphabetically(a, b) {
   return a < b ? -1 : 1;
 }
 
-/** @param {Data} data */
-function createGovsByCityId(data) {
-  data.govsByCityId = {};
-  for (const cp of data.cityPolitics) {
-    if (!data.govsByCityId[cp.cityId]) data.govsByCityId[cp.cityId] = [];
-    data.govsByCityId[cp.cityId].push(cp);
-  }
-}
-
-/** @param {Data} data */
-function createGovsById(data) {
-  data.govsById = {};
-  for (const gov of data.governments) {
-    data.govsById[gov.governmentId] = gov.government;
-  }
-}
-
-/** @param {Data} data */
-function addBigRegionIdToCities(data) {
-  for (const city of data.cities) {
-    if (city.regionId && data.regionsById[city.regionId] && data.regionsById[city.regionId].bigRegionId) {
-      city.bigRegionId = data.regionsById[city.regionId].bigRegionId;
+/**
+ * @param {Csvs} csvs cities are mutated in place
+ * @param {Lookups} lookups
+ */
+function addBigRegionIdToCities(csvs, lookups) {
+  for (const city of csvs.cities) {
+    if (city.regionId && lookups.regionsById[city.regionId] && lookups.regionsById[city.regionId].bigRegionId) {
+      city.bigRegionId = lookups.regionsById[city.regionId].bigRegionId;
     }
   }
 }
 
-/** @param {Data} data */
-function addDatesToPoets(data) {
-  data.datesByPoetId = {};
-  for (const date of data.dates) {
-    if (!data.datesByPoetId[date.poetId]) data.datesByPoetId[date.poetId] = [];
-    data.datesByPoetId[date.poetId].push(date.date);
-  }
-  for (const poetIdStr in data.datesByPoetId) {
+/**
+ * @param {Lookups} lookups poets are mutated in place
+ */
+function addDatesToPoets(lookups) {
+  for (const poetIdStr in lookups.datesByPoetId) {
     const poetId = Number(poetIdStr);
-    const poet = getPoet(data, poetId);
+    const poet = getPoet(lookups, poetId);
     if (poet) {
-      poet.minDate = Math.min(...data.datesByPoetId[poetId]);
-      poet.maxDate = Math.max(...data.datesByPoetId[poetId]);
+      poet.minDate = Math.min(...lookups.datesByPoetId[poetId]);
+      poet.maxDate = Math.max(...lookups.datesByPoetId[poetId]);
     }
   }
 }
 
-/** @param {Data} data */
-function createGenresByGenreId(data) {
-  data.genresByGenreId = {};
-  for (const genre of data.genres) {
+/**
+ * @param {Genre[]} genres
+ * @returns {Record<number, string>}
+ */
+function createGenresByGenreId(genres) {
+  /** @type {Record<number, string>} */
+  const genresByGenreId = {};
+  for (const genre of genres) {
     const genreName = genre.genre;
-    if (!data.genresByGenreId[genre.genreId]) {
-      data.genresByGenreId[genre.genreId] = genreName;
+    if (!genresByGenreId[genre.genreId]) {
+      genresByGenreId[genre.genreId] = genreName;
     } else {
-      const existingGenreName = data.genresByGenreId[genre.genreId];
+      const existingGenreName = genresByGenreId[genre.genreId];
       if (genreName !== existingGenreName) {
         console.log(
           `${genreName} has genreId ${genre.genreId} but does not match existing ${existingGenreName}. Source translation: "${genre.source_translation}"`
@@ -211,21 +291,26 @@ function createGenresByGenreId(data) {
       }
     }
   }
+  return genresByGenreId;
 }
 
 /**
  * @param {Iterable<number>} poetIds
- * @param {Data} data
+ * @param {Lookups} lookups
  * @returns {FilterOption[]}
  */
-function createAlphabetizedListOfPoetsFromIds(poetIds, data) {
+function createAlphabetizedListOfPoetsFromIds(poetIds, lookups) {
   return Array.from(poetIds)
-    .map(poetId => ({ id: poetId, name: getPoet(data, poetId).poetDetailName }))
+    .map(poetId => ({ id: poetId, name: getPoet(lookups, poetId).poetDetailName }))
     .sort((a, b) => sortAlphabetically(a.name, b.name));
 }
 
-/** @param {Data} data */
-function createGeoImaginaryPoets(data) {
+/**
+ * @param {Csvs} csvs
+ * @param {Lookups} lookups
+ * @returns {FilterOption[]}
+ */
+function createGeoImaginaryPoets(csvs, lookups) {
   const poetIdsToOmit = [
     151, // Aristotle
     33, // Castorion
@@ -234,13 +319,14 @@ function createGeoImaginaryPoets(data) {
     149 // Pindar
   ];
 
-  const poetIds = new Set(data.geopoetCities.map(pc => pc.poetId).filter(poetId => !poetIdsToOmit.includes(poetId)));
+  const poetIds = new Set(csvs.geopoetCities.map(pc => pc.poetId).filter(poetId => !poetIdsToOmit.includes(poetId)));
 
-  data.geoImaginaryPoets = createAlphabetizedListOfPoetsFromIds(poetIds, data);
+  const geoImaginaryPoets = createAlphabetizedListOfPoetsFromIds(poetIds, lookups);
 
   // put sappho / alcaeus at end of array
   const sappAlcPoetId = 157;
-  putPoetIdAtEnd(data.geoImaginaryPoets, sappAlcPoetId);
+  putPoetIdAtEnd(geoImaginaryPoets, sappAlcPoetId);
+  return geoImaginaryPoets;
 }
 
 /**
@@ -263,28 +349,39 @@ function putPoetIdAtEnd(array, poetId) {
   }
 }
 
-/** @param {Data} data */
-function createTravelPoets(data) {
+/**
+ * @param {Line[]} lines
+ * @param {Lookups} lookups
+ * @returns {FilterOption[]}
+ */
+function createTravelPoets(lines, lookups) {
   // why do we omit these guys?
   const poetIdsToOmit = [
     29, // Oeniades
     38 // Aristonous
   ];
 
-  const poetIds = new Set(data.lines.map(line => line.poetId).filter(poetId => !poetIdsToOmit.includes(poetId)));
-  data.travelPoets = createAlphabetizedListOfPoetsFromIds(poetIds, data);
+  const poetIds = new Set(lines.map(line => line.poetId).filter(poetId => !poetIdsToOmit.includes(poetId)));
+  return createAlphabetizedListOfPoetsFromIds(poetIds, lookups);
 }
 
-/** @param {Data} data */
-function createTravelCities(data) {
-  const cityIds = new Set(data.lines.flatMap(line => [line.bornCityId, line.activeCityId]));
-  data.travelCities = Array.from(cityIds)
-    .map(cityId => ({ id: cityId, name: getCity(data, cityId).cityname }))
+/**
+ * @param {Line[]} lines
+ * @param {Lookups} lookups
+ * @returns {FilterOption[]}
+ */
+function createTravelCities(lines, lookups) {
+  const cityIds = new Set(lines.flatMap(line => [line.bornCityId, line.activeCityId]));
+  return Array.from(cityIds)
+    .map(cityId => ({ id: cityId, name: getCity(lookups, cityId).cityname }))
     .sort((a, b) => sortAlphabetically(a.name, b.name));
 }
 
-/** @param {Data} data */
-function createRegionsForInterface(data) {
+/**
+ * @param {Csvs} csvs
+ * @returns {FilterOption[]}
+ */
+function createRegionsForInterface(csvs) {
   const regionIdsToOmit = [
     27, // Aeolis
     21, // Asia
@@ -300,7 +397,7 @@ function createRegionsForInterface(data) {
     20, // Thrace
     28 // Troad
   ];
-  data.regionsForInterface = data.regions
+  return csvs.regions
     .filter(region => !regionIdsToOmit.includes(region.regionId))
     .map(region => ({ id: region.regionId, name: region.regionname }))
     .sort((a, b) => sortAlphabetically(a.name, b.name));
@@ -308,13 +405,17 @@ function createRegionsForInterface(data) {
 
 /**
  * Builds one travel line per (birthplace, place-of-activity) pair. Poets with
- * several attested birthplaces therefore yield several lines.
- * @param {Data} data
+ * several attested birthplaces therefore yield several lines. Poets with a
+ * birthplace but nowhere to go are handed back separately, for the places
+ * control bar to list.
+ * @param {Csvs} csvs
+ * @param {Lookups} lookups
+ * @returns {{ lines: Line[], poetsWithUnknownTravel: FilterOption[] }}
  */
-function createLines(data) {
+function createLines(csvs, lookups) {
   /** @type {Record<number, { bornPcs: PoetCity[], activePcs: PoetCity[] }>} */
   const poets = {};
-  for (const pc of data.poetCities) {
+  for (const pc of csvs.poetCities) {
     if (!poets[pc.poetId])
       poets[pc.poetId] = {
         bornPcs: [],
@@ -324,25 +425,26 @@ function createLines(data) {
     else if (pc.relationshipId === 1) poets[pc.poetId].bornPcs.push(pc);
   }
 
-  data.poetsWithUnknownTravel = [];
-  data.lines = [];
+  /** @type {FilterOption[]} */
+  const poetsWithUnknownTravel = [];
+  /** @type {Line[]} */
+  const lines = [];
   for (const poetIdStr in poets) {
     const poetId = parseInt(poetIdStr);
     const poet = poets[poetId];
     if (poet.bornPcs.length === 0 || poet.activePcs.length === 0) {
-      const poet = getPoet(data, poetId);
-      const poetDetailName = poet.poetDetailName;
-      data.poetsWithUnknownTravel.push({ id: poetId, name: poetDetailName });
+      const poetDetailName = getPoet(lookups, poetId).poetDetailName;
+      poetsWithUnknownTravel.push({ id: poetId, name: poetDetailName });
     } else {
       for (const bornPc of poet.bornPcs) {
         for (const activePc of poet.activePcs) {
           const dotted = bornPc.dotted === "dotted" || activePc.dotted === "dotted";
-          const fromCity = getCity(data, bornPc.cityId);
-          const toCity = getCity(data, activePc.cityId);
-          const poetDates = data.datesByPoetId[poetId];
+          const fromCity = getCity(lookups, bornPc.cityId);
+          const toCity = getCity(lookups, activePc.cityId);
+          const poetDates = lookups.datesByPoetId[poetId];
           const bornGovIds = [
             ...new Set(
-              getGovs(data, bornPc.cityId)
+              getGovs(lookups, bornPc.cityId)
                 .filter(gov => poetDates.includes(gov.date))
                 .map(gov => gov.governmentId)
                 .flatMap(govId => convertMixedGovIds(govId))
@@ -350,7 +452,7 @@ function createLines(data) {
           ];
           const activeGovIds = [
             ...new Set(
-              getGovs(data, activePc.cityId)
+              getGovs(lookups, activePc.cityId)
                 .filter(gov => poetDates.includes(gov.date))
                 .map(gov => gov.governmentId)
                 .flatMap(govId => convertMixedGovIds(govId))
@@ -368,14 +470,15 @@ function createLines(data) {
             activeCity: toCity,
             bornGovIds: bornGovIds,
             activeGovIds: activeGovIds,
-            ...poetPrimedData(data, poetId)
+            ...poetPrimedData(lookups, poetId)
           };
-          data.lines.push(line);
+          lines.push(line);
         }
       }
     }
   }
-  data.poetsWithUnknownTravel.sort((a, b) => sortAlphabetically(a.name, b.name));
+  poetsWithUnknownTravel.sort((a, b) => sortAlphabetically(a.name, b.name));
+  return { lines, poetsWithUnknownTravel };
 }
 
 /**
@@ -394,41 +497,17 @@ function convertMixedGovIds(govId) {
   } else return [govId];
 }
 
-/** @param {Data} data */
-function keyLines(data) {
-  data.linesByPoetId = {};
-  for (const line of data.lines) {
-    if (!data.linesByPoetId[line.poetId]) {
-      data.linesByPoetId[line.poetId] = [];
-    }
-    data.linesByPoetId[line.poetId].push(line);
-  }
-
-  data.linesByBornCityId = {};
-  for (const line of data.lines) {
-    if (!data.linesByBornCityId[line.bornCityId]) {
-      data.linesByBornCityId[line.bornCityId] = [];
-    }
-    data.linesByBornCityId[line.bornCityId].push(line);
-  }
-
-  data.linesByActiveCityId = {};
-  for (const line of data.lines) {
-    if (!data.linesByActiveCityId[line.activeCityId]) {
-      data.linesByActiveCityId[line.activeCityId] = [];
-    }
-    data.linesByActiveCityId[line.activeCityId].push(line);
-  }
-}
-
-/** @param {Data} data */
-function createGenreIdsWithNames(data) {
+/**
+ * @param {Lookups} lookups
+ * @returns {FilterOption[]}
+ */
+function createGenreIdsWithNames(lookups) {
   const genresToOmit = [
     1, // Diaskeue
     31 // Possibly lyric
   ];
-  data.genreIdsWithName = Object.keys(data.genresByGenreId)
-    .map(id => ({ id: Number(id), name: data.genresByGenreId[Number(id)] }))
+  return Object.keys(lookups.genresByGenreId)
+    .map(id => ({ id: Number(id), name: lookups.genresByGenreId[Number(id)] }))
     .filter(genre => !genresToOmit.includes(genre.id))
     .sort((a, b) => sortAlphabetically(a.name, b.name));
 }

--- a/js/calcData/getters.js
+++ b/js/calcData/getters.js
@@ -1,43 +1,43 @@
 /**
- * @param {Data} data
+ * @param {Lookups} lookups
  * @param {number} poetId
  * @returns {Poet}
  */
-export function getPoet(data, poetId) {
-  const poet = data.poetsById[poetId];
+export function getPoet(lookups, poetId) {
+  const poet = lookups.poetsById[poetId];
   if (!poet) console.log(`poetId ${poetId} does not exist in poetsById`);
   return poet;
 }
 
 /**
- * @param {Data} data
+ * @param {Lookups} lookups
  * @param {number} poetId
  * @returns {Genre[]}
  */
-export function getGenres(data, poetId) {
-  if (data.genresByPoetId[poetId]) return data.genresByPoetId[poetId];
+export function getGenres(lookups, poetId) {
+  if (lookups.genresByPoetId[poetId]) return lookups.genresByPoetId[poetId];
   else return [];
 }
 
 /**
- * @param {Data} data
+ * @param {Lookups} lookups
  * @param {number} cityId
  * @returns {City}
  */
-export function getCity(data, cityId) {
-  const city = data.citiesById[cityId];
+export function getCity(lookups, cityId) {
+  const city = lookups.citiesById[cityId];
   if (!city) console.log(`cityId ${cityId} does not exist in citiesById`);
   return city;
 }
 
 /**
- * @param {Data} data
+ * @param {Lookups} lookups
  * @param {number} cityId
  * @returns {CityPolitics[]}
  */
-export function getGovs(data, cityId) {
-  if (data.govsByCityId[cityId]) {
-    return data.govsByCityId[cityId];
+export function getGovs(lookups, cityId) {
+  if (lookups.govsByCityId[cityId]) {
+    return lookups.govsByCityId[cityId];
   }
   console.log(`cityId ${cityId} does not exist in govsByCityId`);
   return [];

--- a/js/calcData/getters.js
+++ b/js/calcData/getters.js
@@ -43,9 +43,13 @@ export function getGovs(lookups, cityId) {
   return [];
 }
 
-/** The filters the places and geographical imaginary control bars offer. */
+/** The filters the places control bar offers. */
 /** @type {PlacesFilterType[]} */
-export const PLACES_FILTER_TYPES = ["all", "relationship", "poet", "genre"];
+export const PLACES_FILTER_TYPES = ["relationship", "poet", "genre"];
+
+/** The filters the geographical imaginary control bar offers. */
+/** @type {GeoFilterType[]} */
+export const GEO_FILTER_TYPES = ["all", "poet"];
 
 /** The filters the travel control bar offers. */
 /** @type {TravelFilterType[]} */
@@ -56,8 +60,8 @@ export const TRAVEL_FILTER_TYPES = ["all", "poet", "destination", "smallregion",
  * checking the type against the filters the given map actually offers.
  *
  * Validating here rather than trusting the string is what lets callers switch
- * exhaustively over four or six cases instead of eight, with no branch for a
- * filter their map cannot produce. selectedId always comes from a radio button
+ * exhaustively over two, three or six cases instead of eight, with no branch for
+ * a filter their map cannot produce. selectedId always comes from a radio button
  * this code generated, so a mismatch means the interface builders and the map
  * modes have got out of step.
  * @template {MapFilterType} T
@@ -83,6 +87,14 @@ function getFilter(state, allowed, mapName) {
  */
 export function getPlacesFilter(state) {
   return getFilter(state, PLACES_FILTER_TYPES, "places");
+}
+
+/**
+ * @param {State} state
+ * @returns {[GeoFilterType, number]}
+ */
+export function getGeoFilter(state) {
+  return getFilter(state, GEO_FILTER_TYPES, "geographical imaginary");
 }
 
 /**

--- a/js/calcData/parseCsvs.js
+++ b/js/calcData/parseCsvs.js
@@ -1,4 +1,25 @@
 /**
+ * Every CSV the map loads, against the key it is loaded onto.
+ *
+ * One record rather than ten calls, so the mapping is total: a key of RawCsvs
+ * with no file here, or a key here that RawCsvs does not declare, is a type
+ * error. Passing the wrong filename for a key used to typecheck perfectly.
+ * @type {Record<keyof RawCsvs, string>}
+ */
+const CSV_FILES = {
+  regions: "./dataFiles/regions.csv",
+  cities: "./dataFiles/cities.csv",
+  poetCities: "./dataFiles/poets_cities.csv",
+  poets: "./dataFiles/poets.csv",
+  genres: "./dataFiles/genres.csv",
+  geopoetCities: "./dataFiles/geographical_imaginary_group.csv",
+  cityPolitics: "./dataFiles/city_politics.csv",
+  bigRegions: "./dataFiles/big_regions.csv",
+  dates: "./dataFiles/dates.csv",
+  governments: "./dataFiles/governments.csv"
+};
+
+/**
  * @param {string} file raw CSV text
  * @returns {Promise<{ data: any[] }>}
  */
@@ -9,33 +30,28 @@ function papaParsePromise(file) {
 }
 
 /**
- * Loads every CSV in dataFiles/ onto the shared data bag. Papa Parse yields
- * every field as a string; initializeData() hydrates the numeric ones.
- * @param {Data} data
- * @returns {Promise<void[]>}
+ * Loads every CSV in dataFiles/. Papa Parse yields every field as a string;
+ * initializeData() hydrates the numeric ones.
+ * @returns {Promise<RawCsvs>}
  */
-export function parseCsvs(data) {
-  return Promise.all([
-    parseCsv(data, "regions", "./dataFiles/regions.csv"),
-    parseCsv(data, "cities", "./dataFiles/cities.csv"),
-    parseCsv(data, "poetCities", "./dataFiles/poets_cities.csv"),
-    parseCsv(data, "poets", "./dataFiles/poets.csv"),
-    parseCsv(data, "genres", "./dataFiles/genres.csv"),
-    parseCsv(data, "geopoetCities", "./dataFiles/geographical_imaginary_group.csv"),
-    parseCsv(data, "cityPolitics", "./dataFiles/city_politics.csv"),
-    parseCsv(data, "bigRegions", "./dataFiles/big_regions.csv"),
-    parseCsv(data, "dates", "./dataFiles/dates.csv"),
-    parseCsv(data, "governments", "./dataFiles/governments.csv")
-  ]);
+export async function parseCsvs() {
+  /** @type {Record<string, any[]>} */
+  const raw = {};
+  await Promise.all(
+    Object.entries(CSV_FILES).map(async ([key, filename]) => {
+      raw[key] = await parseCsv(filename);
+    })
+  );
+  // CSV_FILES is declared as a Record over every key of RawCsvs, so the loop
+  // above has filled all of them. That is the whole of what this asserts.
+  return /** @type {RawCsvs} */ (/** @type {unknown} */ (raw));
 }
 
 /**
- * @param {Data} data
- * @param {keyof Data} parameter which key on the data bag to populate
  * @param {string} filename
- * @returns {Promise<void>}
+ * @returns {Promise<any[]>}
  */
-async function parseCsv(data, parameter, filename) {
+async function parseCsv(filename) {
   const response = await fetch(filename);
   // fetch resolves for a 404, so without this the error page is parsed as CSV
   // and the map draws nothing, with no indication why.
@@ -46,5 +62,5 @@ async function parseCsv(data, parameter, filename) {
   }
   const csv = await response.text();
   const parsed = await papaParsePromise(csv);
-  data[parameter] = parsed.data;
+  return parsed.data;
 }

--- a/js/popups/popups.js
+++ b/js/popups/popups.js
@@ -8,7 +8,7 @@ import { createNumberedListOfPoets, createDetailedListOfPoets, renderReference }
  * places / geographical-imaginary maps is showing.
  * @param {State} state
  * @param {Data} data
- * @param {Bubble} bubble
+ * @param {BubbleContents} bubble
  * @returns {string}
  */
 export function createPopupHtml(state, data, bubble) {
@@ -32,7 +32,7 @@ export function createPopupHtml(state, data, bubble) {
 /**
  * The ACTIVITY popup, which splits a city's poets into natives and incomers.
  * @param {Data} data
- * @param {Bubble} bubble
+ * @param {BubbleContents} bubble
  * @returns {string}
  */
 function createActivePopupHtml(data, bubble) {
@@ -89,7 +89,7 @@ function createActivePopupHtml(data, bubble) {
 /**
  * @param {State} state
  * @param {Data} data
- * @param {Bubble} bubble
+ * @param {BubbleContents} bubble
  * @param {PlacesFilterType} type
  * @param {number} num
  * @returns {string}
@@ -106,7 +106,7 @@ function createHeader(state, data, bubble, type, num) {
 /**
  * @param {State} state
  * @param {Data} data
- * @param {Bubble} bubble
+ * @param {BubbleContents} bubble
  * @param {PlacesFilterType} type
  * @param {number} num
  * @returns {string}
@@ -162,7 +162,7 @@ function createDetailedGeoListOfPoets(poets) {
  * @param {State} state
  * @param {Data} data
  * @param {string} cityname already upper-cased
- * @param {Bubble} bubble
+ * @param {BubbleContents} bubble
  * @param {PlacesFilterType} type
  * @param {number} num
  * @returns {string}
@@ -213,7 +213,7 @@ function createPlacesModeTitle(data, cityname, type, num) {
 /**
  * @param {State} state
  * @param {Data} data
- * @param {Bubble} bubble
+ * @param {BubbleContents} bubble
  * @param {PlacesFilterType} type
  * @param {number} num
  * @returns {string}

--- a/js/popups/popups.js
+++ b/js/popups/popups.js
@@ -12,15 +12,18 @@ import { createNumberedListOfPoets, createDetailedListOfPoets, renderReference }
  * @returns {string}
  */
 export function createPopupHtml(state, data, bubble) {
-  const [type, num] = getPlacesFilter(state);
   switch (state.currentMapMode) {
-    case "placesMode":
+    case "placesMode": {
+      const [type, num] = getPlacesFilter(state);
       // Relationship 3 is "activity", which gets its own native/non-native split.
       return type === "relationship" && num === 3
         ? createActivePopupHtml(data, bubble)
-        : createPlacesPopupHtml(state, data, bubble, type, num);
+        : createPlacesPopupHtml(data, bubble, type, num);
+    }
     case "geoimaginaryMode":
-      return createGeoImaginaryPopupHtml(state, data, bubble, type, num);
+      // Its title counts references rather than naming a filter, so unlike the
+      // places map it does not need to know which button is selected.
+      return createGeoImaginaryPopupHtml(bubble);
     case "travelMode":
       // The travel map draws arcs and builds its popups in travelPopups.js.
       throw new Error("createPopupHtml is not used by the travel map");
@@ -87,16 +90,11 @@ function createActivePopupHtml(data, bubble) {
 }
 
 /**
- * @param {State} state
- * @param {Data} data
- * @param {BubbleContents} bubble
- * @param {PlacesFilterType} type
- * @param {number} num
+ * @param {string} cityname already upper-cased
+ * @param {string} title
  * @returns {string}
  */
-function createHeader(state, data, bubble, type, num) {
-  const cityname = bubble.city.infowindowName.toUpperCase();
-  const title = createTitle(state, data, cityname, bubble, type, num);
+function createHeader(cityname, title) {
   return `
     <h3 style="color:${LYRIC_GREY}">${cityname}</h3>
     <h5 style="color:${LYRIC_GREY}">${title}</h5>
@@ -104,17 +102,17 @@ function createHeader(state, data, bubble, type, num) {
 }
 
 /**
- * @param {State} state
  * @param {Data} data
  * @param {BubbleContents} bubble
  * @param {PlacesFilterType} type
  * @param {number} num
  * @returns {string}
  */
-function createPlacesPopupHtml(state, data, bubble, type, num) {
+function createPlacesPopupHtml(data, bubble, type, num) {
+  const cityname = bubble.city.infowindowName.toUpperCase();
   const poetCities = bubble.poetCities;
   return `
-    ${createHeader(state, data, bubble, type, num)}
+    ${createHeader(cityname, createPlacesModeTitle(data, cityname, type, num))}
     ${createNumberedListOfPoets(poetCities.map(pc => pc.poetDetailName))}
     <h4 style="color:${LYRIC_GREY}">DETAILS</h4>
     ${createDetailedListOfPoets(poetCities, data)}
@@ -159,30 +157,10 @@ function createDetailedGeoListOfPoets(poets) {
 }
 
 /**
- * @param {State} state
- * @param {Data} data
- * @param {string} cityname already upper-cased
- * @param {BubbleContents} bubble
- * @param {PlacesFilterType} type
- * @param {number} num
- * @returns {string}
- */
-function createTitle(state, data, cityname, bubble, type, num) {
-  switch (state.currentMapMode) {
-    case "placesMode":
-      return createPlacesModeTitle(data, cityname, type, num);
-    case "geoimaginaryMode": {
-      const referenceStr = bubble.poetCities.length === 1 ? "REFERENCE" : "REFERENCES";
-      return `${bubble.poetCities.length} ${referenceStr} TO ${cityname}`;
-    }
-    case "travelMode":
-      throw new Error("createTitle is not used by the travel map");
-    default:
-      return assertUnreachable(state.currentMapMode, "unrecognized map mode");
-  }
-}
-
-/**
+ * Names the filter the bubble is being shown under. Exhaustive over the three
+ * filters the places control bar offers, and there is no fourth: the ALL that
+ * used to need a throw here belongs to the geographical imaginary map, which
+ * titles its own popups below.
  * @param {Data} data
  * @param {string} cityname already upper-cased
  * @param {PlacesFilterType} type
@@ -201,28 +179,22 @@ function createPlacesModeTitle(data, cityname, type, num) {
       const genrename = data.genresByGenreId[num].toUpperCase();
       return `POET BORN IN ${cityname} AND ASSOCIATED WITH ${genrename}`;
     }
-    case "all":
-      // Offered by the geographical imaginary control bar, which titles its
-      // popups in createTitle rather than here.
-      throw new Error("the places map has no ALL filter");
     default:
       return assertUnreachable(type, "unrecognized places filter");
   }
 }
 
 /**
- * @param {State} state
- * @param {Data} data
  * @param {BubbleContents} bubble
- * @param {PlacesFilterType} type
- * @param {number} num
  * @returns {string}
  */
-function createGeoImaginaryPopupHtml(state, data, bubble, type, num) {
+function createGeoImaginaryPopupHtml(bubble) {
+  const cityname = bubble.city.infowindowName.toUpperCase();
   // calcBubbles always populates poets in geoimaginaryMode.
   const poets = /** @type {GeoBubblePoet[]} */ (bubble.poets);
+  const referenceStr = bubble.poetCities.length === 1 ? "REFERENCE" : "REFERENCES";
   return `
-    ${createHeader(state, data, bubble, type, num)}
+    ${createHeader(cityname, `${bubble.poetCities.length} ${referenceStr} TO ${cityname}`)}
     ${createGeoHeaderListOfPoets(poets)}
     <h4 style="color:${LYRIC_GREY}">DETAILS</h4>
     ${createDetailedGeoListOfPoets(poets)}

--- a/js/popups/travelPopups.js
+++ b/js/popups/travelPopups.js
@@ -4,7 +4,7 @@ import { createNumberedListOfPoets, createDetailedListOfPoets, renderReference }
 /**
  * Builds the html shown when a travel arc is clicked.
  * @param {Data} data
- * @param {DrawnLine} line
+ * @param {TravelArc} line
  * @returns {string}
  */
 export function createTravelPopupHtml(data, line) {
@@ -23,7 +23,7 @@ export function createTravelPopupHtml(data, line) {
 
 /**
  * Renders the citation behind either end of an arc, for every poet on it.
- * @param {DrawnLine} line
+ * @param {TravelArc} line
  * @param {"bornPc" | "activePc"} direction which end of the journey to cite
  * @returns {string}
  */
@@ -44,7 +44,7 @@ function createTravelSource(line, direction) {
  * As createTravelPopupHtml, but the details block reports regimes rather than
  * genres and sources.
  * @param {Data} data
- * @param {DrawnLine} line
+ * @param {TravelArc} line
  * @returns {string}
  */
 export function createGovTravelPopupHtml(data, line) {

--- a/js/renderMap/calcBubbles.js
+++ b/js/renderMap/calcBubbles.js
@@ -10,48 +10,63 @@ import { createPopupHtml } from "../popups/popups.js";
  * @returns {Record<number, Bubble>}
  */
 export function calculateBubbles(state, data, poetCities) {
-  const citiesById = data.citiesById;
   /** @type {Record<number, Bubble>} */
   const bubbles = {};
 
+  for (const [key, rows] of Object.entries(groupRowsByCity(data, poetCities))) {
+    const cityId = Number(key);
+    // The contents are assembled first because the popup is rendered from them,
+    // and from nothing that is added alongside it. That ordering is what lets a
+    // bubble be built complete instead of filled in field by field.
+    /** @type {BubbleContents} */
+    const contents = { city: data.citiesById[cityId], poetCities: rows };
+    if (state.currentMapMode === "geoimaginaryMode") contents.poets = groupRowsByPoet(rows);
+
+    bubbles[cityId] = {
+      ...contents,
+      price: calculateBubblePriceFromNumberOfPoets(rows.length),
+      popupHtml: createPopupHtml(state, data, contents),
+      legend: contents.city.cityname
+    };
+  }
+
+  return bubbles;
+}
+
+/**
+ * Buckets rows by the city they point at, dropping any that name a city missing
+ * from cities.csv.
+ * @param {Data} data
+ * @param {RenderedPoetCity[]} poetCities
+ * @returns {Record<number, RenderedPoetCity[]>}
+ */
+function groupRowsByCity(data, poetCities) {
+  /** @type {Record<number, RenderedPoetCity[]>} */
+  const rowsByCity = {};
   for (const poetCity of poetCities) {
     const cityId = poetCity.cityId;
-    if (cityId && citiesById[cityId]) {
-      if (!bubbles[cityId]) {
-        bubbles[cityId] = /** @type {Bubble} */ ({});
-        bubbles[cityId].city = citiesById[cityId];
-        bubbles[cityId].poetCities = [];
-      }
-      bubbles[cityId].poetCities.push(poetCity);
-    }
+    if (!cityId || !data.citiesById[cityId]) continue;
+    if (!rowsByCity[cityId]) rowsByCity[cityId] = [];
+    rowsByCity[cityId].push(poetCity);
   }
+  return rowsByCity;
+}
 
-  if (state.currentMapMode === "geoimaginaryMode") {
-    for (const cityId in bubbles) {
-      const bubbleCity = bubbles[cityId];
-      // poets starts life keyed by poetId so references can be accumulated,
-      // then is flattened to the sorted array that popups consume.
-      /** @type {Record<number, GeoBubblePoet>} */
-      const poetsById = {};
-      for (const pc of bubbleCity.poetCities) {
-        if (!poetsById[pc.poetId]) {
-          poetsById[pc.poetId] = /** @type {GeoBubblePoet} */ ({ ...pc });
-          poetsById[pc.poetId].references = [];
-        }
-        poetsById[pc.poetId].references.push(pc.reference);
-      }
-      bubbleCity.poets = Object.values(poetsById);
-      bubbleCity.poets.sort((a, b) => sortAlphabetically(a.poetname, b.poetname));
-    }
+/**
+ * Collapses one city's rows to one entry per poet, carrying every citation that
+ * poet made to it. Geographical imaginary only, where a poet often names the
+ * same place several times.
+ * @param {RenderedPoetCity[]} rows
+ * @returns {GeoBubblePoet[]}
+ */
+function groupRowsByPoet(rows) {
+  /** @type {Record<number, GeoBubblePoet>} */
+  const poetsById = {};
+  for (const row of rows) {
+    if (!poetsById[row.poetId]) poetsById[row.poetId] = { ...row, references: [] };
+    poetsById[row.poetId].references.push(row.reference);
   }
-
-  for (const cityId in bubbles) {
-    const bubble = bubbles[cityId];
-    bubble.price = calculateBubblePriceFromNumberOfPoets(bubble.poetCities.length);
-    bubble.popupHtml = createPopupHtml(state, data, bubble);
-    bubble.legend = bubble.city.cityname;
-  }
-  return bubbles;
+  return Object.values(poetsById).sort((a, b) => sortAlphabetically(a.poetname, b.poetname));
 }
 
 /**

--- a/js/renderMap/calcPoetCities.js
+++ b/js/renderMap/calcPoetCities.js
@@ -1,30 +1,65 @@
-import { getGenres, getPlacesFilter } from "../calcData/getters.js";
+import { getGenres, getPlacesFilter, getGeoFilter } from "../calcData/getters.js";
 import { assertUnreachable } from "../assertUnreachable.js";
 import { getDateFilterFn } from "./calcCommon.js";
 
 /** @typedef {PoetCity | GeoPoetCity} AnyPoetCity */
-/** @typedef {(poetCity: AnyPoetCity) => boolean} PoetCityFilter */
 
 /**
  * Picks the right source rows for the current map, applies the date slider and
  * control-bar filters, and flattens the survivors for rendering.
+ *
+ * The two maps are handled apart rather than together, because they do not
+ * offer the same filters: places has ORIGIN, ACTIVITY and the genres,
+ * geographical imaginary has ALL REFERENCES. They share only "poet".
  * @param {Data} data
  * @param {State} state
  * @returns {RenderedPoetCity[]}
  */
 export function calcPoetCities(data, state) {
+  switch (state.currentMapMode) {
+    case "placesMode":
+      return calcPlacesPoetCities(data, state);
+    case "geoimaginaryMode":
+      return calcGeoPoetCities(data, state);
+    case "travelMode":
+      // The travel map draws arcs rather than bubbles, and calculates them in
+      // lines.js. Nothing routes it here.
+      throw new Error("calcPoetCities is not used by the travel map");
+    default:
+      return assertUnreachable(state.currentMapMode, "unrecognized current map mode");
+  }
+}
+
+/**
+ * @param {Data} data
+ * @param {State} state
+ * @returns {RenderedPoetCity[]}
+ */
+function calcPlacesPoetCities(data, state) {
   const [type, num] = getPlacesFilter(state);
-  const dated = getPoetCitiesData(data, state).filter(getDateFilterFn(data, state));
+  const dated = data.poetCities.filter(getDateFilterFn(data, state));
 
   if (type === "genre") return renderGenreRows(dated, data, num);
 
-  return dated.filter(getFilterFn(type, num)).map(poetCity => renderPoetCity(poetCity));
+  return dated.filter(getPlacesFilterFn(type, num)).map(poetCity => renderPoetCity(poetCity));
+}
+
+/**
+ * @param {Data} data
+ * @param {State} state
+ * @returns {RenderedPoetCity[]}
+ */
+function calcGeoPoetCities(data, state) {
+  const [type, num] = getGeoFilter(state);
+  const dated = data.geopoetCities.filter(getDateFilterFn(data, state));
+
+  return dated.filter(getGeoFilterFn(type, num)).map(poetCity => renderPoetCity(poetCity));
 }
 
 /**
  * Filters and renders together, so the entry that qualifies a row is the one
  * that supplies its citation.
- * @param {AnyPoetCity[]} poetCities
+ * @param {PoetCity[]} poetCities
  * @param {Data} data
  * @param {number} genreId
  * @returns {RenderedPoetCity[]}
@@ -38,33 +73,14 @@ function renderGenreRows(poetCities, data, genreId) {
 }
 
 /**
- * @param {Data} data
- * @param {State} state
- * @returns {AnyPoetCity[]}
- */
-function getPoetCitiesData(data, state) {
-  switch (state.currentMapMode) {
-    case "placesMode":
-    case "travelMode":
-      return [...data.poetCities];
-    case "geoimaginaryMode":
-      return [...data.geopoetCities];
-    default:
-      return assertUnreachable(state.currentMapMode, "unrecognized current map mode");
-  }
-}
-
-/**
- * Builds the predicate for the selected radio button. Genre is excluded from
- * the type because renderGenreRows handles it.
+ * Builds the predicate for the selected places radio button. Genre is excluded
+ * from the type because renderGenreRows handles it.
  * @param {Exclude<PlacesFilterType, "genre">} type
  * @param {number} num
- * @returns {PoetCityFilter}
+ * @returns {(poetCity: PoetCity) => boolean}
  */
-function getFilterFn(type, num) {
+function getPlacesFilterFn(type, num) {
   switch (type) {
-    case "all":
-      return () => true;
     case "relationship":
       // Relationship 3 is "activity", which every row qualifies for.
       if (num === 3) return () => true;
@@ -72,7 +88,24 @@ function getFilterFn(type, num) {
     case "poet":
       return poetCity => poetCity.poetId === num;
     default:
-      return assertUnreachable(type, "unrecognized filter when calculating poet cities");
+      return assertUnreachable(type, "unrecognized filter on the places map");
+  }
+}
+
+/**
+ * As getPlacesFilterFn, for the geographical imaginary map's two filters.
+ * @param {GeoFilterType} type
+ * @param {number} num
+ * @returns {(poetCity: GeoPoetCity) => boolean}
+ */
+function getGeoFilterFn(type, num) {
+  switch (type) {
+    case "all":
+      return () => true;
+    case "poet":
+      return poetCity => poetCity.poetId === num;
+    default:
+      return assertUnreachable(type, "unrecognized filter on the geographical imaginary map");
   }
 }
 

--- a/js/renderMap/lines.js
+++ b/js/renderMap/lines.js
@@ -71,69 +71,110 @@ function hashCityIds(from, to) {
 function calculateLines(data, type, num, filteredPoetLines) {
   /** @type {Record<number, DrawnLine>} */
   const lines = {};
-  for (const line of filteredPoetLines) {
-    const hash = hashCityIds(line.bornCityId, line.activeCityId);
-    if (!lines[hash]) {
-      lines[hash] = /** @type {DrawnLine} */ ({});
-      lines[hash].fromCity = line.bornCity;
-      lines[hash].toCity = line.activeCity;
-      lines[hash].poetLines = [];
-      lines[hash].dotted = false;
-      lines[hash].color = TRAVEL_RED;
-      lines[hash].name = `${line.bornCity.infowindowName} -> ${line.activeCity.infowindowName}`.toUpperCase();
-    }
-    lines[hash].poetLines.push(line);
-    colorLine(type, num, lines[hash]);
-    if (line.dotted) lines[hash].dotted = true;
+
+  for (const [key, poetLines] of Object.entries(groupLinesByCityPair(filteredPoetLines))) {
+    const { bornCity: fromCity, activeCity: toCity } = poetLines[0];
+    // The arc is assembled first because the popup is rendered from it, and from
+    // nothing that is added alongside it. That ordering is what lets an arc be
+    // built complete instead of filled in field by field.
+    /** @type {TravelArc} */
+    const arc = {
+      fromCity,
+      toCity,
+      poetLines,
+      dotted: poetLines.some(line => line.dotted),
+      color: arcColor(type, num, fromCity, poetLines),
+      name: `${fromCity.infowindowName} -> ${toCity.infowindowName}`.toUpperCase(),
+      weight: arcWeight(type, poetLines.length)
+    };
+
+    lines[Number(key)] = {
+      ...arc,
+      popupHtml: type === "gov" ? createGovTravelPopupHtml(data, arc) : createTravelPopupHtml(data, arc)
+    };
   }
-  for (const hash in lines) {
-    const line = lines[hash];
-    weightLine(type, line);
-    if (type === "gov") {
-      line.popupHtml = createGovTravelPopupHtml(data, line);
-    } else {
-      line.popupHtml = createTravelPopupHtml(data, line);
-    }
-  }
+
   return lines;
 }
 
 /**
- * Thickens an arc in proportion to how many poets travelled it.
- * @param {TravelFilterType} type
- * @param {DrawnLine} line mutated in place
+ * Buckets poet lines by the city pair they run between, which is what an arc
+ * merges.
+ * @param {Line[]} filteredPoetLines
+ * @returns {Record<number, Line[]>}
  */
-function weightLine(type, line) {
-  const poetsNum = line.poetLines.length;
-  let multiplier = 1;
-  let increment = 0;
-  if (type === "destination" || type === "smallregion" || type === "poet") {
-    multiplier = 2;
-    increment = 1;
+function groupLinesByCityPair(filteredPoetLines) {
+  /** @type {Record<number, Line[]>} */
+  const linesByCityPair = {};
+  for (const line of filteredPoetLines) {
+    const hash = hashCityIds(line.bornCityId, line.activeCityId);
+    if (!linesByCityPair[hash]) linesByCityPair[hash] = [];
+    linesByCityPair[hash].push(line);
   }
-  line.weight = multiplier * poetsNum + increment;
+  return linesByCityPair;
 }
 
 /**
- * Recolours an arc when it leaves (purple) or stays within (yellow) whatever is
- * currently selected. Default is red.
+ * Thickens an arc in proportion to how many poets travelled it, and doubles it
+ * for the filters that leave only a handful of arcs on the map, where a weight
+ * of 1 would be all but invisible.
+ *
+ * Exhaustive rather than defaulting to the thin case, so a seventh travel filter
+ * has to say which of the two it is instead of quietly getting the thin one.
+ * @param {TravelFilterType} type
+ * @param {number} poetsNum
+ * @returns {number}
+ */
+function arcWeight(type, poetsNum) {
+  switch (type) {
+    case "poet":
+    case "destination":
+    case "smallregion":
+      return 2 * poetsNum + 1;
+    case "all":
+    case "region":
+    case "gov":
+      return poetsNum;
+    default:
+      return assertUnreachable(type, "unrecognized filter when weighting a travel arc");
+  }
+}
+
+/**
+ * Purple when an arc leaves whatever is currently selected, yellow when it both
+ * leaves and arrives within it, red otherwise.
+ *
+ * As filterLines above, exhaustive over TravelFilterType. Red was previously the
+ * fallthrough at the end of an if-chain, which meant ALL and POET got it by
+ * saying nothing — and so would any filter added later, silently.
  * @param {TravelFilterType} type
  * @param {number} num
- * @param {DrawnLine} line mutated in place
+ * @param {City} fromCity
+ * @param {Line[]} poetLines
+ * @returns {string}
  */
-function colorLine(type, num, line) {
-  // default color is red
-  if (type === "destination") {
-    if (line.fromCity.cityId === num) line.color = TRAVEL_PURPLE;
-  } else if (type === "smallregion") {
-    if (line.fromCity.regionId === num) line.color = TRAVEL_PURPLE;
-  } else if (type === "region") {
-    if (line.fromCity.bigRegionId === num) line.color = TRAVEL_PURPLE;
-  } else if (type === "gov") {
-    const bornGovIds = line.poetLines.flatMap(pl => pl.bornGovIds).filter(govId => govId === num);
-    const activeGovIds = line.poetLines.flatMap(pl => pl.activeGovIds).filter(govId => govId === num);
-    if (bornGovIds.length && activeGovIds.length) line.color = TRAVEL_YELLOW;
-    else if (bornGovIds.length) line.color = TRAVEL_PURPLE;
+function arcColor(type, num, fromCity, poetLines) {
+  switch (type) {
+    case "all":
+    case "poet":
+      // Neither picks out a place, so there is no leaving or arriving to show.
+      return TRAVEL_RED;
+    case "destination":
+      return fromCity.cityId === num ? TRAVEL_PURPLE : TRAVEL_RED;
+    case "smallregion":
+      return fromCity.regionId === num ? TRAVEL_PURPLE : TRAVEL_RED;
+    case "region":
+      return fromCity.bigRegionId === num ? TRAVEL_PURPLE : TRAVEL_RED;
+    case "gov": {
+      // Read across the whole arc, not one line: several poets can share a
+      // journey, and any of them born under the selected regime colours it.
+      const bornUnder = poetLines.some(line => line.bornGovIds.includes(num));
+      const activeUnder = poetLines.some(line => line.activeGovIds.includes(num));
+      if (bornUnder && activeUnder) return TRAVEL_YELLOW;
+      return bornUnder ? TRAVEL_PURPLE : TRAVEL_RED;
+    }
+    default:
+      return assertUnreachable(type, "unrecognized filter when colouring a travel arc");
   }
 }
 
@@ -146,19 +187,15 @@ function colorLine(type, num, line) {
 function calculateTravelBubbles(data, filteredPoetLines) {
   /** @type {Set<number>} */
   const cityIds = new Set();
-  for (const plId in filteredPoetLines) {
-    const pl = filteredPoetLines[plId];
-    cityIds.add(pl.bornCityId);
-    cityIds.add(pl.activeCityId);
+  for (const line of filteredPoetLines) {
+    cityIds.add(line.bornCityId);
+    cityIds.add(line.activeCityId);
   }
 
   /** @type {Record<number, DrawableBubble>} */
   const bubbles = {};
   for (const cityId of cityIds) {
-    const city = data.citiesById[cityId];
-    bubbles[cityId] = /** @type {DrawableBubble} */ ({});
-    bubbles[cityId].city = city;
-    bubbles[cityId].price = 10;
+    bubbles[cityId] = { city: data.citiesById[cityId], price: 10 };
   }
 
   return bubbles;

--- a/js/renderMap/lines.js
+++ b/js/renderMap/lines.js
@@ -29,7 +29,7 @@ export function calculateAndDrawLines(map, data, state) {
  * @param {number} num
  * @returns {Line[]}
  */
-function filterLines(data, type, num) {
+export function filterLines(data, type, num) {
   switch (type) {
     case "all":
       return data.lines;
@@ -68,7 +68,7 @@ function hashCityIds(from, to) {
  * @param {Line[]} filteredPoetLines
  * @returns {Record<number, DrawnLine>}
  */
-function calculateLines(data, type, num, filteredPoetLines) {
+export function calculateLines(data, type, num, filteredPoetLines) {
   /** @type {Record<number, DrawnLine>} */
   const lines = {};
 

--- a/tests/helpers/loadData.js
+++ b/tests/helpers/loadData.js
@@ -50,10 +50,6 @@ export function loadRawCsvs() {
  * @returns {{ data: Data, alerts: string[], logs: string[] }}
  */
 export function loadInitializedData() {
-  // initializeData() hydrates the raw rows in place, turning the RawCsvs shape
-  // into the Data shape js/ works with.
-  const data = /** @type {Data} */ (/** @type {unknown} */ (loadRawCsvs()));
-
   /** @type {string[]} */
   const alerts = [];
   /** @type {string[]} */
@@ -66,13 +62,11 @@ export function loadInitializedData() {
   console.log = (/** @type {unknown[]} */ ...args) => logs.push(args.join(" "));
 
   try {
-    initializeData(data);
+    return { data: initializeData(loadRawCsvs()), alerts, logs };
   } finally {
     globals.alert = realAlert;
     console.log = realLog;
   }
-
-  return { data, alerts, logs };
 }
 
 /**

--- a/tests/initializeData.test.js
+++ b/tests/initializeData.test.js
@@ -7,7 +7,7 @@ import { test, describe } from "node:test";
 import assert from "node:assert/strict";
 import { loadInitializedData } from "./helpers/loadData.js";
 import { sortAlphabetically } from "../js/calcData/data.js";
-import { PLACES_FILTER_TYPES, TRAVEL_FILTER_TYPES } from "../js/calcData/getters.js";
+import { PLACES_FILTER_TYPES, GEO_FILTER_TYPES, TRAVEL_FILTER_TYPES } from "../js/calcData/getters.js";
 import { createPlacesInterfaceHtml } from "../js/interface/placesInterface.js";
 import { createTravelInterfaceHtml } from "../js/interface/travelInterface.js";
 import { createGeoImaginaryInterfaceHtml } from "../js/interface/geoImaginaryInterface.js";
@@ -267,41 +267,41 @@ describe("known bugs: derived travel lines", () => {
 // ---------------------------------------------------------------------------
 // The control bar is HTML strings, and a radio button's id is the only thing
 // tying a click back to a filter. The types stop a prefix being misspelt; these
-// tests stop a map offering a filter it cannot handle, which the types cannot
-// see because both builders take the same MapFilterType.
+// tests tie each map's declared filter union to what its builder actually emits,
+// which the types cannot see because all three builders take MapFilterType.
+//
+// Asserted as an equality rather than a subset, in both directions at once: a
+// map that offers a filter it cannot handle fails, and so does a map that
+// declares a filter it never offers — which is the dead branch that used to
+// need a throw in createPlacesModeTitle().
 // ---------------------------------------------------------------------------
 
-describe("control bar ids round-trip to filters", () => {
+describe("each control bar offers exactly the filters its map declares", () => {
   /** Every `${prefix}_${num}` id in a block of control bar html. */
   const idsIn = (/** @type {string} */ html) => [...html.matchAll(/id="([^"]+)"/g)].map(match => match[1]);
 
   const prefixesIn = (/** @type {string} */ html) => [...new Set(idsIn(html).map(id => id.split("_")[0]))].sort();
 
-  test("the places control bar offers only places filters", () => {
-    for (const prefix of prefixesIn(createPlacesInterfaceHtml(data))) {
-      assert.ok(
-        PLACES_FILTER_TYPES.includes(/** @type {PlacesFilterType} */ (prefix)),
-        `the places control bar offers "${prefix}", which getPlacesFilter() rejects`
-      );
-    }
+  test("places: ORIGIN and ACTIVITY, the poets, and the genres", () => {
+    assert.deepEqual(prefixesIn(createPlacesInterfaceHtml(data)), [...PLACES_FILTER_TYPES].sort());
   });
 
-  test("the geographical imaginary control bar offers only places filters", () => {
-    for (const prefix of prefixesIn(createGeoImaginaryInterfaceHtml(data))) {
-      assert.ok(
-        PLACES_FILTER_TYPES.includes(/** @type {PlacesFilterType} */ (prefix)),
-        `the geographical imaginary control bar offers "${prefix}", which getPlacesFilter() rejects`
-      );
-    }
+  test("geographical imaginary: ALL REFERENCES and the poets, and nothing else", () => {
+    assert.deepEqual(prefixesIn(createGeoImaginaryInterfaceHtml(data)), [...GEO_FILTER_TYPES].sort());
   });
 
-  test("the travel control bar offers only travel filters", () => {
-    for (const prefix of prefixesIn(createTravelInterfaceHtml(data))) {
-      assert.ok(
-        TRAVEL_FILTER_TYPES.includes(/** @type {TravelFilterType} */ (prefix)),
-        `the travel control bar offers "${prefix}", which getTravelFilter() rejects`
-      );
-    }
+  test("travel: all six", () => {
+    assert.deepEqual(prefixesIn(createTravelInterfaceHtml(data)), [...TRAVEL_FILTER_TYPES].sort());
+  });
+
+  test("the two bubble maps really do offer different filters", () => {
+    // The point of splitting PlacesFilterType from GeoFilterType. If these ever
+    // coincide the split has stopped earning its keep.
+    const places = prefixesIn(createPlacesInterfaceHtml(data));
+    const geo = prefixesIn(createGeoImaginaryInterfaceHtml(data));
+    assert.notDeepEqual(places, geo);
+    assert.ok(!places.includes("all"), "the places map has no ALL button");
+    assert.ok(!geo.includes("genre"), "the geographical imaginary map has no genre buttons");
   });
 
   test("every id parses back to the filter and number it was built from", () => {
@@ -317,7 +317,7 @@ describe("control bar ids round-trip to filters", () => {
   test("the default selectedId of each mode is one that mode can handle", () => {
     // updateMapMode() sets these; they are what the map renders on first paint.
     assert.ok(PLACES_FILTER_TYPES.includes(/** @type {PlacesFilterType} */ ("relationship")));
-    assert.ok(PLACES_FILTER_TYPES.includes(/** @type {PlacesFilterType} */ ("all")));
+    assert.ok(GEO_FILTER_TYPES.includes(/** @type {GeoFilterType} */ ("all")));
     assert.ok(TRAVEL_FILTER_TYPES.includes(/** @type {TravelFilterType} */ ("all")));
   });
 });

--- a/tests/lines.test.js
+++ b/tests/lines.test.js
@@ -1,0 +1,191 @@
+// Behaviour of the travel map's arcs, driven through the real pipeline.
+//
+// filterLines() and calculateLines() are pure, so Node can build the exact arcs
+// the browser draws and assert on how they merge, what colour they take and how
+// thick they are. As in popups.test.js, nothing is stubbed: the CSVs go in and
+// the arcs come out.
+//
+// Colour and weight had no coverage at all before this file, which made them the
+// riskiest part of any change to lines.js — both are plainly visible on the map
+// and neither was asserted anywhere.
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { loadInitializedData } from "./helpers/loadData.js";
+import { filterLines, calculateLines } from "../js/renderMap/lines.js";
+import { getDateFilterFn } from "../js/renderMap/calcCommon.js";
+import { TRAVEL_RED, TRAVEL_PURPLE, TRAVEL_YELLOW } from "../js/constants/colors.js";
+
+const { data } = loadInitializedData();
+
+/** The whole slider range, i.e. what the map shows before anything is dragged. */
+const ALL_DATES = { minDate: -800, maxDate: -400 };
+
+/** governments.csv ids, as the political system control bar offers them. */
+const DEMOCRACY = 3;
+const TYRANNY = 2;
+
+/**
+ * The arcs the travel map draws for one control bar selection, assembled the
+ * same way calculateAndDrawLines() assembles them.
+ * @param {TravelFilterType} type
+ * @param {number} num
+ * @returns {DrawnLine[]}
+ */
+function arcsFor(type, num) {
+  /** @type {State} */
+  const state = { currentMapMode: "travelMode", selectedId: `${type}_${num}`, ...ALL_DATES };
+  const poetLines = filterLines(data, type, num).filter(getDateFilterFn(data, state));
+  return Object.values(calculateLines(data, type, num, poetLines));
+}
+
+/**
+ * @param {DrawnLine[]} arcs
+ * @param {string} name e.g. "THEBES -> ATHENS"
+ * @returns {DrawnLine}
+ */
+function arcNamed(arcs, name) {
+  const matching = arcs.filter(arc => arc.name === name);
+  assert.equal(matching.length, 1, `expected exactly one "${name}" arc, found ${matching.length}`);
+  return matching[0];
+}
+
+const cityIdByName = (/** @type {string} */ cityname) => {
+  const city = data.cities.find(c => c.cityname === cityname);
+  assert.ok(city, `no city named ${cityname}`);
+  return city.cityId;
+};
+
+describe("arcs merge the poets who made the same journey", () => {
+  const arcs = arcsFor("all", 1);
+
+  test("three poets going from Thebes to Athens draw one arc, not three", () => {
+    const arc = arcNamed(arcs, "THEBES -> ATHENS");
+    assert.deepEqual(arc.poetLines.map(line => line.poetDetailName).sort(), ["Khairis", "Pindar", "Pronomus"]);
+  });
+
+  test("one poet's uncertain journey dots the whole arc", () => {
+    // Bacchylides' line to Athens is marked dotted in poets_cities.csv and
+    // Simonides' is not. They share an arc, so the arc is drawn dotted: the
+    // hedge belongs to one of the two, but the map cannot say so.
+    const arc = arcNamed(arcs, "IOULIS (CEOS) -> ATHENS");
+    assert.deepEqual(arc.poetLines.map(line => `${line.poetDetailName}:${line.dotted}`).sort(), [
+      "Bacchylides:true",
+      "Simonides:false"
+    ]);
+    assert.ok(arc.dotted);
+  });
+
+  test("an arc no one hedged is drawn solid", () => {
+    assert.equal(arcNamed(arcs, "THEBES -> ATHENS").dotted, false);
+  });
+
+  test("an arc is named from origin to destination", () => {
+    for (const arc of arcs) {
+      assert.equal(arc.name, `${arc.fromCity.infowindowName} -> ${arc.toCity.infowindowName}`.toUpperCase());
+    }
+  });
+
+  test("the whole slider range drops nothing, so every line above reaches the map", () => {
+    // The other tests here read as claims about the corpus rather than about the
+    // date filter, which is only true while the full range keeps everything.
+    const drawn = arcs.reduce((count, arc) => count + arc.poetLines.length, 0);
+    assert.equal(drawn, data.lines.length);
+  });
+});
+
+describe("arc colour", () => {
+  test("nothing is picked out until something is selected", () => {
+    for (const arc of arcsFor("all", 1)) assert.equal(arc.color, TRAVEL_RED);
+  });
+
+  test("selecting a city marks the journeys out of it, not the ones into it", () => {
+    const athens = cityIdByName("Athens");
+    const arcs = arcsFor("destination", athens);
+    for (const arc of arcs) {
+      const expected = arc.fromCity.cityId === athens ? TRAVEL_PURPLE : TRAVEL_RED;
+      assert.equal(arc.color, expected, `${arc.name} is the wrong way round for a journey out of Athens`);
+    }
+    // Both directions are on the map, so the loop above is actually deciding.
+    assert.ok(
+      arcs.some(arc => arc.color === TRAVEL_PURPLE),
+      "no arc leaves Athens"
+    );
+    assert.ok(
+      arcs.some(arc => arc.color === TRAVEL_RED),
+      "no arc arrives at Athens"
+    );
+  });
+
+  test("selecting a small region marks the journeys out of it", () => {
+    const attica = data.citiesById[cityIdByName("Athens")].regionId;
+    const arcs = arcsFor("smallregion", attica);
+    for (const arc of arcs) {
+      const expected = arc.fromCity.regionId === attica ? TRAVEL_PURPLE : TRAVEL_RED;
+      assert.equal(arc.color, expected, `${arc.name} is the wrong way round for a journey out of Attica`);
+    }
+    assert.ok(arcs.some(arc => arc.color === TRAVEL_PURPLE) && arcs.some(arc => arc.color === TRAVEL_RED));
+  });
+
+  test("under a political system, yellow stays within it, purple leaves it, red arrives in it", () => {
+    const arcs = arcsFor("gov", DEMOCRACY);
+    assert.equal(arcNamed(arcs, "ATHENS -> SALAMIS").color, TRAVEL_YELLOW, "democracy to democracy");
+    assert.equal(arcNamed(arcs, "ATHENS -> DELOS").color, TRAVEL_PURPLE, "out of a democracy");
+    assert.equal(arcNamed(arcs, "THEBES -> ATHENS").color, TRAVEL_RED, "into a democracy");
+  });
+
+  test("the same three cases under tyranny", () => {
+    const arcs = arcsFor("gov", TYRANNY);
+    assert.equal(arcNamed(arcs, "MYTILENE -> LEUCAS").color, TRAVEL_YELLOW, "tyranny to tyranny");
+    assert.equal(arcNamed(arcs, "CHIOS -> ATHENS").color, TRAVEL_PURPLE, "out of a tyranny");
+    assert.equal(arcNamed(arcs, "THEBES -> SYRACUSE").color, TRAVEL_RED, "into a tyranny");
+  });
+});
+
+describe("arc weight", () => {
+  test("an arc is as thick as the number of poets who travelled it", () => {
+    for (const arc of arcsFor("all", 1)) assert.equal(arc.weight, arc.poetLines.length);
+  });
+
+  test("the poet, city and small region filters draw thicker, so a lone journey still reads", () => {
+    // Those three usually leave only a handful of arcs on the map, where a
+    // weight of 1 would be all but invisible.
+    /** @type {[TravelFilterType, number][]} */
+    const SPARSE = [
+      ["destination", cityIdByName("Athens")],
+      ["smallregion", data.citiesById[cityIdByName("Athens")].regionId],
+      ["poet", data.travelPoets[0].id]
+    ];
+    for (const [type, num] of SPARSE) {
+      const arcs = arcsFor(type, num);
+      assert.ok(arcs.length > 0, `${type}_${num} draws nothing`);
+      for (const arc of arcs) assert.equal(arc.weight, 2 * arc.poetLines.length + 1, `${type}: ${arc.name}`);
+    }
+  });
+
+  test("Thebes to Athens carries three poets, so it is drawn at 3 and, picked out, at 7", () => {
+    assert.equal(arcNamed(arcsFor("all", 1), "THEBES -> ATHENS").weight, 3);
+    assert.equal(arcNamed(arcsFor("destination", cityIdByName("Athens")), "THEBES -> ATHENS").weight, 7);
+  });
+});
+
+describe("arc popups", () => {
+  test("the political system filter reports regimes, every other filter reports sources", () => {
+    const gov = arcsFor("gov", DEMOCRACY)[0].popupHtml;
+    assert.match(gov, /Regime \(data from Hansen and Nielsen\)/);
+    assert.doesNotMatch(gov, /Source\(s\)/);
+
+    const all = arcsFor("all", 1)[0].popupHtml;
+    assert.match(all, /Source\(s\)/);
+    assert.doesNotMatch(all, /Regime/);
+  });
+
+  test("every arc gets a popup citing both ends of the journey", () => {
+    for (const arc of arcsFor("all", 1)) {
+      assert.match(arc.popupHtml, /ORIGIN SOURCE/, `${arc.name} popup has no origin`);
+      assert.match(arc.popupHtml, /ACTIVITY SOURCE/, `${arc.name} popup has no destination`);
+      assert.doesNotMatch(arc.popupHtml, /undefined/, `${arc.name} popup contains "undefined"`);
+      assert.doesNotMatch(arc.popupHtml, /NaN/, `${arc.name} popup contains "NaN"`);
+    }
+  });
+});

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -344,11 +344,10 @@ interface State {
 }
 
 /**
- * The single mutable bag of everything. parseCsvs() fills the raw arrays;
- * initializeData() hydrates them and adds every derived lookup below.
+ * The ten CSVs, hydrated: ids and coordinates parsed to numbers, dates negated
+ * to BCE years. The pre-hydration string forms are RawCsvs, in types/csv.d.ts.
  */
-interface Data {
-  // straight from CSV
+interface Csvs {
   cities: City[];
   regions: Region[];
   bigRegions: BigRegion[];
@@ -359,8 +358,18 @@ interface Data {
   genres: Genre[];
   poetCities: PoetCity[];
   geopoetCities: GeoPoetCity[];
+}
 
-  // lookups
+/**
+ * The by-id lookups. Each is a regrouping of exactly one CSV and depends on
+ * nothing else, which is why they can all be built in a single step, before
+ * anything that reads them.
+ *
+ * This, rather than the whole Data, is what getPoet() and its neighbours ask
+ * for — so they can be used while Data is still being assembled, and so their
+ * signatures say they need a lookup rather than the entire world.
+ */
+interface Lookups {
   citiesById: Record<number, City>;
   poetsById: Record<number, Poet>;
   regionsById: Record<number, Region>;
@@ -369,14 +378,15 @@ interface Data {
   govsByCityId: Record<number, CityPolitics[]>;
   govsById: Record<number, string>;
   datesByPoetId: Record<number, number[]>;
+}
 
-  // travel
+/** The travel lines and the control bar lists, derived from the CSVs through the lookups. */
+interface Derived {
   lines: Line[];
   linesByPoetId: Record<number, Line[]>;
   linesByBornCityId: Record<number, Line[]>;
   linesByActiveCityId: Record<number, Line[]>;
 
-  // control-bar contents
   genreIdsWithName: FilterOption[];
   geoImaginaryPoets: FilterOption[];
   travelPoets: FilterOption[];
@@ -384,3 +394,9 @@ interface Data {
   poetsWithUnknownTravel: FilterOption[];
   regionsForInterface: FilterOption[];
 }
+
+/**
+ * Everything the map draws from, assembled once by initializeData() and not
+ * added to afterwards. The three halves above are the order it is built in.
+ */
+interface Data extends Csvs, Lookups, Derived {}

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -229,19 +229,30 @@ interface FilterOption {
  * The filter kinds encoded in the first half of State.selectedId, e.g. the
  * "poet" in "poet_93".
  *
- * Each map offers its own set, and the two overlap rather than nest: "all" and
- * "poet" appear on both, "genre" only on places, "gov" only on travel. Keeping
- * them as separate unions lets getPlacesFilter() and getTravelFilter() each
- * hand back exactly what their map can produce, so consumers switch over four
- * or six cases with nothing impossible left to handle.
+ * There are three maps and three sets, overlapping rather than nesting: "poet"
+ * is on all three, "all" on geographical imaginary and travel but not places,
+ * "relationship" and "genre" only on places, "gov" only on travel. Keeping them
+ * as separate unions lets each getter hand back exactly what its own control
+ * bar can produce, so consumers switch over two or three cases with nothing
+ * impossible left to handle.
+ *
+ * These are what createPlacesInterfaceHtml() actually emits: ORIGIN and
+ * ACTIVITY (relationship), the poets with unknown travel, and the genres.
  */
-type PlacesFilterType = "all" | "relationship" | "poet" | "genre";
+type PlacesFilterType = "relationship" | "poet" | "genre";
 
-/** As PlacesFilterType, for the travel map. */
+/**
+ * What createGeoImaginaryInterfaceHtml() emits: ALL REFERENCES, and one button
+ * per poet. It offers no relationship and no genre, and it is the only one of
+ * the three place-and-bubble maps with an ALL.
+ */
+type GeoFilterType = "all" | "poet";
+
+/** As above, for the travel map. */
 type TravelFilterType = "all" | "poet" | "destination" | "smallregion" | "region" | "gov";
 
 /** Any filter kind, whichever map produced it. */
-type MapFilterType = PlacesFilterType | TravelFilterType;
+type MapFilterType = PlacesFilterType | GeoFilterType | TravelFilterType;
 
 /** One poet's attested movement from one birthplace to one place of activity. */
 interface Line extends PoetPrimed {

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -297,24 +297,38 @@ interface DrawableBubble {
   legend?: string;
 }
 
-/** A circle drawn on the map for one city, with the rows behind its popup. */
-interface Bubble extends DrawableBubble {
+/**
+ * The rows behind one city's bubble. Split from Bubble because it is all the
+ * popup is rendered from, which is what lets calculateBubbles() build a whole
+ * Bubble in one go rather than filling an empty one in field by field.
+ */
+interface BubbleContents {
+  city: City;
   poetCities: RenderedPoetCity[];
   /** Only populated in geoimaginaryMode. */
   poets?: GeoBubblePoet[];
 }
 
-/** One drawn arc, merging every Line that shares the same city pair. */
-interface DrawnLine {
+/** A circle drawn on the map for one city, with the rows behind its popup. */
+interface Bubble extends BubbleContents, DrawableBubble {}
+
+/**
+ * One drawn arc, merging every Line that shares the same city pair, before its
+ * popup is rendered. As BubbleContents, this is everything the popup is built
+ * from, so the DrawnLine below can be built complete.
+ */
+interface TravelArc {
   fromCity: City;
   toCity: City;
   poetLines: Line[];
   dotted: boolean;
   color: string;
   name: string;
-  /** Set by weightLine() before the arc is drawn. */
   weight: number;
-  /** Set by calculateLines() before the arc is drawn. */
+}
+
+/** A TravelArc with its popup rendered, ready to draw. */
+interface DrawnLine extends TravelArc {
   popupHtml: string;
 }
 


### PR DESCRIPTION
Third of five. **Stacked on #343** (which is stacked on #342) — this PR's diff is against `built-data`.

## The bad state

The places map and the geographical imaginary map shared one union:

```ts
type PlacesFilterType = "all" | "relationship" | "poet" | "genre";
```

Neither map offers those four:

| control bar | emits |
| --- | --- |
| `createPlacesInterfaceHtml` | `relationship`, `poet`, `genre` — **no ALL** |
| `createGeoImaginaryInterfaceHtml` | `all`, `poet` — **no relationship, no genre** |

The union was the two sets added together, so every consumer had to handle filters its own map could not produce. The cost was sitting in the code as throws that existed only to plug holes the type had opened:

```js
createPlacesModeTitle()  case "all":         throw new Error("the places map has no ALL filter");
createTitle()            case "travelMode":  throw new Error("createTitle is not used by the travel map");
```

## The fix

```ts
type PlacesFilterType = "relationship" | "poet" | "genre";
type GeoFilterType = "all" | "poet";
```

Both throws delete themselves, and `createTitle()` goes with them — its only job was to dispatch on the map mode, which its caller already knows.

`calcPoetCities()` branches on the mode once, at the top, and each map runs through its own predicate: two cases for the geographical imaginary, two for places once genre is peeled off, neither carrying a branch for something the other map offers. The dead `travelMode` case in `getPoetCitiesData()` — which returned `poetCities` for a map that never calls it — goes too.

`createPopupHtml()` now reads the filter only on the branch that needs it. The geographical imaginary popup titles itself by counting references, so it never needed to know which button was selected, and no longer asks.

## The tests get stronger, not weaker

They asserted each builder emits *only* filters its map accepts. They now assert the two sets are **equal**, which also catches the opposite fault: a map declaring a filter its control bar never offers — precisely the dead branch that needed the throw.

A new test pins the point of the split, so it fails if the two maps ever quietly converge again:

```js
test("the two bubble maps really do offer different filters", () => {
  assert.notDeepEqual(places, geo);
  assert.ok(!places.includes("all"), "the places map has no ALL button");
  assert.ok(!geo.includes("genre"), "the geographical imaginary map has no genre buttons");
});
```

## Verification

No behaviour change — all 33 aspects of `Data` and of the rendered output (bubbles for six views, arcs for all 182 travel filters) compared against the parent branch: **0 differences**.

Tests (98), lint, format and the browser smoke test all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
