### PR TITLE
Parse the ids hydrate() was missing, and make the omission a type error

### DIFF
--- a/js/calcData/data.js
+++ b/js/calcData/data.js
@@ -39,6 +39,29 @@ export function initializeData(raw) {
 }
 
 /**
+ * Every field Papa Parse hands back as a string that is not one.
+ *
+ * The three marked below were missing when this was a flat list of forEach
+ * calls, so a Poet held the string "149" where its type promised a number. It
+ * went unnoticed for as long as it did because an id is only ever used as an
+ * object key, and poetsById["149"] and poetsById[149] are the same key — until
+ * something compares one with ===.
+ * @type {NumericCsvFields}
+ */
+export const NUMERIC_CSV_FIELDS = {
+  regions: { int: ["regionId", "bigRegionId"] },
+  cities: { int: ["cityId", "regionId"], float: ["lat", "long"] },
+  poetCities: { int: ["poetId", "cityId", "relationshipId"] },
+  poets: { int: ["poetId"] }, // was missing
+  genres: { int: ["poetId", "genreId"] }, // poetId was missing
+  geopoetCities: { int: ["poetId", "cityId", "imaginaryid"] },
+  cityPolitics: { int: ["cityId", "governmentId"], bce: ["date"] },
+  bigRegions: { int: ["regionId"] }, // the whole table was missing
+  dates: { int: ["poetId"], bce: ["date"] },
+  governments: { int: ["governmentId"] }
+};
+
+/**
  * Papa Parse hands back every field as a string. This parses the numeric ones in
  * place and hands the rows back under their hydrated types, which is the only
  * form the rest of the codebase ever sees.
@@ -52,27 +75,14 @@ function hydrate(raw) {
   /** @type {Record<keyof RawCsvs, any[]>} */
   const rows = raw;
 
-  rows.genres.forEach(genre => (genre.genreId = parseInt(genre.genreId)));
-  rows.cities.forEach(city => (city.cityId = parseInt(city.cityId)));
-  rows.cities.forEach(city => (city.regionId = parseInt(city.regionId)));
-  rows.cities.forEach(city => (city.lat = parseFloat(city.lat)));
-  rows.cities.forEach(city => (city.long = parseFloat(city.long)));
-  rows.cityPolitics.forEach(city => (city.cityId = parseInt(city.cityId)));
-  rows.cityPolitics.forEach(city => (city.governmentId = parseInt(city.governmentId)));
-  rows.cityPolitics.forEach(cp => (cp.date = -1 * parseInt(cp.date)));
-  rows.poetCities.forEach(poetCity => (poetCity.relationshipId = parseInt(poetCity.relationshipId)));
-  rows.poetCities.forEach(poetCity => (poetCity.poetId = parseInt(poetCity.poetId)));
-  rows.poetCities.forEach(poetCity => (poetCity.cityId = parseInt(poetCity.cityId)));
-  rows.geopoetCities.forEach(poetCity => (poetCity.poetId = parseInt(poetCity.poetId)));
-  rows.geopoetCities.forEach(poetCity => (poetCity.imaginaryid = parseInt(poetCity.imaginaryid)));
-  rows.geopoetCities.forEach(poetCity => (poetCity.cityId = parseInt(poetCity.cityId)));
-  rows.regions.forEach(region => (region.regionId = parseInt(region.regionId)));
-  rows.regions.forEach(region => (region.bigRegionId = parseInt(region.bigRegionId)));
-  rows.dates.forEach(date => {
-    date.poetId = parseInt(date.poetId);
-    date.date = -1 * parseInt(date.date);
-  });
-  rows.governments.forEach(gov => (gov.governmentId = parseInt(gov.governmentId)));
+  for (const table of /** @type {(keyof RawCsvs)[]} */ (Object.keys(NUMERIC_CSV_FIELDS))) {
+    const fields = NUMERIC_CSV_FIELDS[table];
+    for (const row of rows[table]) {
+      for (const field of fields.int ?? []) row[field] = parseInt(row[field]);
+      for (const field of fields.float ?? []) row[field] = parseFloat(row[field]);
+      for (const field of fields.bce ?? []) row[field] = -1 * parseInt(row[field]);
+    }
+  }
 
   return rows;
 }

