### PR TITLE
Look the poet up when a popup renders, instead of priming every row

### DIFF
--- a/js/calcData/data.js
+++ b/js/calcData/data.js
@@ -1,4 +1,4 @@
-import { getPoet, getCity, getGenres, getGovs } from "./getters.js";
+import { getPoet, getCity, getGovs } from "./getters.js";
 
 /**
  * Hydrates the raw CSV rows (ids and coordinates become numbers, dates become
@@ -24,22 +24,14 @@ export function initializeData(raw) {
 
   const derived = derive(csvs, lookups);
 
-  // Assigned onto the rows, not built into them, which is the one place left
-  // where a type runs ahead of the object it describes: until this line, a
-  // PoetCity is missing the four PoetPrimed fields its type says it has.
-  //
-  // A travel line could be built complete because createLines() makes it. These
-  // rows are made by Papa Parse and mutated in place ever since, and derive()
-  // above has captured these exact objects as bornPc and activePc, so handing
-  // back primed copies would leave those references pointing at the originals.
-  //
-  // Last, and in this order: createLines() reads poetCities in file order, so
-  // sorting them any earlier would reorder the poets on every travel arc. The
-  // "every row is primed with its poet's display data" test in
-  // tests/initializeData.test.js is what holds the claim above together.
-  for (const pc of [...csvs.poetCities, ...csvs.geopoetCities]) {
-    Object.assign(pc, poetPrimedData(lookups, pc.poetId));
-  }
+  // What used to be the priming pass: the four display strings were copied onto
+  // every poet-city row and travel line here, and these warnings fired as a side
+  // effect of the copy. Popups now look the poet up when they render, so all
+  // that is left is the check — which is what it always really was.
+  warnAboutIncompletePoets(csvs, lookups);
+
+  // createLines() reads poetCities in file order, so sorting any earlier would
+  // reorder the poets on every travel arc.
   sortPoetCities(lookups, csvs.poetCities);
   sortPoetCities(lookups, csvs.geopoetCities);
 
@@ -196,38 +188,25 @@ function sortPoetCities(lookups, poetCities) {
 }
 
 /**
- * A poet's display name, dates, sources and genres, to be copied onto a row (or
- * a travel line) so popups can render without a second lookup.
+ * Reports poets that are on the map but missing the display data popups show.
  *
- * Returned rather than assigned, so a travel line can be built with these fields
- * already on it instead of existing briefly without them.
+ * Reported once per poet rather than once per row, which is what the priming
+ * pass did — a poet with five rows alerted five times. Reporting it here rather
+ * than where popups read it keeps it to startup: at render time the same alert
+ * would fire again on every redraw.
+ * @param {Csvs} csvs
  * @param {Lookups} lookups
- * @param {number} poetId
- * @returns {PoetPrimed}
  */
