### PR TITLE
Tie the map mode to the filter it is showing

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,11 @@
 import { initializeData } from "./js/calcData/data.js";
 import { parseCsvs } from "./js/calcData/parseCsvs.js";
-import { addMapModeEventListener, addPoetsEventListener, updateMapMode } from "./js/interface/interface.js";
+import {
+  addMapModeEventListener,
+  addPoetsEventListener,
+  defaultMapState,
+  updateMapMode
+} from "./js/interface/interface.js";
 import { initializeMap } from "./js/drawMap/initializeMap.js";
 import { initializeSlider } from "./js/interface/slider.js";
 import { createEssay, initializeCloseEssayClicks } from "./js/essay/essay.js";
@@ -13,16 +18,15 @@ async function main() {
   const data = initializeData(await parseCsvs());
   /** @type {State} */
   const state = {
-    currentMapMode: "placesMode",
+    map: defaultMapState("placesMode"),
     minDate: -800,
-    maxDate: -400,
-    selectedId: "relationship_3"
+    maxDate: -400
   };
 
   addMapModeEventListener(map, data, state);
   addPoetsEventListener(map, data, state);
 
-  updateMapMode(map, data, state);
+  updateMapMode(map, data, state, state.map.currentMapMode);
   initializeSlider(map, data, state);
 }
 

--- a/js/calcData/getters.js
+++ b/js/calcData/getters.js
@@ -1,3 +1,5 @@
+import { assertUnreachable } from "../assertUnreachable.js";
+
 /**
  * @param {Lookups} lookups
  * @param {number} poetId
@@ -56,51 +58,58 @@ export const GEO_FILTER_TYPES = ["all", "poet"];
 export const TRAVEL_FILTER_TYPES = ["all", "poet", "destination", "smallregion", "region", "gov"];
 
 /**
- * Splits state.selectedId (e.g. "poet_93") into its filter type and numeric id,
- * checking the type against the filters the given map actually offers.
+ * Pairs a map mode with the filter its control bar has selected, parsing the
+ * radio button's id (e.g. "poet_93") into its kind and number.
  *
- * Validating here rather than trusting the string is what lets callers switch
- * exhaustively over two, three or six cases instead of eight, with no branch for
- * a filter their map cannot produce. selectedId always comes from a radio button
- * this code generated, so a mismatch means the interface builders and the map
- * modes have got out of step.
+ * The single place a MapState is constructed, and the only place a selectedId
+ * string becomes a filter. Because it is exhaustive over the three modes and
+ * checks each id against that mode's own filters, a mode paired with a filter
+ * it does not offer cannot leave here — which is what lets every consumer
+ * downstream narrow with a switch and handle nothing impossible.
+ *
+ * selectedId always comes from a radio button this code generated, so a
+ * mismatch means the interface builders and the map modes have got out of step.
+ * @param {MapMode} currentMapMode
+ * @param {string} selectedId
+ * @returns {MapState}
+ */
+export function mapStateFrom(currentMapMode, selectedId) {
+  switch (currentMapMode) {
+    case "placesMode":
+      return { currentMapMode, filter: parseFilter(selectedId, PLACES_FILTER_TYPES, "places") };
+    case "geoimaginaryMode":
+      return { currentMapMode, filter: parseFilter(selectedId, GEO_FILTER_TYPES, "geographical imaginary") };
+    case "travelMode":
+      return { currentMapMode, filter: parseFilter(selectedId, TRAVEL_FILTER_TYPES, "travel") };
+    default:
+      return assertUnreachable(currentMapMode, "unrecognized map mode");
+  }
+}
+
+/**
+ * The id a filter was built from, and will be found under in the control bar.
+ * The inverse of parseFilter().
+ * @param {PlacesFilter | GeoFilter | TravelFilter} filter
+ * @returns {string}
+ */
+export function selectedIdOf(filter) {
+  return `${filter.type}_${filter.num}`;
+}
+
+/**
  * @template {MapFilterType} T
- * @param {State} state
+ * @param {string} selectedId
  * @param {T[]} allowed
  * @param {string} mapName
- * @returns {[T, number]}
+ * @returns {{ type: T, num: number }}
  */