--- a/tests/initializeData.test.js
+++ b/tests/initializeData.test.js
@@ -32,16 +32,54 @@ describe("initializeData runs clean", () => {
 });
 
 describe("hydration", () => {
-  test("ids and coordinates become numbers", () => {
-    for (const city of data.cities) {
-      assert.equal(typeof city.cityId, "number", `${city.cityname} has a non-numeric cityId`);
-      assert.equal(typeof city.lat, "number", `${city.cityname} has a non-numeric lat`);
-      assert.equal(typeof city.long, "number", `${city.cityname} has a non-numeric long`);
+  test("every field the types declare numeric really is one, on every row", () => {
+    // Written out by hand rather than read from NUMERIC_CSV_FIELDS, which would
+    // only assert that table against itself. This is the independent statement
+    // of the same claim, and it is what was missing: the version of this test it
+    // replaces checked cities and poetCities alone, so poets.poetId,
+    // genres.poetId and the whole of bigRegions went unparsed and unnoticed.
+    /** @type {[keyof Csvs, string[]][]} */
+    const NUMERIC = [
+      ["cities", ["cityId", "regionId", "lat", "long"]],
+      ["regions", ["regionId", "bigRegionId"]],
+      ["bigRegions", ["regionId"]],
+      ["governments", ["governmentId"]],
+      ["cityPolitics", ["cityId", "governmentId", "date"]],
+      ["dates", ["poetId", "date"]],
+      ["poets", ["poetId"]],
+      ["genres", ["poetId", "genreId"]],
+      ["poetCities", ["poetId", "cityId", "relationshipId"]],
+      ["geopoetCities", ["imaginaryid", "poetId", "cityId"]]
+    ];
+    for (const [table, fields] of NUMERIC) {
+      const rows = /** @type {Record<string, unknown>[]} */ (/** @type {unknown} */ (data[table]));
+      assert.ok(rows.length > 0, `${table} is empty`);
+      for (const field of fields) {
+        const bad = rows.filter(row => typeof row[field] !== "number").length;
+        assert.equal(bad, 0, `${bad}/${rows.length} rows of ${table} have a non-numeric ${field}`);
+      }
     }
-    for (const pc of data.poetCities) {
-      assert.equal(typeof pc.poetId, "number");
-      assert.equal(typeof pc.cityId, "number");
-    }
+  });
+
+  test("ids can be compared across tables with ===", () => {
+    // What the strings actually broke. An id is nearly always used as an object
+    // key, where poetsById["149"] and poetsById[149] are the same key, so the
+    // three unparsed fields hid behind that for as long as nothing compared one.
+    const pindar = data.poets.find(poet => poet.poetDetailName === "Pindar");
+    assert.ok(pindar, "expected a poet named Pindar");
+    assert.ok(
+      data.lines.some(line => line.poetId === pindar.poetId),
+      "Pindar's travel lines should be findable by === on poetId"
+    );
+    assert.ok(
+      data.genres.some(genre => genre.poetId === pindar.poetId),
+      "Pindar's genres should be findable by === on poetId"
+    );
+    const region = data.regions[0];
+    assert.ok(
+      data.bigRegions.some(bigRegion => bigRegion.regionId === region.bigRegionId),
+      "a region's bigRegionId should match a big region by ==="
+    );
   });
 
   test("cities with no coordinates hydrate to NaN, and are skipped when drawing", () => {

--- a/types/csv.d.ts
+++ b/types/csv.d.ts
@@ -149,6 +149,27 @@ interface RawCsvs {
   governments: RawGovernment[];
 }
 
+/**
+ * Which fields of which CSV hydrate() parses out of their string form.
+ *
+ * Total over the ten CSVs, and each field name is checked against that CSV's own
+ * columns — `keyof RawCsvs[K][number]` is the column set of one row of table K.
+ * So a field named here that the CSV does not have, or a table left out
+ * entirely, is a type error.
+ *
+ * This exists because hydrate() used to be a flat list of forEach calls with no
+ * relationship to the types they were producing, and three fields were simply
+ * missing from it: poets.poetId, genres.poetId, and the whole of bigRegions.
+ */
+type NumericCsvFields = {
+  [K in keyof RawCsvs]: {
+    int?: (keyof RawCsvs[K][number])[];
+    float?: (keyof RawCsvs[K][number])[];
+    /** Written as a positive year BCE in the CSV, stored negative so it sorts. */
+    bce?: (keyof RawCsvs[K][number])[];
+  };
+};
+
 /** The three tables that carry source citations. */
 type CitedCsv = "poetCities" | "geopoetCities" | "genres";
 


### PR DESCRIPTION
Item 1 of the four follow-ups. **Stacked on #347.**

## The bug

Three fields were never parsed out of their string form:

| field | state |
| --- | --- |
| `poets.poetId` | missing |
| `genres.poetId` | missing |
| `bigRegions.regionId` | the whole table was absent from `hydrate()` |

Their types said `number` and they held `"149"`. It survived because an id is nearly always used as an object key, where `poetsById["149"]` and `poetsById[149]` are the same key — so nothing noticed until something compared one with `===`. Nothing in the site did; a test written against `Line.poetId` in #347 is what turned it up.

## The cause is worth more than the fix

`hydrate()` was twenty `forEach` calls with no relationship to the types they were producing, so a missing one looked exactly like the surrounding code. It's now a table:

```js
/** @type {NumericCsvFields} */
export const NUMERIC_CSV_FIELDS = {
  poets: { int: ["poetId"] },
  cities: { int: ["cityId", "regionId"], float: ["lat", "long"] },
  dates: { int: ["poetId"], bce: ["date"] },
  ...
};
```

`NumericCsvFields` is a mapped type over `RawCsvs`, so the table is **total** over the ten CSVs and each field name is checked against that CSV's own columns — `keyof RawCsvs[K][number]` is the column set of one row of table K. I checked both failure modes rather than assuming:

```
Property 'bigRegions' is missing in type ... but required in type 'NumericCsvFields'
Type '"poetID"' is not assignable to type 'keyof RawPoet'. Did you mean '"poetId"'?
```

This is a piece of item #3 (deriving hydrated types from the `Raw*` types) arriving early, and the part of it that pays for itself immediately.

## Tests

The hydration test checked `cities` and `poetCities` alone, which is exactly why it caught none of this. It now names every numeric field of every table — written out by hand rather than read from `NUMERIC_CSV_FIELDS`, since reading it would only assert that table against itself. A second test compares ids across tables with `===`, which is what the strings actually broke.

Both fail when `poets.poetId` is removed from the table again:

```
133/133 rows of poets have a non-numeric poetId
Pindar's travel lines should be findable by === on poetId
```

## Verification

Bubbles, arcs, control bar html, the control bar lists, and `initializeData()`'s alert/log output are all identical to #347.

Worth recording because it looked like a regression at first: a comparison harness that fed `bigRegions.regionId` straight into the region filter *did* change, because it had been passing the string `"2"` against a numeric `bigRegionId` and matching nothing. The site never did that — `parseFilter()` parses the number out of the radio button's id — so no filter was broken in the app. The harness was testing a path the app cannot produce.

Tests (99), lint, format and the browser smoke test all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