-function poetPrimedData(lookups, poetId) {
-  const poet = getPoet(lookups, poetId);
-
-  let poetDetailName = "";
-  if (poet.poetDetailName) poetDetailName = poet.poetDetailName;
-  else alert(`Poet ${poet.poetname} with poetId ${poetId} lacks a details name`);
-
-  let poetDates = "";
-  if (poet.dates) poetDates = poet.dates;
-  else console.log(`Poet ${poet.poetname} with poetId ${poetId} lacks dates`);
-
-  let poetSources = "";
-  if (poet.sources) poetSources = poet.sources;
-  else console.log(`Poet ${poet.poetname} with poetId ${poetId} lacks sources`);
-
-  return {
-    poetDetailName,
-    poetDates,
-    poetSources,
-    poetGenres: getGenres(lookups, poetId)
-      .map(genre => genre.genre)
-      .join(", ")
-  };
+function warnAboutIncompletePoets(csvs, lookups) {
+  const poetIds = new Set([...csvs.poetCities, ...csvs.geopoetCities].map(pc => pc.poetId));
+  for (const poetId of poetIds) {
+    const poet = getPoet(lookups, poetId);
+    // getPoet has already logged the missing id; there is nothing more to say.
+    if (!poet) continue;
+    if (!poet.poetDetailName) alert(`Poet ${poet.poetname} with poetId ${poetId} lacks a details name`);
+    if (!poet.dates) console.log(`Poet ${poet.poetname} with poetId ${poetId} lacks dates`);
+    if (!poet.sources) console.log(`Poet ${poet.poetname} with poetId ${poetId} lacks sources`);
+  }
 }
 
 /**
@@ -469,8 +448,7 @@ function createLines(csvs, lookups) {
             bornCity: fromCity,
             activeCity: toCity,
             bornGovIds: bornGovIds,
-            activeGovIds: activeGovIds,
-            ...poetPrimedData(lookups, poetId)
+            activeGovIds: activeGovIds
           };
           lines.push(line);
         }

--- a/js/calcData/getters.js
+++ b/js/calcData/getters.js
@@ -113,3 +113,27 @@ function parseFilter(selectedId, allowed, mapName) {
   }
   return { type: filterType, num: parseInt(stringNum) };
 }
+
+/**
+ * The strings popups show about a poet, looked up when the popup is built.
+ *
+ * Called at render time rather than copied onto every row at startup. The
+ * lookups are property accesses on poetsById and genresByPoetId, so the copy
+ * they replaced was saving nothing worth the four fields it added to four types
+ * — fields the rows did not have until the priming pass ran.
+ *
+ * The empty-string fallbacks are for data that is missing rather than absent:
+ * warnAboutIncompletePoets() reports it at startup, and this keeps a popup
+ * rendering a blank line instead of the word "undefined".
+ * @param {Lookups} lookups
+ * @param {number} poetId
+ * @returns {PoetDisplay}
+ */
+export function getPoetDisplay(lookups, poetId) {
+  const poet = getPoet(lookups, poetId);
+  return {
+    detailName: poet?.poetDetailName ?? "",
+    dates: poet?.dates ?? "",
+    sources: poet?.sources ?? ""
+  };
+}

--- a/js/popups/popups.js
+++ b/js/popups/popups.js
@@ -1,5 +1,6 @@
 import { LYRIC_GREY, LYRIC_RED } from "../constants/colors.js";
 import { assertUnreachable } from "../assertUnreachable.js";
+import { getPoetDisplay } from "../calcData/getters.js";
 import { createNumberedListOfPoets, createDetailedListOfPoets, renderReference } from "./popupsCommon.js";
 
 /**
@@ -23,7 +24,7 @@ export function createPlacesPopupHtml(data, bubble, filter) {
   const poetCities = bubble.poetCities;
   return `
     ${createHeader(cityname, createPlacesModeTitle(data, cityname, type, num))}
-    ${createNumberedListOfPoets(poetCities.map(pc => pc.poetDetailName))}
+    ${createNumberedListOfPoets(poetCities.map(pc => getPoetDisplay(data, pc.poetId).detailName))}
     <h4 style="color:${LYRIC_GREY}">DETAILS</h4>
     ${createDetailedListOfPoets(poetCities, data)}
   `;
@@ -57,7 +58,7 @@ function createActivePopupHtml(data, bubble) {
   if (bornPoetCities.length > 0) {
     nativeHeader = `
       <h5 style="color:${LYRIC_GREY}">${nativeTitle}</h2>
-      ${createNumberedListOfPoets(bornPoetCities.map(pc => pc.poetDetailName))}
+      ${createNumberedListOfPoets(bornPoetCities.map(pc => getPoetDisplay(data, pc.poetId).detailName))}
     `;
     nativeDetails = `
       <h4 style="color:${LYRIC_GREY}">NATIVE POETS</h4>
@@ -68,7 +69,7 @@ function createActivePopupHtml(data, bubble) {
   if (otherPoetCities.length > 0) {
     nonNativeHeader = `
       <h5 style="color:${LYRIC_GREY}">${nonNativeTitle}</h2>
-      ${createNumberedListOfPoets(otherPoetCities.map(pc => pc.poetDetailName))}
+      ${createNumberedListOfPoets(otherPoetCities.map(pc => getPoetDisplay(data, pc.poetId).detailName))}
     `;
     nonNativeDetails = `
       <h4 style="color:${LYRIC_GREY}">NON-NATIVE POETS</h4>
@@ -117,16 +118,17 @@ function createGeoHeaderListOfPoets(poets) {
 
 /**
  * @param {GeoBubblePoet[]} poets
+ * @param {Data} data
  * @returns {string}
  */
-function createDetailedGeoListOfPoets(poets) {
+function createDetailedGeoListOfPoets(poets, data) {
   return `
     ${poets
       .map((poet, idx) => {
         return `
       <p>
         <span style="color:${LYRIC_RED}">${idx + 1}</span>. ${poet.poetname}<br>
-        Dates: ${poet.poetDates}<br>
+        Dates: ${getPoetDisplay(data, poet.poetId).dates}<br>
         ${poet.references.map(reference => renderReference(reference)).join("<br><br>")}
       </p >
       `;
@@ -172,15 +174,16 @@ function createPlacesModeTitle(data, cityname, type, num) {
  * optional field on a type shared with the places map, so this was the one
  * place left that had to cast.
  * @param {GeoBubbleContents} bubble
+ * @param {Data} data
  * @returns {string}
  */
-export function createGeoPopupHtml(bubble) {
+export function createGeoPopupHtml(bubble, data) {
   const cityname = bubble.city.infowindowName.toUpperCase();
   const referenceStr = bubble.poetCities.length === 1 ? "REFERENCE" : "REFERENCES";
   return `
     ${createHeader(cityname, `${bubble.poetCities.length} ${referenceStr} TO ${cityname}`)}
     ${createGeoHeaderListOfPoets(bubble.poets)}
     <h4 style="color:${LYRIC_GREY}">DETAILS</h4>
-    ${createDetailedGeoListOfPoets(bubble.poets)}
+    ${createDetailedGeoListOfPoets(bubble.poets, data)}
   `;
 }

--- a/js/popups/popupsCommon.js
+++ b/js/popups/popupsCommon.js
@@ -1,11 +1,14 @@
 import { LYRIC_RED } from "../constants/colors.js";
-import { getGenres } from "../calcData/getters.js";
+import { getGenres, getPoetDisplay } from "../calcData/getters.js";
 
 /**
  * Anything a detail paragraph can be rendered from: a rendered poet-city row in
  * places / geographical-imaginary mode, or a travel line in travel mode. Travel
  * lines carry no citation of their own, hence the optional reference.
- * @typedef {PoetPrimed & { poetId: number, reference?: Reference }} DetailedPoet
+ *
+ * A poetId is now the whole of it. The display strings used to be carried on the
+ * row as well, which is why this was an intersection with PoetPrimed.
+ * @typedef {{ poetId: number, reference?: Reference }} DetailedPoet
  */
 
 /**
@@ -32,12 +35,13 @@ export function createDetailedListOfPoets(poets, data) {
   return `
     ${poets
       .map((poet, idx) => {
+        const display = getPoetDisplay(data, poet.poetId);
         return `
       <p>
-        <span style="color:${LYRIC_RED}">${idx + 1}</span>. ${poet.poetDetailName}<br>
-        Dates: ${poet.poetDates}<br>
-        ${createGenreString(poet, data)}
-        Source(s): ${poet.poetSources}<br>
+        <span style="color:${LYRIC_RED}">${idx + 1}</span>. ${display.detailName}<br>
+        Dates: ${display.dates}<br>
+        ${createGenreString(data, poet.poetId)}
+        Source(s): ${display.sources}<br>
         ${renderReference(poet.reference)}
       </p>
       `;
@@ -47,17 +51,20 @@ export function createDetailedListOfPoets(poets, data) {
 }
 
 /**
- * @param {DetailedPoet} poet
- * @param {Data} data
+ * This always looked the genres up — it needed the count to choose between
+ * "Genre" and "Genres" — and read the joined names off the primed row beside it.
+ * Now it joins the names it already has.
+ * @param {Lookups} lookups
+ * @param {number} poetId
  * @returns {string}
  */
-function createGenreString(poet, data) {
-  if (poet.poetGenres) {
-    const genres = getGenres(data, poet.poetId);
-    const genreStr = genres.length > 1 ? "Genres" : "Genre";
-    return `${genreStr}: ${poet.poetGenres}<br>`;
-  }
-  return "";
+function createGenreString(lookups, poetId) {
+  const genres = getGenres(lookups, poetId);
+  const genreNames = genres.map(genre => genre.genre).join(", ");
+  // Blank when a poet has no genres, and also when the ones they have are
+  // unnamed, which is what reading the joined string off the row did.
+  if (!genreNames) return "";
+  return `${genres.length > 1 ? "Genres" : "Genre"}: ${genreNames}<br>`;
 }
 
 /**

--- a/js/popups/travelPopups.js
+++ b/js/popups/travelPopups.js
@@ -1,5 +1,6 @@
 import { LYRIC_GREY, LYRIC_RED } from "../constants/colors.js";
 import { createNumberedListOfPoets, createDetailedListOfPoets, renderReference } from "./popupsCommon.js";
+import { getPoetDisplay } from "../calcData/getters.js";
 
 /**
  * Builds the html shown when a travel arc is clicked.
@@ -11,13 +12,13 @@ export function createTravelPopupHtml(data, line) {
   return `
   <h3 style="color:${LYRIC_GREY}">${line.name}</h3>
   <h5 style="color:${LYRIC_GREY}">POET(S)</h5>
-  ${createNumberedListOfPoets(line.poetLines.map(pl => pl.poetDetailName))}
+  ${createNumberedListOfPoets(line.poetLines.map(pl => getPoetDisplay(data, pl.poetId).detailName))}
   <h4 style="color:${LYRIC_GREY}">DETAILS</h4>
   ${createDetailedListOfPoets(line.poetLines, data)}
   <h4 style="color:${LYRIC_GREY}">ORIGIN SOURCE</h4>
-  ${createTravelSource(line, "bornPc")}
+  ${createTravelSource(line, "bornPc", data)}
   <h4 style="color:${LYRIC_GREY}">ACTIVITY SOURCE</h4>
-  ${createTravelSource(line, "activePc")}
+  ${createTravelSource(line, "activePc", data)}
   `;
 }
 
@@ -25,14 +26,15 @@ export function createTravelPopupHtml(data, line) {
  * Renders the citation behind either end of an arc, for every poet on it.
  * @param {TravelArc} line
  * @param {"bornPc" | "activePc"} direction which end of the journey to cite
+ * @param {Data} data
  * @returns {string}
  */
-function createTravelSource(line, direction) {
+function createTravelSource(line, direction, data) {
   return line.poetLines
     .map((pl, idx) => {
       return `
     <p>
-    <span style="color:${LYRIC_RED}">${idx + 1}</span>. ${pl.poetDetailName}<br>
+    <span style="color:${LYRIC_RED}">${idx + 1}</span>. ${getPoetDisplay(data, pl.poetId).detailName}<br>
     ${renderReference(pl[direction])}
     </p>
     `;
@@ -51,13 +53,13 @@ export function createGovTravelPopupHtml(data, line) {
   return `
   <h3 style="color:${LYRIC_GREY}">${line.name}</h3>
   <h5 style="color:${LYRIC_GREY}">POET(S)</h5>
-  ${createNumberedListOfPoets(line.poetLines.map(pl => pl.poetDetailName))}
+  ${createNumberedListOfPoets(line.poetLines.map(pl => getPoetDisplay(data, pl.poetId).detailName))}
   <h4 style="color:${LYRIC_GREY}">DETAILS</h4>
   ${createRegimeTravelListOfPoets(line.poetLines, data)}
   <h4 style="color:${LYRIC_GREY}">ORIGIN SOURCE</h4>
-  ${createTravelSource(line, "bornPc")}
+  ${createTravelSource(line, "bornPc", data)}
   <h4 style="color:${LYRIC_GREY}">ACTIVITY SOURCE</h4>
-  ${createTravelSource(line, "activePc")}
+  ${createTravelSource(line, "activePc", data)}
   `;
 }
 
@@ -72,9 +74,9 @@ function createRegimeTravelListOfPoets(poets, data) {
       .map((poet, idx) => {
         return `
       <p>
-        <span style="color:${LYRIC_RED}">${idx + 1}</span>. ${poet.poetDetailName}<br>
+        <span style="color:${LYRIC_RED}">${idx + 1}</span>. ${getPoetDisplay(data, poet.poetId).detailName}<br>
         Regime (data from Hansen and Nielsen): ${renderGovNames(poet.bornGovIds, data)} -> ${renderGovNames(poet.activeGovIds, data)}<br>
-        Dates: ${poet.poetDates}<br>
+        Dates: ${getPoetDisplay(data, poet.poetId).dates}<br>
       </p>
       `;
       })

--- a/js/renderMap/calcBubbles.js
+++ b/js/renderMap/calcBubbles.js
@@ -37,7 +37,7 @@ export function calculateGeoBubbles(data, poetCities) {
   for (const [cityId, rows] of groupRowsByCity(data, poetCities)) {
     /** @type {GeoBubbleContents} */
     const contents = { city: data.citiesById[cityId], poetCities: rows, poets: groupRowsByPoet(rows) };
-    bubbles[cityId] = { ...contents, ...drawnAs(contents, createGeoPopupHtml(contents)) };
+    bubbles[cityId] = { ...contents, ...drawnAs(contents, createGeoPopupHtml(contents, data)) };
   }
   return bubbles;
 }

--- a/js/renderMap/calcPoetCities.js
+++ b/js/renderMap/calcPoetCities.js
@@ -116,10 +116,6 @@ function renderPoetCity(poetCity, genre) {
     cityId: poetCity.cityId,
     cityname: poetCity.cityname,
     poetname: poetCity.poetname,
-    poetDetailName: poetCity.poetDetailName,
-    poetDates: poetCity.poetDates,
-    poetGenres: poetCity.poetGenres,
-    poetSources: poetCity.poetSources,
     relationshipId: poetCity.relationshipId,
     reference: reference
   };

--- a/tests/initializeData.test.js
+++ b/tests/initializeData.test.js
@@ -82,11 +82,17 @@ describe("hydration", () => {
     }
   });
 
-  test("every row is primed with its poet's display data", () => {
-    for (const pc of [...data.poetCities, ...data.geopoetCities]) {
-      assert.equal(typeof pc.poetDetailName, "string");
-      assert.ok(pc.poetDetailName.length > 0, `row for poetId ${pc.poetId} has no poetDetailName`);
-      assert.equal(typeof pc.poetDates, "string");
+  test("every poet on the map has the display data popups show", () => {
+    // Popups read these through getPoetDisplay() when they render, and it falls
+    // back to "" rather than leaking "undefined" into the page — so a poet
+    // missing them renders a blank line instead of failing. This is what
+    // warnAboutIncompletePoets() alerts about at startup, asserted directly.
+    const mapped = new Set([...data.poetCities, ...data.geopoetCities].map(pc => pc.poetId));
+    for (const poetId of mapped) {
+      const poet = data.poetsById[poetId];
+      assert.ok(poet.poetDetailName.length > 0, `poetId ${poetId} has no poetDetailName`);
+      assert.ok(poet.dates.length > 0, `${poet.poetname} has no dates`);
+      assert.ok(poet.sources.length > 0, `${poet.poetname} has no sources`);
     }
   });
 });
@@ -221,7 +227,7 @@ describe("known bugs: derived travel lines", () => {
     // createLines() takes the cartesian product of birthplaces and places of
     // activity without excluding the case where the two are the same city.
     const degenerate = data.lines.filter(l => l.bornCityId === l.activeCityId);
-    assert.deepEqual(degenerate.map(l => `${l.poetDetailName}: ${l.bornCity.cityname}`).sort(), [
+    assert.deepEqual(degenerate.map(l => `${data.poetsById[l.poetId].poetDetailName}: ${l.bornCity.cityname}`).sort(), [
       "Alcman: Sparta",
       "Corinna: Thebes",
       "Tyrtaeus: Sparta"

--- a/tests/lines.test.js
+++ b/tests/lines.test.js
@@ -50,6 +50,13 @@ function arcNamed(arcs, name) {
   return matching[0];
 }
 
+/**
+ * A travel line no longer carries its poet's display name; popups look it up.
+ * @param {Line} line
+ * @returns {string}
+ */
+const detailNameOf = line => data.poetsById[line.poetId].poetDetailName;
+
 const cityIdByName = (/** @type {string} */ cityname) => {
   const city = data.cities.find(c => c.cityname === cityname);
   assert.ok(city, `no city named ${cityname}`);
@@ -61,7 +68,7 @@ describe("arcs merge the poets who made the same journey", () => {
 
   test("three poets going from Thebes to Athens draw one arc, not three", () => {
     const arc = arcNamed(arcs, "THEBES -> ATHENS");
-    assert.deepEqual(arc.poetLines.map(line => line.poetDetailName).sort(), ["Khairis", "Pindar", "Pronomus"]);
+    assert.deepEqual(arc.poetLines.map(line => detailNameOf(line)).sort(), ["Khairis", "Pindar", "Pronomus"]);
   });
 
   test("one poet's uncertain journey dots the whole arc", () => {
@@ -69,7 +76,7 @@ describe("arcs merge the poets who made the same journey", () => {
     // Simonides' is not. They share an arc, so the arc is drawn dotted: the
     // hedge belongs to one of the two, but the map cannot say so.
     const arc = arcNamed(arcs, "IOULIS (CEOS) -> ATHENS");
-    assert.deepEqual(arc.poetLines.map(line => `${line.poetDetailName}:${line.dotted}`).sort(), [
+    assert.deepEqual(arc.poetLines.map(line => `${detailNameOf(line)}:${line.dotted}`).sort(), [
       "Bacchylides:true",
       "Simonides:false"
     ]);

--- a/tests/popups.test.js
+++ b/tests/popups.test.js
@@ -149,7 +149,12 @@ describe("geographical imaginary map", () => {
 
 describe("travel map", () => {
   test("an arc popup names both ends, the poets, and both citations", () => {
-    const line = data.lines.find(l => l.poetDetailName === "Pindar");
+    // Looked up through poetsById, as the popup does. Comparing against
+    // poet.poetId directly would not work: poets.csv's poetId is never parsed,
+    // so a Poet holds the string "149" where its type promises a number. It goes
+    // unnoticed because these ids are only ever used as object keys, which
+    // coerce. Worth fixing, but not here.
+    const line = data.lines.find(l => data.poetsById[l.poetId].poetDetailName === "Pindar");
     assert.ok(line, "expected Pindar to have a travel line");
     const drawnLine = {
       fromCity: line.bornCity,

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -145,18 +145,24 @@ interface Genre {
 }
 
 /**
- * Poet metadata copied onto poet-city rows and travel lines by poetPrimedData(),
- * so popups can render without a second lookup.
+ * The strings a popup shows about a poet, read through getPoetDisplay() when the
+ * popup is built.
+ *
+ * These used to be four fields copied onto every poet-city row and travel line
+ * at startup — "priming" — so that popups could render without a second lookup.
+ * The lookup they saved is a property access on poetsById. What they cost was
+ * four fields on each of PoetCity, GeoPoetCity, Line and RenderedPoetCity that
+ * the rows did not have for part of startup, and an ordering constraint between
+ * the priming pass and createLines().
  */
-interface PoetPrimed {
-  poetDetailName: string;
-  poetDates: string;
-  poetSources: string;
-  poetGenres: string;
+interface PoetDisplay {
+  detailName: string;
+  dates: string;
+  sources: string;
 }
 
-/** A row of dataFiles/poets_cities.csv, after hydration and priming. */
-interface PoetCity extends PoetPrimed {
+/** A row of dataFiles/poets_cities.csv, hydrated. */
+interface PoetCity {
   poetname: string;
   poetId: number;
   cityname: string;
@@ -179,8 +185,8 @@ interface PoetCity extends PoetPrimed {
   source_explicit: string;
 }
 
-/** A row of dataFiles/geographical_imaginary_group.csv, after hydration and priming. */
-interface GeoPoetCity extends PoetPrimed {
+/** A row of dataFiles/geographical_imaginary_group.csv, hydrated. */
+interface GeoPoetCity {
   imaginaryid: number;
   poetname: string;
   poetId: number;
@@ -255,7 +261,7 @@ type TravelFilterType = "all" | "poet" | "destination" | "smallregion" | "region
 type MapFilterType = PlacesFilterType | GeoFilterType | TravelFilterType;
 
 /** One poet's attested movement from one birthplace to one place of activity. */
-interface Line extends PoetPrimed {
+interface Line {
   poetId: number;
   bornCityId: number;
   activeCityId: number;
@@ -281,7 +287,7 @@ interface Reference {
  * A poet-city row flattened for rendering: the subset of fields popups need,
  * with the citation collapsed into a single `reference`.
  */
-interface RenderedPoetCity extends PoetPrimed {
+interface RenderedPoetCity {
   poetId: number;
   cityId: number;
   cityname: string;


### PR DESCRIPTION
Follow-up to the five-PR stack, **based on #346**. Your suggestion, and it's a better fix than the staged-types one I was going to propose — that would have closed the type hole while keeping the thing that caused it.

## What priming was

Four strings — a poet's display name, dates, sources and genres — copied onto every poet-city row and every travel line at startup. The stated reason:

> so popups can render without a second lookup

That lookup is `lookups.poetsById[poetId]`, a property access on an object built for exactly this. 841 rows primed at startup to avoid a few thousand hash lookups per redraw, against the cost of:

- `PoetPrimed` mixed into `PoetCity`, `GeoPoetCity`, `Line` and `RenderedPoetCity` — four fields each, none of them from the CSV the first two describe.
- The rows not having those fields until the priming pass ran, so for part of startup each was typed complete and wasn't. **The one place left in `initializeData()` where a type ran ahead of its object** — the one you asked about, that needed a paragraph of comment to explain why it couldn't be fixed the way the travel lines were.
- That paragraph's reason: `createLines()` had already captured those exact row objects as `bornPc`/`activePc`, so handing back primed copies would leave those references pointing at unprimed originals. Priming was therefore pinned *after* `createLines()` — an ordering constraint with no other reason to exist.

All three go away together.

## What replaces it

`getPoetDisplay()` reads the three strings through `getPoet()` when a popup is built. `createGenreString()` joins the names it was **already looking up** — it needed the count to choose between "Genre" and "Genres", then read the joined string off the row beside it.

The warnings that fired from inside `poetPrimedData()` become `warnAboutIncompletePoets()`, which is what they always were: a check that a poet on the map has the data popups will ask for. Keeping it at startup means one alert rather than one per redraw, and it's now once per poet rather than once per row — a poet with five rows used to alert five times.

The row-level test asserting every row was primed becomes a poet-level test asserting every poet on the map has the display data: same claim about the same corpus, made where the data lives.

## A pre-existing bug this turned up

`poets.csv`'s `poetId` is **never parsed**. `hydrate()` parses ids on eight tables and skips this one, so a `Poet` holds the string `"149"` where its type promises a `number` — as does `Genre.poetId`.

It has gone unnoticed because those ids are only ever used as object keys, where `poetsById[149]` and `poetsById["149"]` coerce alike. A test comparing one with `===` is what turned it up. Not fixed here — it wants its own PR, and it's really an instance of item #9 from the original list (hydrated types drifting from what hydration actually does).

## Verification

No behaviour change: every bubble's popup html, price and legend across nine views; every arc's popup html, name, colour and weight across all 182 travel filters; the control bar lists; and the alert/log output of `initializeData()` — all **byte-identical** to #346.

Tests (98), lint, format and the browser smoke test all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
