### PR TITLE
Split the bubble types by the map that draws them

### DIFF
--- a/js/calcData/data.js
+++ b/js/calcData/data.js
@@ -93,9 +93,9 @@ function hydrate(raw) {
  */
 function createLookups(csvs) {
   return {
-    citiesById: keyById(csvs.cities, city => city.cityId),
-    poetsById: keyById(csvs.poets, poet => poet.poetId),
-    regionsById: keyById(csvs.regions, region => region.regionId),
+    citiesById: keyById(csvs.cities, city => city.cityId, identity),
+    poetsById: keyById(csvs.poets, poet => poet.poetId, identity),
+    regionsById: keyById(csvs.regions, region => region.regionId, identity),
     genresByPoetId: groupById(csvs.genres, genre => genre.poetId, identity),
     genresByGenreId: createGenresByGenreId(csvs.genres),
     govsByCityId: groupById(csvs.cityPolitics, cityPolitics => cityPolitics.cityId, identity),
@@ -153,14 +153,14 @@ function identity(value) {
  * @template T, V
  * @param {T[]} rows
  * @param {(row: T) => number} idOf
- * @param {(row: T) => V} [valueOf] defaults to the row itself
+ * @param {(row: T) => V} valueOf pass identity to key the rows themselves
  * @returns {Record<number, V>}
  */
 function keyById(rows, idOf, valueOf) {
   /** @type {Record<number, V>} */
   const byId = {};
   for (const row of rows) {
-    byId[idOf(row)] = valueOf ? valueOf(row) : /** @type {any} */ (row);
+    byId[idOf(row)] = valueOf(row);
   }
   return byId;
 }

--- a/js/interface/commonInterface.js
+++ b/js/interface/commonInterface.js
@@ -1,7 +1,6 @@
 // The control bar is plain HTML built as strings, so a radio button's id is the
-// only thing tying a click back to a filter. That id is `${prefix}_${num}`, it
-// becomes state.selectedId, and getPlacesFilter() / getTravelFilter() parse it
-// back apart.
+// only thing tying a click back to a filter. That id is `${prefix}_${num}`, and
+// mapStateFrom() parses it back apart into the filter its map is showing.
 //
 // The prefix is therefore typed rather than a bare string: misspell one here and
 // it stops compiling, instead of producing a button that alerts when clicked.

--- a/js/popups/popups.js
+++ b/js/popups/popups.js
@@ -3,39 +3,36 @@ import { assertUnreachable } from "../assertUnreachable.js";
 import { createNumberedListOfPoets, createDetailedListOfPoets, renderReference } from "./popupsCommon.js";
 
 /**
- * Builds the html shown when a city bubble is clicked, for whichever of the
- * places / geographical-imaginary maps is showing.
- * @param {State} state
+ * Builds the html shown when a city bubble on the places map is clicked.
+ *
+ * Entered directly by calculatePlacesBubbles() rather than through a function
+ * that switched on the map mode. That switch had a branch for the travel map,
+ * which draws arcs and builds its popups in travelPopups.js, so it could only
+ * throw.
  * @param {Data} data
- * @param {BubbleContents} bubble
+ * @param {PlacesBubbleContents} bubble
+ * @param {PlacesFilter} filter
  * @returns {string}
  */
-export function createPopupHtml(state, data, bubble) {
-  const mapState = state.map;
-  switch (mapState.currentMapMode) {
-    case "placesMode": {
-      const { type, num } = mapState.filter;
-      // Relationship 3 is "activity", which gets its own native/non-native split.
-      return type === "relationship" && num === 3
-        ? createActivePopupHtml(data, bubble)
-        : createPlacesPopupHtml(data, bubble, type, num);
-    }
-    case "geoimaginaryMode":
-      // Its title counts references rather than naming a filter, so unlike the
-      // places map it does not need to know which button is selected.
-      return createGeoImaginaryPopupHtml(bubble);
-    case "travelMode":
-      // The travel map draws arcs and builds its popups in travelPopups.js.
-      throw new Error("createPopupHtml is not used by the travel map");
-    default:
-      return assertUnreachable(mapState, "unrecognized map mode");
-  }
+export function createPlacesPopupHtml(data, bubble, filter) {
+  const { type, num } = filter;
+  // Relationship 3 is "activity", which gets its own native/non-native split.
+  if (type === "relationship" && num === 3) return createActivePopupHtml(data, bubble);
+
+  const cityname = bubble.city.infowindowName.toUpperCase();
+  const poetCities = bubble.poetCities;
+  return `
+    ${createHeader(cityname, createPlacesModeTitle(data, cityname, type, num))}
+    ${createNumberedListOfPoets(poetCities.map(pc => pc.poetDetailName))}
+    <h4 style="color:${LYRIC_GREY}">DETAILS</h4>
+    ${createDetailedListOfPoets(poetCities, data)}
+  `;
 }
 
 /**
  * The ACTIVITY popup, which splits a city's poets into natives and incomers.
  * @param {Data} data
- * @param {BubbleContents} bubble
+ * @param {PlacesBubbleContents} bubble
  * @returns {string}
  */
 function createActivePopupHtml(data, bubble) {
@@ -98,24 +95,6 @@ function createHeader(cityname, title) {
   return `
     <h3 style="color:${LYRIC_GREY}">${cityname}</h3>
     <h5 style="color:${LYRIC_GREY}">${title}</h5>
-  `;
-}
-
-/**
- * @param {Data} data
- * @param {BubbleContents} bubble
- * @param {PlacesFilterType} type
- * @param {number} num
- * @returns {string}
- */
-function createPlacesPopupHtml(data, bubble, type, num) {
-  const cityname = bubble.city.infowindowName.toUpperCase();
-  const poetCities = bubble.poetCities;
-  return `
-    ${createHeader(cityname, createPlacesModeTitle(data, cityname, type, num))}
-    ${createNumberedListOfPoets(poetCities.map(pc => pc.poetDetailName))}
-    <h4 style="color:${LYRIC_GREY}">DETAILS</h4>
-    ${createDetailedListOfPoets(poetCities, data)}
   `;
 }
 
@@ -185,18 +164,23 @@ function createPlacesModeTitle(data, cityname, type, num) {
 }
 
 /**
- * @param {BubbleContents} bubble
+ * Builds the html shown when a city bubble on the geographical imaginary map is
+ * clicked. Its title counts references rather than naming a filter, so unlike
+ * the places map it never needs to know which button is selected.
+ *
+ * `bubble.poets` is read straight off a GeoBubbleContents. It used to be an
+ * optional field on a type shared with the places map, so this was the one
+ * place left that had to cast.
+ * @param {GeoBubbleContents} bubble
  * @returns {string}
  */
-function createGeoImaginaryPopupHtml(bubble) {
+export function createGeoPopupHtml(bubble) {
   const cityname = bubble.city.infowindowName.toUpperCase();
-  // calcBubbles always populates poets in geoimaginaryMode.
-  const poets = /** @type {GeoBubblePoet[]} */ (bubble.poets);
   const referenceStr = bubble.poetCities.length === 1 ? "REFERENCE" : "REFERENCES";
   return `
     ${createHeader(cityname, `${bubble.poetCities.length} ${referenceStr} TO ${cityname}`)}
-    ${createGeoHeaderListOfPoets(poets)}
+    ${createGeoHeaderListOfPoets(bubble.poets)}
     <h4 style="color:${LYRIC_GREY}">DETAILS</h4>
-    ${createDetailedGeoListOfPoets(poets)}
+    ${createDetailedGeoListOfPoets(bubble.poets)}
   `;
 }

--- a/js/renderMap/calcBubbles.js
+++ b/js/renderMap/calcBubbles.js
@@ -1,36 +1,63 @@
 import { sortAlphabetically } from "../calcData/data.js";
-import { createPopupHtml } from "../popups/popups.js";
+import { createPlacesPopupHtml, createGeoPopupHtml } from "../popups/popups.js";
 
 /**
  * Groups rendered rows by city into one bubble per city, sized by how many
  * poets it holds, and attaches each bubble's popup html.
- * @param {State} state
+ *
+ * One function per map rather than one taking the mode, because the two build
+ * different bubbles: only the geographical imaginary groups its rows by poet.
+ * Returning the narrower type is what lets its popup read `poets` without a
+ * cast asserting that this really was the geographical imaginary after all.
+ * @param {Data} data
+ * @param {PlacesFilter} filter
+ * @param {RenderedPoetCity[]} poetCities
+ * @returns {Record<number, PlacesBubble>}
+ */
+export function calculatePlacesBubbles(data, filter, poetCities) {
+  /** @type {Record<number, PlacesBubble>} */
+  const bubbles = {};
+  for (const [cityId, rows] of groupRowsByCity(data, poetCities)) {
+    /** @type {PlacesBubbleContents} */
+    const contents = { city: data.citiesById[cityId], poetCities: rows };
+    bubbles[cityId] = { ...contents, ...drawnAs(contents, createPlacesPopupHtml(data, contents, filter)) };
+  }
+  return bubbles;
+}
+
+/**
+ * As calculatePlacesBubbles, for the geographical imaginary map.
  * @param {Data} data
  * @param {RenderedPoetCity[]} poetCities
- * @returns {Record<number, Bubble>}
+ * @returns {Record<number, GeoBubble>}
  */
-export function calculateBubbles(state, data, poetCities) {
-  /** @type {Record<number, Bubble>} */
+export function calculateGeoBubbles(data, poetCities) {
+  /** @type {Record<number, GeoBubble>} */
   const bubbles = {};
-
-  for (const [key, rows] of Object.entries(groupRowsByCity(data, poetCities))) {
-    const cityId = Number(key);
-    // The contents are assembled first because the popup is rendered from them,
-    // and from nothing that is added alongside it. That ordering is what lets a
-    // bubble be built complete instead of filled in field by field.
-    /** @type {BubbleContents} */
-    const contents = { city: data.citiesById[cityId], poetCities: rows };
-    if (state.map.currentMapMode === "geoimaginaryMode") contents.poets = groupRowsByPoet(rows);
-
-    bubbles[cityId] = {
-      ...contents,
-      price: calculateBubblePriceFromNumberOfPoets(rows.length),
-      popupHtml: createPopupHtml(state, data, contents),
-      legend: contents.city.cityname
-    };
+  for (const [cityId, rows] of groupRowsByCity(data, poetCities)) {
+    /** @type {GeoBubbleContents} */
+    const contents = { city: data.citiesById[cityId], poetCities: rows, poets: groupRowsByPoet(rows) };
+    bubbles[cityId] = { ...contents, ...drawnAs(contents, createGeoPopupHtml(contents)) };
   }
-
   return bubbles;
+}
+
+/**
+ * What every bubble gets once its contents are known: the size it is drawn at,
+ * the popup it opens and the label beneath it.
+ *
+ * Taken as an argument rather than rendered here, because the popup is the one
+ * thing the two maps do not share.
+ * @param {PlacesBubbleContents} contents
+ * @param {string} popupHtml
+ * @returns {{ price: number, popupHtml: string, legend: string }}
+ */
+function drawnAs(contents, popupHtml) {
+  return {
+    price: calculateBubblePriceFromNumberOfPoets(contents.poetCities.length),
+    popupHtml,
+    legend: contents.city.cityname
+  };
 }
 
 /**
@@ -38,7 +65,7 @@ export function calculateBubbles(state, data, poetCities) {
  * from cities.csv.
  * @param {Data} data
  * @param {RenderedPoetCity[]} poetCities
- * @returns {Record<number, RenderedPoetCity[]>}
+ * @returns {[number, RenderedPoetCity[]][]}
  */
 function groupRowsByCity(data, poetCities) {
   /** @type {Record<number, RenderedPoetCity[]>} */
@@ -49,7 +76,7 @@ function groupRowsByCity(data, poetCities) {
     if (!rowsByCity[cityId]) rowsByCity[cityId] = [];
     rowsByCity[cityId].push(poetCity);
   }
-  return rowsByCity;
+  return Object.entries(rowsByCity).map(([cityId, rows]) => [Number(cityId), rows]);
 }
 
 /**

--- a/js/renderMap/calcPoetCities.js
+++ b/js/renderMap/calcPoetCities.js
@@ -5,39 +5,19 @@ import { getDateFilterFn } from "./calcCommon.js";
 /** @typedef {PoetCity | GeoPoetCity} AnyPoetCity */
 
 /**
- * Picks the right source rows for the current map, applies the date slider and
- * control-bar filters, and flattens the survivors for rendering.
+ * Applies the date slider and the selected places filter, and flattens the
+ * survivors for rendering.
  *
- * The two maps are handled apart rather than together, because they do not
- * offer the same filters: places has ORIGIN, ACTIVITY and the genres,
- * geographical imaginary has ALL REFERENCES. They share only "poet".
- * @param {Data} data
- * @param {State} state
- * @returns {RenderedPoetCity[]}
- */
-export function calcPoetCities(data, state) {
-  const mapState = state.map;
-  switch (mapState.currentMapMode) {
-    case "placesMode":
-      return calcPlacesPoetCities(data, state, mapState.filter);
-    case "geoimaginaryMode":
-      return calcGeoPoetCities(data, state, mapState.filter);
-    case "travelMode":
-      // The travel map draws arcs rather than bubbles, and calculates them in
-      // lines.js. Nothing routes it here.
-      throw new Error("calcPoetCities is not used by the travel map");
-    default:
-      return assertUnreachable(mapState, "unrecognized current map mode");
-  }
-}
-
-/**
+ * Exported alongside calcGeoPoetCities() rather than behind one function that
+ * switched on the map mode. That switch needed a third branch for the travel
+ * map, which draws arcs rather than bubbles and never called it, so the branch
+ * could only throw.
  * @param {Data} data
  * @param {State} state
  * @param {PlacesFilter} filter
  * @returns {RenderedPoetCity[]}
  */
-function calcPlacesPoetCities(data, state, filter) {
+export function calcPlacesPoetCities(data, state, filter) {
   const { type, num } = filter;
   const dated = data.poetCities.filter(getDateFilterFn(data, state));
 
@@ -47,12 +27,13 @@ function calcPlacesPoetCities(data, state, filter) {
 }
 
 /**
+ * As calcPlacesPoetCities, for the geographical imaginary map's rows.
  * @param {Data} data
  * @param {State} state
  * @param {GeoFilter} filter
  * @returns {RenderedPoetCity[]}
  */
-function calcGeoPoetCities(data, state, filter) {
+export function calcGeoPoetCities(data, state, filter) {
   const dated = data.geopoetCities.filter(getDateFilterFn(data, state));
 
   return dated.filter(getGeoFilterFn(filter.type, filter.num)).map(poetCity => renderPoetCity(poetCity));

--- a/js/renderMap/updateMap.js
+++ b/js/renderMap/updateMap.js
@@ -1,6 +1,6 @@
 import { calculateAndDrawLines } from "./lines.js";
-import { calcPoetCities } from "./calcPoetCities.js";
-import { calculateBubbles } from "./calcBubbles.js";
+import { calcPlacesPoetCities, calcGeoPoetCities } from "./calcPoetCities.js";
+import { calculatePlacesBubbles, calculateGeoBubbles } from "./calcBubbles.js";
 import { drawBubblesAndLegends } from "../drawMap/drawBubbles.js";
 import { assertUnreachable } from "../assertUnreachable.js";
 
@@ -14,13 +14,18 @@ export function updateMap(map, data, state) {
   clearMap(map);
   const mapState = state.map;
   switch (mapState.currentMapMode) {
+    // Each map runs its own pipeline end to end, narrowed once here. The two
+    // bubble maps used to share one, which meant every step downstream had to
+    // re-establish which of them it was working for.
     case "placesMode":
-    case "geoimaginaryMode": {
-      const poetCities = calcPoetCities(data, state);
-      const bubbles = calculateBubbles(state, data, poetCities);
-      drawBubblesAndLegends(map, bubbles);
+      drawBubblesAndLegends(
+        map,
+        calculatePlacesBubbles(data, mapState.filter, calcPlacesPoetCities(data, state, mapState.filter))
+      );
       break;
-    }
+    case "geoimaginaryMode":
+      drawBubblesAndLegends(map, calculateGeoBubbles(data, calcGeoPoetCities(data, state, mapState.filter)));
+      break;
     case "travelMode":
       // Narrowed here, so the travel map is handed a travel filter rather than
       // re-deriving one and having to consider filters it does not offer.

--- a/tests/browser/smoke.test.js
+++ b/tests/browser/smoke.test.js
@@ -18,9 +18,9 @@ import { test, describe, before, after } from "node:test";
 import assert from "node:assert/strict";
 import { chromium } from "playwright";
 import { serveSite } from "./serve.js";
-import { loadInitializedData, stateFor } from "../helpers/loadData.js";
-import { calcPoetCities } from "../../js/renderMap/calcPoetCities.js";
-import { calculateBubbles } from "../../js/renderMap/calcBubbles.js";
+import { loadInitializedData, ALL_DATES } from "../helpers/loadData.js";
+import { calcPlacesPoetCities, calcGeoPoetCities } from "../../js/renderMap/calcPoetCities.js";
+import { calculatePlacesBubbles, calculateGeoBubbles } from "../../js/renderMap/calcBubbles.js";
 
 const { data } = loadInitializedData();
 
@@ -28,15 +28,33 @@ const { data } = loadInitializedData();
 const CIRCLES_PER_BUBBLE = 2;
 
 /**
- * How many bubbles the pure pipeline says a given view should have, counting
+ * How many bubbles the pure pipeline says a places view should have, counting
  * only those with coordinates — drawBubbles() skips the rest.
- * @param {MapMode} currentMapMode
- * @param {string} selectedId
+ * @param {PlacesFilter} filter
  * @returns {number}
  */
-function expectedBubbles(currentMapMode, selectedId) {
-  const state = stateFor(currentMapMode, selectedId);
-  const bubbles = calculateBubbles(state, data, calcPoetCities(data, state));
+function expectedPlacesBubbles(filter) {
+  /** @type {State} */
+  const state = { map: { currentMapMode: "placesMode", filter }, ...ALL_DATES };
+  return drawable(calculatePlacesBubbles(data, filter, calcPlacesPoetCities(data, state, filter)));
+}
+
+/**
+ * As expectedPlacesBubbles, for the geographical imaginary map.
+ * @param {GeoFilter} filter
+ * @returns {number}
+ */
+function expectedGeoBubbles(filter) {
+  /** @type {State} */
+  const state = { map: { currentMapMode: "geoimaginaryMode", filter }, ...ALL_DATES };
+  return drawable(calculateGeoBubbles(data, calcGeoPoetCities(data, state, filter)));
+}
+
+/**
+ * @param {Record<number, Bubble>} bubbles
+ * @returns {number}
+ */
+function drawable(bubbles) {
   return Object.values(bubbles).filter(bubble => bubble.city.lat && bubble.city.long).length;
 }
 
@@ -143,21 +161,21 @@ const popupText = async () => {
 describe("the map paints", () => {
   test("places: activity draws a circle pair for every placed city", async () => {
     await select("relationship_3");
-    assert.equal(await drawnPaths(), expectedBubbles("placesMode", "relationship_3") * CIRCLES_PER_BUBBLE);
+    assert.equal(await drawnPaths(), expectedPlacesBubbles({ type: "relationship", num: 3 }) * CIRCLES_PER_BUBBLE);
   });
 
   test("places: origin draws fewer, since not every city is a birthplace", async () => {
     await select("relationship_1");
     const origin = await drawnPaths();
-    assert.equal(origin, expectedBubbles("placesMode", "relationship_1") * CIRCLES_PER_BUBBLE);
+    assert.equal(origin, expectedPlacesBubbles({ type: "relationship", num: 1 }) * CIRCLES_PER_BUBBLE);
     assert.ok(origin > 0);
-    assert.ok(origin < expectedBubbles("placesMode", "relationship_3") * CIRCLES_PER_BUBBLE);
+    assert.ok(origin < expectedPlacesBubbles({ type: "relationship", num: 3 }) * CIRCLES_PER_BUBBLE);
   });
 
   test("geographical imaginary draws its own, larger set", async () => {
     await page.locator("#geoimaginaryMode").dispatchEvent("click");
     await page.waitForTimeout(600);
-    assert.equal(await drawnPaths(), expectedBubbles("geoimaginaryMode", "all_1") * CIRCLES_PER_BUBBLE);
+    assert.equal(await drawnPaths(), expectedGeoBubbles({ type: "all", num: 1 }) * CIRCLES_PER_BUBBLE);
   });
 
   test("travel draws arcs, not bubbles", async () => {

--- a/tests/data-integrity.test.js
+++ b/tests/data-integrity.test.js
@@ -617,7 +617,7 @@ describe("known data bugs: rows that never reach the map", () => {
     const orphans = raw.geopoetCities.filter(row => filled(row.cityId) && !cityIds.has(id(row.cityId)));
     assert.equal(orphans.length, 13);
     assert.equal(new Set(orphans.map(row => id(row.cityId))).size, 12);
-    // calculateBubbles() skips any row whose cityId does not resolve, so these
+    // The bubble builders skip any row whose cityId does not resolve, so these
     // citations are researched, translated, cited — and render nowhere.
     //
     // Three are locatable in Pleiades:

--- a/tests/popups.test.js
+++ b/tests/popups.test.js
@@ -1,27 +1,41 @@
 // Rendering tests for the popups, driven through the real filter pipeline.
 //
-// calcPoetCities() and calculateBubbles() are pure, so Node can build the exact
+// The per-map calc functions are pure, so Node can build the exact
 // bubbles the browser builds and assert on the html they produce. These are the
 // tests to lean on when changing popup copy — notably issue #332, which will
 // change how a poet with several reported birthplaces is described.
 
 import { test, describe } from "node:test";
 import assert from "node:assert/strict";
-import { loadInitializedData, stateFor } from "./helpers/loadData.js";
-import { calcPoetCities } from "../js/renderMap/calcPoetCities.js";
-import { calculateBubbles } from "../js/renderMap/calcBubbles.js";
+import { loadInitializedData, ALL_DATES } from "./helpers/loadData.js";
+import { calcPlacesPoetCities, calcGeoPoetCities } from "../js/renderMap/calcPoetCities.js";
+import { calculatePlacesBubbles, calculateGeoBubbles } from "../js/renderMap/calcBubbles.js";
 import { createTravelPopupHtml } from "../js/popups/travelPopups.js";
 
 const { data } = loadInitializedData();
 
 /**
- * @param {MapMode} currentMapMode
- * @param {string} selectedId
- * @returns {Record<number, Bubble>}
+ * The bubbles the places map draws for one control bar selection. Takes the
+ * filter itself rather than a selectedId, because each map now runs its own
+ * pipeline and there is no shared entry point to pass a string to.
+ * @param {PlacesFilter} filter
+ * @returns {Record<number, PlacesBubble>}
  */
-function bubblesFor(currentMapMode, selectedId) {
-  const state = stateFor(currentMapMode, selectedId);
-  return calculateBubbles(state, data, calcPoetCities(data, state));
+function placesBubblesFor(filter) {
+  /** @type {State} */
+  const state = { map: { currentMapMode: "placesMode", filter }, ...ALL_DATES };
+  return calculatePlacesBubbles(data, filter, calcPlacesPoetCities(data, state, filter));
+}
+
+/**
+ * As placesBubblesFor, for the geographical imaginary map.
+ * @param {GeoFilter} filter
+ * @returns {Record<number, GeoBubble>}
+ */
+function geoBubblesFor(filter) {
+  /** @type {State} */
+  const state = { map: { currentMapMode: "geoimaginaryMode", filter }, ...ALL_DATES };
+  return calculateGeoBubbles(data, calcGeoPoetCities(data, state, filter));
 }
 
 const cityIdByName = (/** @type {string} */ name) => {
@@ -31,9 +45,11 @@ const cityIdByName = (/** @type {string} */ name) => {
 };
 
 /**
- * The popup html for a city's bubble, asserting both exist. calculateBubbles()
- * always sets popupHtml for the modes these tests exercise, but the type allows
- * for travel mode, where bubbles are drawn without popups.
+ * The popup html for a city's bubble.
+ *
+ * PlacesBubble and GeoBubble both require popupHtml, so unlike the travel
+ * bubbles — which are drawn without popups — there is nothing to assert here
+ * beyond the city being on the map at all.
  * @param {Record<number, Bubble>} bubbles
  * @param {string} cityname
  * @returns {string}
@@ -41,32 +57,11 @@ const cityIdByName = (/** @type {string} */ name) => {
 function popupFor(bubbles, cityname) {
   const bubble = bubbles[cityIdByName(cityname)];
   assert.ok(bubble, `no bubble for ${cityname}`);
-  assert.ok(bubble.popupHtml, `no popup html for ${cityname}`);
   return bubble.popupHtml;
-}
-
-/**
- * As popupFor, for a bubble already in hand.
- * @param {Bubble} bubble
- * @returns {string}
- */
-function popupOf(bubble) {
-  assert.ok(bubble.popupHtml, `no popup html for ${bubble.city.cityname}`);
-  return bubble.popupHtml;
-}
-
-/**
- * The grouped poets on a geographical-imaginary bubble, asserting they exist.
- * @param {Bubble} bubble
- * @returns {GeoBubblePoet[]}
- */
-function poetsOf(bubble) {
-  assert.ok(bubble.poets, `no grouped poets for ${bubble.city.cityname}`);
-  return bubble.poets;
 }
 
 describe("places map: origin", () => {
-  const bubbles = bubblesFor("placesMode", "relationship_1");
+  const bubbles = placesBubblesFor({ type: "relationship", num: 1 });
 
   test("a birthplace bubble is titled 'POETS BORN IN <city>'", () => {
     assert.match(popupFor(bubbles, "Sparta"), /POETS BORN IN SPARTA/);
@@ -106,7 +101,7 @@ describe("places map: origin", () => {
 });
 
 describe("places map: activity", () => {
-  const bubbles = bubblesFor("placesMode", "relationship_3");
+  const bubbles = placesBubblesFor({ type: "relationship", num: 3 });
 
   test("a city's poets are split into natives and non-natives", () => {
     const athens = popupFor(bubbles, "Athens");
@@ -118,7 +113,7 @@ describe("places map: activity", () => {
 
   test("every bubble produces html and a legend", () => {
     for (const bubble of Object.values(bubbles)) {
-      assert.ok(popupOf(bubble).length > 0);
+      assert.ok(bubble.popupHtml.length > 0);
       assert.equal(bubble.legend, bubble.city.cityname);
       assert.ok(bubble.price > 0, `${bubble.city.cityname} has no bubble size`);
     }
@@ -126,17 +121,17 @@ describe("places map: activity", () => {
 });
 
 describe("geographical imaginary map", () => {
-  const bubbles = bubblesFor("geoimaginaryMode", "all_1");
+  const bubbles = geoBubblesFor({ type: "all", num: 1 });
 
   test("a bubble counts the references made to it", () => {
     const bubble = Object.values(bubbles).find(b => b.poetCities.length > 1);
     assert.ok(bubble, "expected at least one city referred to more than once");
-    assert.match(popupOf(bubble), /\d+ REFERENCES TO /);
+    assert.match(bubble.popupHtml, /\d+ REFERENCES TO /);
   });
 
   test("poets are grouped, so one poet with three references is listed once", () => {
     for (const bubble of Object.values(bubbles)) {
-      const poets = poetsOf(bubble);
+      const poets = bubble.poets;
       const poetIds = poets.map(p => p.poetId);
       assert.equal(new Set(poetIds).size, poetIds.length, `${bubble.city.cityname} lists a poet twice`);
       const totalReferences = poets.reduce((n, p) => n + p.references.length, 0);
@@ -147,8 +142,8 @@ describe("geographical imaginary map", () => {
   test("singular and plural are used correctly", () => {
     const single = Object.values(bubbles).find(b => b.poetCities.length === 1);
     assert.ok(single);
-    assert.match(popupOf(single), /1 REFERENCE TO /);
-    assert.doesNotMatch(popupOf(single), /1 REFERENCES TO /);
+    assert.match(single.popupHtml, /1 REFERENCE TO /);
+    assert.doesNotMatch(single.popupHtml, /1 REFERENCES TO /);
   });
 });
 
@@ -177,18 +172,19 @@ describe("travel map", () => {
 
 describe("popup html is well formed enough to render", () => {
   test("no popup leaks 'undefined' or 'NaN' into the page", () => {
-    /** @type {[MapMode, string][]} */
+    /** @type {[string, Record<number, Bubble>][]} */
     const VIEWS = [
-      ["placesMode", "relationship_1"],
-      ["placesMode", "relationship_3"],
-      ["geoimaginaryMode", "all_1"]
+      ["places/origin", placesBubblesFor({ type: "relationship", num: 1 })],
+      ["places/activity", placesBubblesFor({ type: "relationship", num: 3 })],
+      ["places/genre", placesBubblesFor({ type: "genre", num: 2 })],
+      ["geographical imaginary", geoBubblesFor({ type: "all", num: 1 })]
     ];
-    for (const [mode, selectedId] of VIEWS) {
-      for (const bubble of Object.values(bubblesFor(mode, selectedId))) {
-        const html = popupOf(bubble);
+    for (const [view, bubbles] of VIEWS) {
+      for (const bubble of Object.values(bubbles)) {
+        const html = bubble.popupHtml;
         const cityname = bubble.city.cityname;
-        assert.doesNotMatch(html, /undefined/, `${mode}/${selectedId} popup for ${cityname} contains "undefined"`);
-        assert.doesNotMatch(html, /NaN/, `${mode}/${selectedId} popup for ${cityname} contains "NaN"`);
+        assert.doesNotMatch(html, /undefined/, `${view} popup for ${cityname} contains "undefined"`);
+        assert.doesNotMatch(html, /NaN/, `${view} popup for ${cityname} contains "NaN"`);
       }
     }
   });

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -41,10 +41,10 @@ interface LyricMap {
 // ---------------------------------------------------------------------------
 // CSV-backed entities.
 //
-// Papa Parse hands back every field as a string. initializeData() then mutates
-// the id/lat/long fields in place into numbers. The types below describe the
-// HYDRATED shape, i.e. what the rest of the codebase actually sees; the raw
-// pre-hydration arrays are cast to any[] inside initializeData().
+// Papa Parse hands back every field as a string. hydrate(), in data.js, then
+// parses the id/lat/long fields in place into numbers. The types below describe
+// the HYDRATED shape, i.e. what the rest of the codebase actually sees; the
+// pre-hydration string forms are the Raw* types in types/csv.d.ts.
 // ---------------------------------------------------------------------------
 
 /** A row of dataFiles/cities.csv. */
@@ -145,8 +145,8 @@ interface Genre {
 }
 
 /**
- * Poet metadata copied onto poet-city rows and travel lines by
- * primeObjWithPoetData(), so popups can render without a second lookup.
+ * Poet metadata copied onto poet-city rows and travel lines by poetPrimedData(),
+ * so popups can render without a second lookup.
  */
 interface PoetPrimed {
   poetDetailName: string;
@@ -226,8 +226,8 @@ interface FilterOption {
 }
 
 /**
- * The filter kinds encoded in the first half of State.selectedId, e.g. the
- * "poet" in "poet_93".
+ * The filter kinds encoded in the first half of a control bar radio button's
+ * id, e.g. the "poet" in "poet_93".
  *
  * There are three maps and three sets, overlapping rather than nesting: "poet"
  * is on all three, "all" on geographical imaginary and travel but not places,
@@ -309,23 +309,49 @@ interface DrawableBubble {
 }
 
 /**
- * The rows behind one city's bubble. Split from Bubble because it is all the
- * popup is rendered from, which is what lets calculateBubbles() build a whole
- * Bubble in one go rather than filling an empty one in field by field.
+ * The rows behind one places bubble. Split from PlacesBubble because it is all
+ * the popup is rendered from, which is what lets a whole bubble be built in one
+ * go rather than filled in field by field.
  */
-interface BubbleContents {
+interface PlacesBubbleContents {
   city: City;
   poetCities: RenderedPoetCity[];
-  /** Only populated in geoimaginaryMode. */
-  poets?: GeoBubblePoet[];
 }
 
-/** A circle drawn on the map for one city, with the rows behind its popup. */
-interface Bubble extends BubbleContents, DrawableBubble {}
+/**
+ * The rows behind one geographical imaginary bubble, which additionally groups
+ * them by poet: a poet often names the same place several times, and the popup
+ * lists each poet once with all of their citations.
+ *
+ * `poets` is required here rather than optional on a shared type. It was the
+ * latter, described as "only populated in geoimaginaryMode" — true, but not
+ * something the type said, so the popup that reads it had to cast.
+ */
+interface GeoBubbleContents extends PlacesBubbleContents {
+  poets: GeoBubblePoet[];
+}
+
+/**
+ * A circle drawn on the places map. Unlike a travel bubble it always has a
+ * popup and a label, so both are required.
+ */
+interface PlacesBubble extends PlacesBubbleContents, DrawableBubble {
+  popupHtml: string;
+  legend: string;
+}
+
+/** As PlacesBubble, for the geographical imaginary map. */
+interface GeoBubble extends GeoBubbleContents, DrawableBubble {
+  popupHtml: string;
+  legend: string;
+}
+
+/** A circle on either of the two bubble maps. */
+type Bubble = PlacesBubble | GeoBubble;
 
 /**
  * One drawn arc, merging every Line that shares the same city pair, before its
- * popup is rendered. As BubbleContents, this is everything the popup is built
+ * popup is rendered. As PlacesBubbleContents, this is everything the popup is built
  * from, so the DrawnLine below can be built complete.
  */
 interface TravelArc {


### PR DESCRIPTION
Last of five. **Stacked on #345.**

## The bad state

`Bubble` carried a field only one of its two maps ever populated:

```ts
interface BubbleContents {
  city: City;
  poetCities: RenderedPoetCity[];
  /** Only populated in geoimaginaryMode. */
  poets?: GeoBubblePoet[];
}
```

True, and enforced by nothing — so the popup that reads it had to assert the fact itself:

```js
// calcBubbles always populates poets in geoimaginaryMode.
const poets = /** @type {GeoBubblePoet[]} */ (bubble.poets);
```

The comment *was* the guarantee. That is the last cast of its kind in `js/`.

## The fix

`PlacesBubbleContents` has what the places map builds; `GeoBubbleContents` extends it with the per-poet grouping the geographical imaginary popup lists, where `poets` is **required**. `calculateGeoBubbles()` returns `Record<number, GeoBubble>`, so its popup reads `bubble.poets` off a type that has it.

Getting there meant giving each map its own pipeline end to end — which is what the previous four PRs were clearing the way for:

```
calcPlacesPoetCities -> calculatePlacesBubbles -> createPlacesPopupHtml
calcGeoPoetCities    -> calculateGeoBubbles    -> createGeoPopupHtml
```

`updateMap()` narrows `state.map` once and picks one. Two more throws go with the switches they were stranded in — `calcPoetCities()`'s `travelMode` branch and `createPopupHtml()`'s — both of which existed only because a shared entry point had to account for a map that never called it.

`PlacesBubble` and `GeoBubble` also require `popupHtml` and `legend`. Both stay optional on `DrawableBubble`, because travel bubbles genuinely have neither, but the two bubble maps always set them — and saying so lets `popups.test.js` drop three defensive assertions that existed only to satisfy the type.

## Also in here

Four doc comments that earlier commits in this stack left pointing at things that no longer exist: `primeObjWithPoetData()`, the `any[]` cast in `initializeData()`, `State.selectedId`, and `getPlacesFilter()`/`getTravelFilter()`. Flagging it because they are strictly speaking each the previous PRs' debris; fixing them in place would have meant rebasing the whole stack.

`keyById()`'s optional `valueOf` — whose default branch needed an `any` — is now required, with `identity` passed explicitly as `groupById()` already did.

## Verification

No behaviour change — 386 bubbles across nine views (six places filters, three geographical imaginary) compared **whole**, popup html and key order included, against the parent branch: **0 differences**.

Tests (98), lint, format and the browser smoke test all pass.

## Where the stack lands

After all five, the value-level casts left in `js/` are: DOM lookups (`querySelector` returns `Element | null`), the Papa Parse string→number boundary in `hydrate()`, and `parseCsvs()` asserting that a record typed over `keyof RawCsvs` filled every key. No domain type is reinterpreted as another any more, and these impossible states now fail to compile:

- an object typed complete before its fields are set
- a `Data` in use before it is built
- a places map filtered by ALL, or a travel map filtered by genre
- a map mode paired with another map's filter
- a default filter a control bar does not offer
- a places bubble read for its geographical-imaginary poet grouping

🤖 Generated with [Claude Code](https://claude.com/claude-code)