-function getFilter(state, allowed, mapName) {
-  const [type, stringNum] = state.selectedId.split("_");
+function parseFilter(selectedId, allowed, mapName) {
+  const [type, stringNum] = selectedId.split("_");
   const filterType = allowed.find(known => known === type);
   if (!filterType) {
-    const message = `"${type}" is not a ${mapName} filter (selectedId "${state.selectedId}")`;
+    const message = `"${type}" is not a ${mapName} filter (selectedId "${selectedId}")`;
     alert(message);
     throw new Error(message);
   }
-  return [filterType, parseInt(stringNum)];
-}
-
-/**
- * @param {State} state
- * @returns {[PlacesFilterType, number]}
- */
-export function getPlacesFilter(state) {
-  return getFilter(state, PLACES_FILTER_TYPES, "places");
-}
-
-/**
- * @param {State} state
- * @returns {[GeoFilterType, number]}
- */
-export function getGeoFilter(state) {
-  return getFilter(state, GEO_FILTER_TYPES, "geographical imaginary");
-}
-
-/**
- * @param {State} state
- * @returns {[TravelFilterType, number]}
- */
-export function getTravelFilter(state) {
-  return getFilter(state, TRAVEL_FILTER_TYPES, "travel");
+  return { type: filterType, num: parseInt(stringNum) };
 }

--- a/js/interface/interface.js
+++ b/js/interface/interface.js
@@ -2,7 +2,40 @@ import { updateMap } from "../renderMap/updateMap.js";
 import { createGeoImaginaryInterfaceHtml } from "./geoImaginaryInterface.js";
 import { createPlacesInterfaceHtml } from "./placesInterface.js";
 import { createTravelInterfaceHtml } from "./travelInterface.js";
+import { mapStateFrom, selectedIdOf } from "../calcData/getters.js";
 import { assertUnreachable } from "../assertUnreachable.js";
+
+/**
+ * The filter each map opens on, before anything is clicked.
+ *
+ * Typed a field per mode, so a default a control bar does not offer stops
+ * compiling. Writing placesMode: { type: "all", num: 1 } here used to be
+ * perfectly good JavaScript that alerted on first paint.
+ * @type {DefaultFilters}
+ */
+export const DEFAULT_FILTERS = {
+  placesMode: { type: "relationship", num: 3 },
+  travelMode: { type: "all", num: 1 },
+  geoimaginaryMode: { type: "all", num: 1 }
+};
+
+/**
+ * The state a map starts in.
+ * @param {MapMode} currentMapMode
+ * @returns {MapState}
+ */
+export function defaultMapState(currentMapMode) {
+  switch (currentMapMode) {
+    case "placesMode":
+      return { currentMapMode, filter: DEFAULT_FILTERS.placesMode };
+    case "travelMode":
+      return { currentMapMode, filter: DEFAULT_FILTERS.travelMode };
+    case "geoimaginaryMode":
+      return { currentMapMode, filter: DEFAULT_FILTERS.geoimaginaryMode };
+    default:
+      return assertUnreachable(currentMapMode, "unrecognized map mode");
+  }
+}
 
 /**
  * Redraws the map whenever a different filter is picked in the control bar.
@@ -12,11 +45,12 @@ import { assertUnreachable } from "../assertUnreachable.js";
  */
 export function addPoetsEventListener(map, data, state) {
   /** @type {HTMLElement} */ (document.querySelector("#poetsSelector")).addEventListener("click", () => {
-    const currentSelected = /** @type {HTMLInputElement} */ (
-      document.querySelector("div.buttonContainer input:checked")
-    ).id;
-    if (state.selectedId !== currentSelected) {
-      state.selectedId = currentSelected;
+    const selectedId = /** @type {HTMLInputElement} */ (document.querySelector("div.buttonContainer input:checked")).id;
+    // Parsed against the mode currently showing, so the pair is checked as it
+    // is built rather than every time it is read.
+    const next = mapStateFrom(state.map.currentMapMode, selectedId);
+    if (next.filter.type !== state.map.filter.type || next.filter.num !== state.map.filter.num) {
+      state.map = next;
       updateMap(map, data, state);
     }
   });
@@ -31,41 +65,45 @@ export function addPoetsEventListener(map, data, state) {
 export function addMapModeEventListener(map, data, state) {
   /** @type {HTMLElement} */ (document.querySelector("#mapModeSelector")).addEventListener("click", () => {
     const currentSelected = /** @type {HTMLInputElement} */ (document.querySelector("fieldset input:checked")).id;
-    if (state.currentMapMode !== currentSelected) {
-      state.currentMapMode = /** @type {State["currentMapMode"]} */ (currentSelected);
-      updateMapMode(map, data, state);
+    if (state.map.currentMapMode !== currentSelected) {
+      updateMapMode(map, data, state, /** @type {MapMode} */ (currentSelected));
     }
   });
 }
 
 /**
- * Swaps in the control bar for the current mode, selects its default filter and
+ * Swaps in the control bar for the given mode, selects its default filter and
  * redraws.
+ *
+ * The mode and the filter move together, in one assignment to state.map. They
+ * used to be two fields set one after the other, so between those two lines the
+ * state held the new mode alongside the previous map's filter.
  * @param {LyricMap} map
  * @param {Data} data
  * @param {State} state
+ * @param {MapMode} currentMapMode
  */
-export function updateMapMode(map, data, state) {
+export function updateMapMode(map, data, state, currentMapMode) {
   let interfaceHtml;
-  switch (state.currentMapMode) {
+  switch (currentMapMode) {
     case "placesMode":
       interfaceHtml = createPlacesInterfaceHtml(data);
-      state.selectedId = "relationship_3";
       break;
     case "travelMode":
       interfaceHtml = createTravelInterfaceHtml(data);
-      state.selectedId = "all_1";
       break;
     case "geoimaginaryMode":
       interfaceHtml = createGeoImaginaryInterfaceHtml(data);
-      state.selectedId = "all_1";
       break;
     default:
       // Never returns, so interfaceHtml is known to be set below.
-      assertUnreachable(state.currentMapMode, "unrecognized map mode");
+      assertUnreachable(currentMapMode, "unrecognized map mode");
   }
 
+  state.map = defaultMapState(currentMapMode);
+  const selectedId = selectedIdOf(state.map.filter);
+
   /** @type {HTMLElement} */ (document.getElementById("poetsSelector")).innerHTML = interfaceHtml;
-  /** @type {HTMLInputElement} */ (document.getElementById(state.selectedId)).checked = true;
+  /** @type {HTMLInputElement} */ (document.getElementById(selectedId)).checked = true;
   updateMap(map, data, state);
 }

--- a/js/popups/popups.js
+++ b/js/popups/popups.js
@@ -1,5 +1,4 @@
 import { LYRIC_GREY, LYRIC_RED } from "../constants/colors.js";
-import { getPlacesFilter } from "../calcData/getters.js";
 import { assertUnreachable } from "../assertUnreachable.js";
 import { createNumberedListOfPoets, createDetailedListOfPoets, renderReference } from "./popupsCommon.js";
 
@@ -12,9 +11,10 @@ import { createNumberedListOfPoets, createDetailedListOfPoets, renderReference }
  * @returns {string}
  */
 export function createPopupHtml(state, data, bubble) {
-  switch (state.currentMapMode) {
+  const mapState = state.map;
+  switch (mapState.currentMapMode) {
     case "placesMode": {
-      const [type, num] = getPlacesFilter(state);
+      const { type, num } = mapState.filter;
       // Relationship 3 is "activity", which gets its own native/non-native split.
       return type === "relationship" && num === 3
         ? createActivePopupHtml(data, bubble)
@@ -28,7 +28,7 @@ export function createPopupHtml(state, data, bubble) {
       // The travel map draws arcs and builds its popups in travelPopups.js.
       throw new Error("createPopupHtml is not used by the travel map");
     default:
-      return assertUnreachable(state.currentMapMode, "unrecognized map mode");
+      return assertUnreachable(mapState, "unrecognized map mode");
   }
 }
 

--- a/js/renderMap/calcBubbles.js
+++ b/js/renderMap/calcBubbles.js
@@ -20,7 +20,7 @@ export function calculateBubbles(state, data, poetCities) {
     // bubble be built complete instead of filled in field by field.
     /** @type {BubbleContents} */
     const contents = { city: data.citiesById[cityId], poetCities: rows };
-    if (state.currentMapMode === "geoimaginaryMode") contents.poets = groupRowsByPoet(rows);
+    if (state.map.currentMapMode === "geoimaginaryMode") contents.poets = groupRowsByPoet(rows);
 
     bubbles[cityId] = {
       ...contents,

--- a/js/renderMap/calcPoetCities.js
+++ b/js/renderMap/calcPoetCities.js
@@ -1,4 +1,4 @@
-import { getGenres, getPlacesFilter, getGeoFilter } from "../calcData/getters.js";
+import { getGenres } from "../calcData/getters.js";
 import { assertUnreachable } from "../assertUnreachable.js";
 import { getDateFilterFn } from "./calcCommon.js";
 
@@ -16,27 +16,29 @@ import { getDateFilterFn } from "./calcCommon.js";
  * @returns {RenderedPoetCity[]}
  */
 export function calcPoetCities(data, state) {
-  switch (state.currentMapMode) {
+  const mapState = state.map;
+  switch (mapState.currentMapMode) {
     case "placesMode":
-      return calcPlacesPoetCities(data, state);
+      return calcPlacesPoetCities(data, state, mapState.filter);
     case "geoimaginaryMode":
-      return calcGeoPoetCities(data, state);
+      return calcGeoPoetCities(data, state, mapState.filter);
     case "travelMode":
       // The travel map draws arcs rather than bubbles, and calculates them in
       // lines.js. Nothing routes it here.
       throw new Error("calcPoetCities is not used by the travel map");
     default:
-      return assertUnreachable(state.currentMapMode, "unrecognized current map mode");
+      return assertUnreachable(mapState, "unrecognized current map mode");
   }
 }
 
 /**
  * @param {Data} data
  * @param {State} state
+ * @param {PlacesFilter} filter
  * @returns {RenderedPoetCity[]}
  */
-function calcPlacesPoetCities(data, state) {
-  const [type, num] = getPlacesFilter(state);
+function calcPlacesPoetCities(data, state, filter) {
+  const { type, num } = filter;
   const dated = data.poetCities.filter(getDateFilterFn(data, state));
 
   if (type === "genre") return renderGenreRows(dated, data, num);
@@ -47,13 +49,13 @@ function calcPlacesPoetCities(data, state) {
 /**
  * @param {Data} data
  * @param {State} state
+ * @param {GeoFilter} filter
  * @returns {RenderedPoetCity[]}
  */
-function calcGeoPoetCities(data, state) {
-  const [type, num] = getGeoFilter(state);
+function calcGeoPoetCities(data, state, filter) {
   const dated = data.geopoetCities.filter(getDateFilterFn(data, state));
 
-  return dated.filter(getGeoFilterFn(type, num)).map(poetCity => renderPoetCity(poetCity));
+  return dated.filter(getGeoFilterFn(filter.type, filter.num)).map(poetCity => renderPoetCity(poetCity));
 }
 
 /**

--- a/js/renderMap/lines.js
+++ b/js/renderMap/lines.js
@@ -1,7 +1,6 @@
 import { TRAVEL_RED, TRAVEL_PURPLE, TRAVEL_YELLOW } from "../constants/colors.js";
 import { drawLines } from "../drawMap/drawLines.js";
 import { drawBubblesAndLegends } from "../drawMap/drawBubbles.js";
-import { getTravelFilter } from "../calcData/getters.js";
 import { createTravelPopupHtml, createGovTravelPopupHtml } from "../popups/travelPopups.js";
 import { getDateFilterFn } from "./calcCommon.js";
 import { assertUnreachable } from "../assertUnreachable.js";
@@ -10,13 +9,11 @@ import { assertUnreachable } from "../assertUnreachable.js";
  * @param {LyricMap} map
  * @param {Data} data
  * @param {State} state
+ * @param {TravelFilter} filter narrowed by updateMap, from state.map
  */
-export function calculateAndDrawLines(map, data, state) {
-  // Parsed once here and threaded down. Re-deriving it inside colorLine and
-  // weightLine meant splitting state.selectedId a few hundred times per redraw.
-  const [type, num] = getTravelFilter(state);
-  const filteredPoetLines = filterLines(data, type, num).filter(getDateFilterFn(data, state));
-  const calculatedLines = calculateLines(data, type, num, filteredPoetLines);
+export function calculateAndDrawLines(map, data, state, filter) {
+  const filteredPoetLines = filterLines(data, filter).filter(getDateFilterFn(data, state));
+  const calculatedLines = calculateLines(data, filter, filteredPoetLines);
   const travelBubbles = calculateTravelBubbles(data, filteredPoetLines);
   drawLines(map, calculatedLines);
   drawBubblesAndLegends(map, travelBubbles);
@@ -25,11 +22,10 @@ export function calculateAndDrawLines(map, data, state) {
 /**
  * Narrows every poet line down to those matching the selected radio button.
  * @param {Data} data
- * @param {TravelFilterType} type
- * @param {number} num
+ * @param {TravelFilter} filter
  * @returns {Line[]}
  */
-export function filterLines(data, type, num) {
+export function filterLines(data, { type, num }) {
   switch (type) {
     case "all":
       return data.lines;
@@ -63,12 +59,11 @@ function hashCityIds(from, to) {
  * Merges every poet line sharing a city pair into a single drawn arc, then
  * colours, weights and builds a popup for each.
  * @param {Data} data
- * @param {TravelFilterType} type
- * @param {number} num
+ * @param {TravelFilter} filter
  * @param {Line[]} filteredPoetLines
  * @returns {Record<number, DrawnLine>}
  */
-export function calculateLines(data, type, num, filteredPoetLines) {
+export function calculateLines(data, { type, num }, filteredPoetLines) {
   /** @type {Record<number, DrawnLine>} */
   const lines = {};
 

--- a/js/renderMap/updateMap.js
+++ b/js/renderMap/updateMap.js
@@ -12,7 +12,8 @@ import { assertUnreachable } from "../assertUnreachable.js";
  */
 export function updateMap(map, data, state) {
   clearMap(map);
-  switch (state.currentMapMode) {
+  const mapState = state.map;
+  switch (mapState.currentMapMode) {
     case "placesMode":
     case "geoimaginaryMode": {
       const poetCities = calcPoetCities(data, state);
@@ -21,10 +22,12 @@ export function updateMap(map, data, state) {
       break;
     }
     case "travelMode":
-      calculateAndDrawLines(map, data, state);
+      // Narrowed here, so the travel map is handed a travel filter rather than
+      // re-deriving one and having to consider filters it does not offer.
+      calculateAndDrawLines(map, data, state, mapState.filter);
       break;
     default:
-      assertUnreachable(state.currentMapMode, "unrecognized map mode");
+      assertUnreachable(mapState, "unrecognized map mode");
   }
   // axe-core is loaded globally by index.html, so accessibility can be checked
   // from the devtools console at any point: await axe.run()

--- a/tests/browser/smoke.test.js
+++ b/tests/browser/smoke.test.js
@@ -18,7 +18,7 @@ import { test, describe, before, after } from "node:test";
 import assert from "node:assert/strict";
 import { chromium } from "playwright";
 import { serveSite } from "./serve.js";
-import { loadInitializedData } from "../helpers/loadData.js";
+import { loadInitializedData, stateFor } from "../helpers/loadData.js";
 import { calcPoetCities } from "../../js/renderMap/calcPoetCities.js";
 import { calculateBubbles } from "../../js/renderMap/calcBubbles.js";
 
@@ -30,13 +30,12 @@ const CIRCLES_PER_BUBBLE = 2;
 /**
  * How many bubbles the pure pipeline says a given view should have, counting
  * only those with coordinates — drawBubbles() skips the rest.
- * @param {State["currentMapMode"]} currentMapMode
+ * @param {MapMode} currentMapMode
  * @param {string} selectedId
  * @returns {number}
  */
 function expectedBubbles(currentMapMode, selectedId) {
-  /** @type {State} */
-  const state = { currentMapMode, selectedId, minDate: -800, maxDate: -400 };
+  const state = stateFor(currentMapMode, selectedId);
   const bubbles = calculateBubbles(state, data, calcPoetCities(data, state));
   return Object.values(bubbles).filter(bubble => bubble.city.lat && bubble.city.long).length;
 }

--- a/tests/helpers/loadData.js
+++ b/tests/helpers/loadData.js
@@ -3,6 +3,7 @@ import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { parseCsv } from "./csv.js";
 import { initializeData } from "../../js/calcData/data.js";
+import { mapStateFrom } from "../../js/calcData/getters.js";
 
 const dataFilesDir = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "dataFiles");
 
@@ -67,6 +68,26 @@ export function loadInitializedData() {
     globals.alert = realAlert;
     console.log = realLog;
   }
+}
+
+/** The whole slider range, i.e. what a map shows before anything is dragged. */
+export const ALL_DATES = { minDate: -800, maxDate: -400 };
+
+/**
+ * A State as the browser holds it: a map mode paired with the filter its control
+ * bar has selected, plus a date range.
+ *
+ * Built through mapStateFrom(), which is the same call the click handlers make,
+ * so a test cannot quietly assert against a mode-and-filter pair the map has no
+ * way to produce — asking for one throws here rather than rendering something
+ * the application never shows.
+ * @param {MapMode} currentMapMode
+ * @param {string} selectedId
+ * @param {{ minDate: number, maxDate: number }} [dates]
+ * @returns {State}
+ */
+export function stateFor(currentMapMode, selectedId, dates = ALL_DATES) {
+  return { map: mapStateFrom(currentMapMode, selectedId), ...dates };
 }
 
 /**

--- a/tests/initializeData.test.js
+++ b/tests/initializeData.test.js
@@ -7,7 +7,8 @@ import { test, describe } from "node:test";
 import assert from "node:assert/strict";
 import { loadInitializedData } from "./helpers/loadData.js";
 import { sortAlphabetically } from "../js/calcData/data.js";
-import { PLACES_FILTER_TYPES, GEO_FILTER_TYPES, TRAVEL_FILTER_TYPES } from "../js/calcData/getters.js";
+import { PLACES_FILTER_TYPES, GEO_FILTER_TYPES, TRAVEL_FILTER_TYPES, selectedIdOf } from "../js/calcData/getters.js";
+import { defaultMapState } from "../js/interface/interface.js";
 import { createPlacesInterfaceHtml } from "../js/interface/placesInterface.js";
 import { createTravelInterfaceHtml } from "../js/interface/travelInterface.js";
 import { createGeoImaginaryInterfaceHtml } from "../js/interface/geoImaginaryInterface.js";
@@ -314,10 +315,25 @@ describe("each control bar offers exactly the filters its map declares", () => {
     }
   });
 
-  test("the default selectedId of each mode is one that mode can handle", () => {
-    // updateMapMode() sets these; they are what the map renders on first paint.
-    assert.ok(PLACES_FILTER_TYPES.includes(/** @type {PlacesFilterType} */ ("relationship")));
-    assert.ok(GEO_FILTER_TYPES.includes(/** @type {GeoFilterType} */ ("all")));
-    assert.ok(TRAVEL_FILTER_TYPES.includes(/** @type {TravelFilterType} */ ("all")));
+  test("the button each map opens on is one its control bar actually renders", () => {
+    // DEFAULT_FILTERS is typed per mode, so a default the map cannot handle no
+    // longer compiles. What the types still cannot see is whether the radio
+    // button it names exists: updateMapMode() looks it up by id and sets
+    // .checked on it, so a default naming a button no one renders would throw
+    // on first paint. Hence this, which the previous version of the test — a
+    // membership check against the filter union — could not catch.
+    /** @type {[MapMode, string][]} */
+    const CONTROL_BARS = [
+      ["placesMode", createPlacesInterfaceHtml(data)],
+      ["travelMode", createTravelInterfaceHtml(data)],
+      ["geoimaginaryMode", createGeoImaginaryInterfaceHtml(data)]
+    ];
+    for (const [mode, html] of CONTROL_BARS) {
+      const selectedId = selectedIdOf(defaultMapState(mode).filter);
+      assert.ok(
+        idsIn(html).includes(selectedId),
+        `${mode} opens on "${selectedId}", which its control bar does not render`
+      );
+    }
   });
 });

--- a/tests/lines.test.js
+++ b/tests/lines.test.js
@@ -11,15 +11,13 @@
 
 import { test, describe } from "node:test";
 import assert from "node:assert/strict";
-import { loadInitializedData } from "./helpers/loadData.js";
+import { loadInitializedData, stateFor } from "./helpers/loadData.js";
 import { filterLines, calculateLines } from "../js/renderMap/lines.js";
+import { selectedIdOf } from "../js/calcData/getters.js";
 import { getDateFilterFn } from "../js/renderMap/calcCommon.js";
 import { TRAVEL_RED, TRAVEL_PURPLE, TRAVEL_YELLOW } from "../js/constants/colors.js";
 
 const { data } = loadInitializedData();
-
-/** The whole slider range, i.e. what the map shows before anything is dragged. */
-const ALL_DATES = { minDate: -800, maxDate: -400 };
 
 /** governments.csv ids, as the political system control bar offers them. */
 const DEMOCRACY = 3;
@@ -33,10 +31,12 @@ const TYRANNY = 2;
  * @returns {DrawnLine[]}
  */
 function arcsFor(type, num) {
-  /** @type {State} */
-  const state = { currentMapMode: "travelMode", selectedId: `${type}_${num}`, ...ALL_DATES };
-  const poetLines = filterLines(data, type, num).filter(getDateFilterFn(data, state));
-  return Object.values(calculateLines(data, type, num, poetLines));
+  /** @type {TravelFilter} */
+  const filter = { type, num };
+  // Round-tripped through the control bar id, as a click on that button would.
+  const state = stateFor("travelMode", selectedIdOf(filter));
+  const poetLines = filterLines(data, filter).filter(getDateFilterFn(data, state));
+  return Object.values(calculateLines(data, filter, poetLines));
 }
 
 /**

--- a/tests/popups.test.js
+++ b/tests/popups.test.js
@@ -7,23 +7,20 @@
 
 import { test, describe } from "node:test";
 import assert from "node:assert/strict";
-import { loadInitializedData } from "./helpers/loadData.js";
+import { loadInitializedData, stateFor } from "./helpers/loadData.js";
 import { calcPoetCities } from "../js/renderMap/calcPoetCities.js";
 import { calculateBubbles } from "../js/renderMap/calcBubbles.js";
 import { createTravelPopupHtml } from "../js/popups/travelPopups.js";
 
 const { data } = loadInitializedData();
 
-const ALL_DATES = { minDate: -800, maxDate: -400 };
-
 /**
- * @param {State["currentMapMode"]} currentMapMode
+ * @param {MapMode} currentMapMode
  * @param {string} selectedId
  * @returns {Record<number, Bubble>}
  */
 function bubblesFor(currentMapMode, selectedId) {
-  /** @type {State} */
-  const state = { currentMapMode, selectedId, ...ALL_DATES };
+  const state = stateFor(currentMapMode, selectedId);
   return calculateBubbles(state, data, calcPoetCities(data, state));
 }
 
@@ -180,7 +177,7 @@ describe("travel map", () => {
 
 describe("popup html is well formed enough to render", () => {
   test("no popup leaks 'undefined' or 'NaN' into the page", () => {
-    /** @type {[State["currentMapMode"], string][]} */
+    /** @type {[MapMode, string][]} */
     const VIEWS = [
       ["placesMode", "relationship_1"],
       ["placesMode", "relationship_3"],

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -343,15 +343,67 @@ interface DrawnLine extends TravelArc {
   popupHtml: string;
 }
 
-/** Which of the three maps is showing, and the current filters. */
+/** Which of the three maps is showing. */
+type MapMode = "placesMode" | "travelMode" | "geoimaginaryMode";
+
+/**
+ * One control bar selection, parsed: the kind of filter, and the id it names.
+ *
+ * `num` means something different in each case — a relationshipId, a poetId, a
+ * genreId, a cityId, a regionId or a governmentId — which is why the three
+ * aliases below exist rather than one shared shape.
+ */
+interface PlacesFilter {
+  type: PlacesFilterType;
+  num: number;
+}
+
+/** As PlacesFilter, for the geographical imaginary map. */
+interface GeoFilter {
+  type: GeoFilterType;
+  num: number;
+}
+
+/** As PlacesFilter, for the travel map. */
+interface TravelFilter {
+  type: TravelFilterType;
+  num: number;
+}
+
+/**
+ * Which map is showing and what its control bar has selected — one value,
+ * because the two are not independent. A map mode and a filter its control bar
+ * cannot produce is not a state this application has; before this was a union
+ * it was merely a state nothing happened to write.
+ *
+ * The pairing was previously enforced at runtime, by getPlacesFilter() and its
+ * neighbours re-parsing a selectedId string on every read and alerting if the
+ * halves disagreed. Now the pair is constructed once, by mapStateFrom(), and
+ * every consumer narrows it with a switch on currentMapMode.
+ */
+type MapState =
+  | { currentMapMode: "placesMode"; filter: PlacesFilter }
+  | { currentMapMode: "travelMode"; filter: TravelFilter }
+  | { currentMapMode: "geoimaginaryMode"; filter: GeoFilter };
+
+/** The map showing, its filter, and the date range every map shares. */
 interface State {
-  currentMapMode: "placesMode" | "travelMode" | "geoimaginaryMode";
+  map: MapState;
   /** Negative for BCE. */
   minDate: number;
   /** Negative for BCE. */
   maxDate: number;
-  /** The checked radio button's id, e.g. "poet_93" or "relationship_1". */
-  selectedId: string;
+}
+
+/**
+ * The filter each map opens on, before anything is clicked. Typed one field per
+ * mode, so a default its own control bar does not offer — placesMode: "all",
+ * say — is a compile error rather than an alert on first paint.
+ */
+interface DefaultFilters {
+  placesMode: PlacesFilter;
+  travelMode: TravelFilter;
+  geoimaginaryMode: GeoFilter;
 }
 
 /**


### PR DESCRIPTION
Fourth of five, and the one the others were clearing the way for. **Stacked on #344.**

## The bad state

`State` kept the map mode and the selected filter as independent fields:

```ts
interface State {
  currentMapMode: "placesMode" | "travelMode" | "geoimaginaryMode";
  selectedId: string;   // "poet_93", "relationship_1", ...
}
```

So a travel map filtered by genre, a places map filtered by ALL, and a geographical imaginary map filtered by political system were all perfectly well-typed values. Nothing wrote them — but nothing said they could not exist, and the check that they did not happen was made **at runtime, on every read**: `getPlacesFilter()`, `getGeoFilter()` and `getTravelFilter()` each re-split the string and alerted if the halves disagreed.

## The fix

```ts
type MapState =
  | { currentMapMode: "placesMode";       filter: PlacesFilter }
  | { currentMapMode: "travelMode";       filter: TravelFilter }
  | { currentMapMode: "geoimaginaryMode"; filter: GeoFilter };

interface State { map: MapState; minDate: number; maxDate: number }
```

I checked this actually bites rather than assuming it — all four of these were valid TS before, and now:

```
js/badstate.js(3,34): error TS2322: Type '"genre"' is not assignable to type 'TravelFilterType'.
js/badstate.js(5,32): error TS2322: Type '"all"'   is not assignable to type 'PlacesFilterType'.
js/badstate.js(7,29): error TS2322: Type '"gov"'   is not assignable to type 'GeoFilterType'.
js/badstate.js(9,44): error TS2322: Type '"all"'   is not assignable to type 'PlacesFilterType'.
```

The three getters collapse into `mapStateFrom()` — the single place a `MapState` is constructed, and the only place a `selectedId` becomes a filter. It is exhaustive over the modes and checks each id against that mode's own filters, so an ill-formed pair cannot leave it. Everything downstream narrows with a `switch` and gets the filter type that goes with the mode.

The travel map benefits most directly: `updateMap()` narrows and hands `calculateAndDrawLines()` a `TravelFilter`, so it no longer parses state itself, and no longer has to be trusted to have been called in the right mode.

`selectedId` is gone as a field — it was a serialised pair, and is now built only where the DOM needs it, by `selectedIdOf()`, the inverse of the parse.

`DEFAULT_FILTERS` gets a type with a field per mode, so `placesMode: { type: "all" }` stops compiling; it used to be ordinary JavaScript that alerted on first paint. `updateMapMode()` also sets mode and filter in **one** assignment — they were two statements, and between them the state held the new mode beside the previous map's filter.

## Tests

The three files that built a `State` by hand now share a `stateFor()` helper that goes through `mapStateFrom()`, so a test cannot quietly assert against a pair the application cannot produce.

The old *"the default selectedId of each mode is one that mode can handle"* is now enforced by `DefaultFilters`, so it is replaced with one the types **still** cannot make: that the button each map opens on is one its control bar actually renders. `updateMapMode()` looks that id up and sets `.checked` on it, so a default naming a button no one renders throws on first paint — and nothing checked it before. Confirmed to fail when a default is repointed.

## Knowingly left

`createFilterInput()` still takes `MapFilterType` rather than the filter type of the map calling it, so a control bar can still be written to emit a prefix its own map rejects. Constraining that needs a bigger change than it earns; the round-trip tests (tightened to equalities in #344) are what cover it.

## Verification

No behaviour change — the bubbles for six views and the arcs for all 182 travel filters, popup html included, are **byte-identical** to the parent branch (1.5M and 1.7M chars of serialised output).

Tests (98), lint, format and the browser smoke test all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
