### PR TITLE
Give the geographical imaginary map its own filter type

### DIFF
--- a/js/calcData/getters.js
+++ b/js/calcData/getters.js
@@ -43,9 +43,13 @@ export function getGovs(lookups, cityId) {
   return [];
 }
 
-/** The filters the places and geographical imaginary control bars offer. */
+/** The filters the places control bar offers. */
 /** @type {PlacesFilterType[]} */
-export const PLACES_FILTER_TYPES = ["all", "relationship", "poet", "genre"];
+export const PLACES_FILTER_TYPES = ["relationship", "poet", "genre"];
+
+/** The filters the geographical imaginary control bar offers. */
+/** @type {GeoFilterType[]} */
+export const GEO_FILTER_TYPES = ["all", "poet"];
 
 /** The filters the travel control bar offers. */
 /** @type {TravelFilterType[]} */
@@ -56,8 +60,8 @@ export const TRAVEL_FILTER_TYPES = ["all", "poet", "destination", "smallregion",
  * checking the type against the filters the given map actually offers.
  *
  * Validating here rather than trusting the string is what lets callers switch
- * exhaustively over four or six cases instead of eight, with no branch for a
- * filter their map cannot produce. selectedId always comes from a radio button
+ * exhaustively over two, three or six cases instead of eight, with no branch for
+ * a filter their map cannot produce. selectedId always comes from a radio button
  * this code generated, so a mismatch means the interface builders and the map
  * modes have got out of step.
  * @template {MapFilterType} T
@@ -83,6 +87,14 @@ function getFilter(state, allowed, mapName) {
  */
 export function getPlacesFilter(state) {
   return getFilter(state, PLACES_FILTER_TYPES, "places");
+}
+
+/**
+ * @param {State} state
+ * @returns {[GeoFilterType, number]}
+ */
+export function getGeoFilter(state) {
+  return getFilter(state, GEO_FILTER_TYPES, "geographical imaginary");
 }
 
 /**

--- a/js/popups/popups.js
+++ b/js/popups/popups.js
@@ -12,15 +12,18 @@ import { createNumberedListOfPoets, createDetailedListOfPoets, renderReference }
  * @returns {string}
  */
 export function createPopupHtml(state, data, bubble) {
-  const [type, num] = getPlacesFilter(state);
   switch (state.currentMapMode) {
-    case "placesMode":
+    case "placesMode": {
+      const [type, num] = getPlacesFilter(state);
       // Relationship 3 is "activity", which gets its own native/non-native split.
       return type === "relationship" && num === 3
         ? createActivePopupHtml(data, bubble)
-        : createPlacesPopupHtml(state, data, bubble, type, num);
+        : createPlacesPopupHtml(data, bubble, type, num);
+    }
     case "geoimaginaryMode":
-      return createGeoImaginaryPopupHtml(state, data, bubble, type, num);
+      // Its title counts references rather than naming a filter, so unlike the
+      // places map it does not need to know which button is selected.
+      return createGeoImaginaryPopupHtml(bubble);
     case "travelMode":
       // The travel map draws arcs and builds its popups in travelPopups.js.
       throw new Error("createPopupHtml is not used by the travel map");
@@ -87,16 +90,11 @@ function createActivePopupHtml(data, bubble) {
 }
 
 /**
- * @param {State} state
- * @param {Data} data
- * @param {BubbleContents} bubble
- * @param {PlacesFilterType} type
- * @param {number} num
+ * @param {string} cityname already upper-cased
+ * @param {string} title
  * @returns {string}
  */
-function createHeader(state, data, bubble, type, num) {
-  const cityname = bubble.city.infowindowName.toUpperCase();
-  const title = createTitle(state, data, cityname, bubble, type, num);
+function createHeader(cityname, title) {
   return `
     <h3 style="color:${LYRIC_GREY}">${cityname}</h3>
     <h5 style="color:${LYRIC_GREY}">${title}</h5>
@@ -104,17 +102,17 @@ function createHeader(state, data, bubble, type, num) {
 }
 
 /**
- * @param {State} state
  * @param {Data} data
  * @param {BubbleContents} bubble
  * @param {PlacesFilterType} type
  * @param {number} num
  * @returns {string}
  */
-function createPlacesPopupHtml(state, data, bubble, type, num) {
+function createPlacesPopupHtml(data, bubble, type, num) {
+  const cityname = bubble.city.infowindowName.toUpperCase();
   const poetCities = bubble.poetCities;
   return `
-    ${createHeader(state, data, bubble, type, num)}
+    ${createHeader(cityname, createPlacesModeTitle(data, cityname, type, num))}
     ${createNumberedListOfPoets(poetCities.map(pc => pc.poetDetailName))}
     <h4 style="color:${LYRIC_GREY}">DETAILS</h4>
     ${createDetailedListOfPoets(poetCities, data)}
@@ -159,30 +157,10 @@ function createDetailedGeoListOfPoets(poets) {
 }
 
 /**
- * @param {State} state
- * @param {Data} data
- * @param {string} cityname already upper-cased
- * @param {BubbleContents} bubble
- * @param {PlacesFilterType} type
- * @param {number} num
- * @returns {string}
- */
-function createTitle(state, data, cityname, bubble, type, num) {
-  switch (state.currentMapMode) {
-    case "placesMode":
-      return createPlacesModeTitle(data, cityname, type, num);
-    case "geoimaginaryMode": {
-      const referenceStr = bubble.poetCities.length === 1 ? "REFERENCE" : "REFERENCES";
-      return `${bubble.poetCities.length} ${referenceStr} TO ${cityname}`;
-    }
-    case "travelMode":
-      throw new Error("createTitle is not used by the travel map");
-    default:
-      return assertUnreachable(state.currentMapMode, "unrecognized map mode");
-  }
-}
-
-/**
+ * Names the filter the bubble is being shown under. Exhaustive over the three
+ * filters the places control bar offers, and there is no fourth: the ALL that
+ * used to need a throw here belongs to the geographical imaginary map, which
+ * titles its own popups below.
  * @param {Data} data
  * @param {string} cityname already upper-cased
  * @param {PlacesFilterType} type
@@ -201,28 +179,22 @@ function createPlacesModeTitle(data, cityname, type, num) {
       const genrename = data.genresByGenreId[num].toUpperCase();
       return `POET BORN IN ${cityname} AND ASSOCIATED WITH ${genrename}`;
     }
-    case "all":
-      // Offered by the geographical imaginary control bar, which titles its
-      // popups in createTitle rather than here.
-      throw new Error("the places map has no ALL filter");
     default:
       return assertUnreachable(type, "unrecognized places filter");
   }
 }
 
 /**
- * @param {State} state
- * @param {Data} data
  * @param {BubbleContents} bubble
- * @param {PlacesFilterType} type
- * @param {number} num
  * @returns {string}
  */
-function createGeoImaginaryPopupHtml(state, data, bubble, type, num) {
+function createGeoImaginaryPopupHtml(bubble) {
+  const cityname = bubble.city.infowindowName.toUpperCase();
   // calcBubbles always populates poets in geoimaginaryMode.
   const poets = /** @type {GeoBubblePoet[]} */ (bubble.poets);
+  const referenceStr = bubble.poetCities.length === 1 ? "REFERENCE" : "REFERENCES";
   return `
-    ${createHeader(state, data, bubble, type, num)}
+    ${createHeader(cityname, `${bubble.poetCities.length} ${referenceStr} TO ${cityname}`)}
     ${createGeoHeaderListOfPoets(poets)}
     <h4 style="color:${LYRIC_GREY}">DETAILS</h4>
     ${createDetailedGeoListOfPoets(poets)}

--- a/js/renderMap/calcPoetCities.js
+++ b/js/renderMap/calcPoetCities.js
@@ -1,30 +1,65 @@
-import { getGenres, getPlacesFilter } from "../calcData/getters.js";
+import { getGenres, getPlacesFilter, getGeoFilter } from "../calcData/getters.js";
 import { assertUnreachable } from "../assertUnreachable.js";
 import { getDateFilterFn } from "./calcCommon.js";
 
 /** @typedef {PoetCity | GeoPoetCity} AnyPoetCity */
-/** @typedef {(poetCity: AnyPoetCity) => boolean} PoetCityFilter */
 
 /**
  * Picks the right source rows for the current map, applies the date slider and
  * control-bar filters, and flattens the survivors for rendering.
+ *
+ * The two maps are handled apart rather than together, because they do not
+ * offer the same filters: places has ORIGIN, ACTIVITY and the genres,
+ * geographical imaginary has ALL REFERENCES. They share only "poet".
  * @param {Data} data
  * @param {State} state
  * @returns {RenderedPoetCity[]}
  */
 export function calcPoetCities(data, state) {
+  switch (state.currentMapMode) {
+    case "placesMode":
+      return calcPlacesPoetCities(data, state);
+    case "geoimaginaryMode":
+      return calcGeoPoetCities(data, state);
+    case "travelMode":
+      // The travel map draws arcs rather than bubbles, and calculates them in
+      // lines.js. Nothing routes it here.
+      throw new Error("calcPoetCities is not used by the travel map");
+    default:
+      return assertUnreachable(state.currentMapMode, "unrecognized current map mode");
+  }
+}
+
+/**
+ * @param {Data} data
+ * @param {State} state
+ * @returns {RenderedPoetCity[]}
+ */
+function calcPlacesPoetCities(data, state) {
   const [type, num] = getPlacesFilter(state);
-  const dated = getPoetCitiesData(data, state).filter(getDateFilterFn(data, state));
+  const dated = data.poetCities.filter(getDateFilterFn(data, state));
 
   if (type === "genre") return renderGenreRows(dated, data, num);
 
-  return dated.filter(getFilterFn(type, num)).map(poetCity => renderPoetCity(poetCity));
+  return dated.filter(getPlacesFilterFn(type, num)).map(poetCity => renderPoetCity(poetCity));
+}
+
+/**
+ * @param {Data} data
+ * @param {State} state
+ * @returns {RenderedPoetCity[]}
+ */
+function calcGeoPoetCities(data, state) {
+  const [type, num] = getGeoFilter(state);
+  const dated = data.geopoetCities.filter(getDateFilterFn(data, state));
+
+  return dated.filter(getGeoFilterFn(type, num)).map(poetCity => renderPoetCity(poetCity));
 }
 
 /**
  * Filters and renders together, so the entry that qualifies a row is the one
  * that supplies its citation.
- * @param {AnyPoetCity[]} poetCities
+ * @param {PoetCity[]} poetCities
  * @param {Data} data
  * @param {number} genreId
  * @returns {RenderedPoetCity[]}
@@ -38,33 +73,14 @@ function renderGenreRows(poetCities, data, genreId) {
 }
 
 /**
- * @param {Data} data
- * @param {State} state
- * @returns {AnyPoetCity[]}
- */
-function getPoetCitiesData(data, state) {
-  switch (state.currentMapMode) {
-    case "placesMode":
-    case "travelMode":
-      return [...data.poetCities];
-    case "geoimaginaryMode":
-      return [...data.geopoetCities];
-    default:
-      return assertUnreachable(state.currentMapMode, "unrecognized current map mode");
-  }
-}
-
-/**
- * Builds the predicate for the selected radio button. Genre is excluded from
- * the type because renderGenreRows handles it.
+ * Builds the predicate for the selected places radio button. Genre is excluded
+ * from the type because renderGenreRows handles it.
  * @param {Exclude<PlacesFilterType, "genre">} type
  * @param {number} num
- * @returns {PoetCityFilter}
+ * @returns {(poetCity: PoetCity) => boolean}
  */
-function getFilterFn(type, num) {
+function getPlacesFilterFn(type, num) {
   switch (type) {
-    case "all":
-      return () => true;
     case "relationship":
       // Relationship 3 is "activity", which every row qualifies for.
       if (num === 3) return () => true;
@@ -72,7 +88,24 @@ function getFilterFn(type, num) {
     case "poet":
       return poetCity => poetCity.poetId === num;
     default:
-      return assertUnreachable(type, "unrecognized filter when calculating poet cities");
+      return assertUnreachable(type, "unrecognized filter on the places map");
+  }
+}
+
+/**
+ * As getPlacesFilterFn, for the geographical imaginary map's two filters.
+ * @param {GeoFilterType} type
+ * @param {number} num
+ * @returns {(poetCity: GeoPoetCity) => boolean}
+ */
+function getGeoFilterFn(type, num) {
+  switch (type) {
+    case "all":
+      return () => true;
+    case "poet":
+      return poetCity => poetCity.poetId === num;
+    default:
+      return assertUnreachable(type, "unrecognized filter on the geographical imaginary map");
   }
 }
 

--- a/tests/initializeData.test.js
+++ b/tests/initializeData.test.js
@@ -7,7 +7,7 @@ import { test, describe } from "node:test";
 import assert from "node:assert/strict";
 import { loadInitializedData } from "./helpers/loadData.js";
 import { sortAlphabetically } from "../js/calcData/data.js";
-import { PLACES_FILTER_TYPES, TRAVEL_FILTER_TYPES } from "../js/calcData/getters.js";
+import { PLACES_FILTER_TYPES, GEO_FILTER_TYPES, TRAVEL_FILTER_TYPES } from "../js/calcData/getters.js";
 import { createPlacesInterfaceHtml } from "../js/interface/placesInterface.js";
 import { createTravelInterfaceHtml } from "../js/interface/travelInterface.js";
 import { createGeoImaginaryInterfaceHtml } from "../js/interface/geoImaginaryInterface.js";
@@ -267,41 +267,41 @@ describe("known bugs: derived travel lines", () => {
 // ---------------------------------------------------------------------------
 // The control bar is HTML strings, and a radio button's id is the only thing
 // tying a click back to a filter. The types stop a prefix being misspelt; these
-// tests stop a map offering a filter it cannot handle, which the types cannot
-// see because both builders take the same MapFilterType.
+// tests tie each map's declared filter union to what its builder actually emits,
+// which the types cannot see because all three builders take MapFilterType.
+//
+// Asserted as an equality rather than a subset, in both directions at once: a
+// map that offers a filter it cannot handle fails, and so does a map that
+// declares a filter it never offers — which is the dead branch that used to
+// need a throw in createPlacesModeTitle().
 // ---------------------------------------------------------------------------
 
-describe("control bar ids round-trip to filters", () => {
+describe("each control bar offers exactly the filters its map declares", () => {
   /** Every `${prefix}_${num}` id in a block of control bar html. */
   const idsIn = (/** @type {string} */ html) => [...html.matchAll(/id="([^"]+)"/g)].map(match => match[1]);
 
   const prefixesIn = (/** @type {string} */ html) => [...new Set(idsIn(html).map(id => id.split("_")[0]))].sort();
 
-  test("the places control bar offers only places filters", () => {
-    for (const prefix of prefixesIn(createPlacesInterfaceHtml(data))) {
-      assert.ok(
-        PLACES_FILTER_TYPES.includes(/** @type {PlacesFilterType} */ (prefix)),
-        `the places control bar offers "${prefix}", which getPlacesFilter() rejects`
-      );
-    }
+  test("places: ORIGIN and ACTIVITY, the poets, and the genres", () => {
+    assert.deepEqual(prefixesIn(createPlacesInterfaceHtml(data)), [...PLACES_FILTER_TYPES].sort());
   });
 
-  test("the geographical imaginary control bar offers only places filters", () => {
-    for (const prefix of prefixesIn(createGeoImaginaryInterfaceHtml(data))) {
-      assert.ok(
-        PLACES_FILTER_TYPES.includes(/** @type {PlacesFilterType} */ (prefix)),
-        `the geographical imaginary control bar offers "${prefix}", which getPlacesFilter() rejects`
-      );
-    }
+  test("geographical imaginary: ALL REFERENCES and the poets, and nothing else", () => {
+    assert.deepEqual(prefixesIn(createGeoImaginaryInterfaceHtml(data)), [...GEO_FILTER_TYPES].sort());
   });
 
-  test("the travel control bar offers only travel filters", () => {
-    for (const prefix of prefixesIn(createTravelInterfaceHtml(data))) {
-      assert.ok(
-        TRAVEL_FILTER_TYPES.includes(/** @type {TravelFilterType} */ (prefix)),
-        `the travel control bar offers "${prefix}", which getTravelFilter() rejects`
-      );
-    }
+  test("travel: all six", () => {
+    assert.deepEqual(prefixesIn(createTravelInterfaceHtml(data)), [...TRAVEL_FILTER_TYPES].sort());
+  });
+
+  test("the two bubble maps really do offer different filters", () => {
+    // The point of splitting PlacesFilterType from GeoFilterType. If these ever
+    // coincide the split has stopped earning its keep.
+    const places = prefixesIn(createPlacesInterfaceHtml(data));
+    const geo = prefixesIn(createGeoImaginaryInterfaceHtml(data));
+    assert.notDeepEqual(places, geo);
+    assert.ok(!places.includes("all"), "the places map has no ALL button");
+    assert.ok(!geo.includes("genre"), "the geographical imaginary map has no genre buttons");
   });
 
   test("every id parses back to the filter and number it was built from", () => {
@@ -317,7 +317,7 @@ describe("control bar ids round-trip to filters", () => {
   test("the default selectedId of each mode is one that mode can handle", () => {
     // updateMapMode() sets these; they are what the map renders on first paint.
     assert.ok(PLACES_FILTER_TYPES.includes(/** @type {PlacesFilterType} */ ("relationship")));
-    assert.ok(PLACES_FILTER_TYPES.includes(/** @type {PlacesFilterType} */ ("all")));
+    assert.ok(GEO_FILTER_TYPES.includes(/** @type {GeoFilterType} */ ("all")));
     assert.ok(TRAVEL_FILTER_TYPES.includes(/** @type {TravelFilterType} */ ("all")));
   });
 });

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -229,19 +229,30 @@ interface FilterOption {
  * The filter kinds encoded in the first half of State.selectedId, e.g. the
  * "poet" in "poet_93".
  *
- * Each map offers its own set, and the two overlap rather than nest: "all" and
- * "poet" appear on both, "genre" only on places, "gov" only on travel. Keeping
- * them as separate unions lets getPlacesFilter() and getTravelFilter() each
- * hand back exactly what their map can produce, so consumers switch over four
- * or six cases with nothing impossible left to handle.
+ * There are three maps and three sets, overlapping rather than nesting: "poet"
+ * is on all three, "all" on geographical imaginary and travel but not places,
+ * "relationship" and "genre" only on places, "gov" only on travel. Keeping them
+ * as separate unions lets each getter hand back exactly what its own control
+ * bar can produce, so consumers switch over two or three cases with nothing
+ * impossible left to handle.
+ *
+ * These are what createPlacesInterfaceHtml() actually emits: ORIGIN and
+ * ACTIVITY (relationship), the poets with unknown travel, and the genres.
  */
-type PlacesFilterType = "all" | "relationship" | "poet" | "genre";
+type PlacesFilterType = "relationship" | "poet" | "genre";
 
-/** As PlacesFilterType, for the travel map. */
+/**
+ * What createGeoImaginaryInterfaceHtml() emits: ALL REFERENCES, and one button
+ * per poet. It offers no relationship and no genre, and it is the only one of
+ * the three place-and-bubble maps with an ALL.
+ */
+type GeoFilterType = "all" | "poet";
+
+/** As above, for the travel map. */
 type TravelFilterType = "all" | "poet" | "destination" | "smallregion" | "region" | "gov";
 
 /** Any filter kind, whichever map produced it. */
-type MapFilterType = PlacesFilterType | TravelFilterType;
+type MapFilterType = PlacesFilterType | GeoFilterType | TravelFilterType;
 
 /** One poet's attested movement from one birthplace to one place of activity. */
 interface Line extends PoetPrimed {


### PR DESCRIPTION
Third of five, now rebased onto `master` after #342 and #343 merged. Replaces #344, which GitHub closed and will not reopen after its base branch was deleted; same commit, no content change.

## The bad state

The places map and the geographical imaginary map shared one union:

```ts
type PlacesFilterType = "all" | "relationship" | "poet" | "genre";
```

Neither map offers those four:

| control bar | emits |
| --- | --- |
| `createPlacesInterfaceHtml` | `relationship`, `poet`, `genre` — **no ALL** |
| `createGeoImaginaryInterfaceHtml` | `all`, `poet` — **no relationship, no genre** |

The union was the two sets added together, so every consumer had to handle filters its own map could not produce. The cost was sitting in the code as throws that existed only to plug holes the type had opened:

```js
createPlacesModeTitle()  case "all":         throw new Error("the places map has no ALL filter");
createTitle()            case "travelMode":  throw new Error("createTitle is not used by the travel map");
```

## The fix

```ts
type PlacesFilterType = "relationship" | "poet" | "genre";
type GeoFilterType = "all" | "poet";
```

Both throws delete themselves, and `createTitle()` goes with them — its only job was to dispatch on the map mode, which its caller already knows.

`calcPoetCities()` branches on the mode once, at the top, and each map runs through its own predicate: two cases for the geographical imaginary, two for places once genre is peeled off, neither carrying a branch for something the other map offers. The dead `travelMode` case in `getPoetCitiesData()` — which returned `poetCities` for a map that never calls it — goes too.

`createPopupHtml()` now reads the filter only on the branch that needs it. The geographical imaginary popup titles itself by counting references, so it never needed to know which button was selected, and no longer asks.

## The tests get stronger, not weaker

They asserted each builder emits *only* filters its map accepts. They now assert the two sets are **equal**, which also catches the opposite fault: a map declaring a filter its control bar never offers — precisely the dead branch that needed the throw.

A new test pins the point of the split, so it fails if the two maps ever quietly converge again:

```js
test("the two bubble maps really do offer different filters", () => {
  assert.notDeepEqual(places, geo);
  assert.ok(!places.includes("all"), "the places map has no ALL button");
  assert.ok(!geo.includes("genre"), "the geographical imaginary map has no genre buttons");
});
```

## Verification

No behaviour change — all 33 aspects of `Data` and of the rendered output (bubbles for six views, arcs for all 182 travel filters) compared against the parent branch: **0 differences**.

Tests (98), lint, format and the browser smoke test all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
