### PR TITLE
Keep the typecheck inside the repository, and install what it needs

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -41,10 +41,12 @@ jobs:
       - name: Format
         run: npm run format:check
 
+      # npm run typecheck installs what it needs itself, so this is only here to
+      # get the exact lockfile rather than whatever npm install resolves to.
       - name: Install type declarations and playwright
         run: npm ci
       - name: Typecheck
-        run: npx -y -p typescript@5 tsc -p jsconfig.json
+        run: npm run typecheck
 
       # Serves the repository and opens it in headless Chromium, to check the
       # map actually paints. Not a screenshot test: see tests/browser/.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,30 @@
+# Notes for agents
+
+Vanilla JS, served with no build step. Nothing is bundled or compiled, and the
+site is plain files served as-is. Keep it that way — see the README for why.
+
+## Checks
+
+Run these, in this order, before saying a change is done. They are the same four
+things CI runs, and all four should be silent on a clean tree.
+
+```sh
+npm test              # needs nothing but Node
+npm run lint
+npm run format        # or format:check, to see rather than fix
+npm run typecheck     # installs @types/node and playwright itself
+```
+
+`npm run test:browser` serves the repository and opens it in headless Chromium.
+It installs its own dependencies too, but downloads Chromium the first time, so
+it is slow on a fresh clone and is not part of `npm test`. Run it for changes to
+`js/renderMap/` or anything else that only shows up once Leaflet draws.
+
+## Don't run tsc by hand
+
+`npm run typecheck` installs before it checks, deliberately. Calling
+`npx tsc -p jsconfig.json` yourself skips that, and the failure is misleading
+rather than obvious: without `@types/node`, TypeScript resolves the missing
+packages by walking up out of the repository, then reports errors in whatever
+unrelated `node_modules` it lands in. A wall of errors in files with `../../`
+paths means the install was skipped, not that the code is broken.

--- a/README.md
+++ b/README.md
@@ -33,9 +33,11 @@ headless Chromium to check each map actually paints and that nothing errors. It
 needs an install, so it is kept separate from `npm test`:
 
 ```sh
-npm ci && npx playwright install chromium
 npm run test:browser
 ```
+
+That installs its own dependencies first, downloading Chromium the first time,
+which is slow. Everything after the first run is fast.
 
 ### Formatting
 
@@ -54,9 +56,16 @@ and deleting `jsconfig.json` and `types/` would leave the site working exactly
 as it does now.
 
 ```sh
-npm ci && npm run typecheck
+npm run typecheck
 ```
 
-The one dependency is `@types/node`, needed to check the tests. It is type
-declarations rather than code: nothing from `node_modules` is imported, served
-or deployed.
+It installs what it needs first, so it is clean from a fresh clone. Skipping
+that install does not merely skip a check — it makes `tsc` report errors in
+files that are not this project's, because `@types/node` is missing and
+TypeScript resolves the missing packages by walking up to whatever
+`node_modules` it can find above the repository.
+
+The dependencies are `@types/node`, needed to check the tests, and `playwright`,
+needed to check the browser smoke test. Both are type declarations as far as
+this project is concerned: nothing from `node_modules` is imported by the site,
+served or deployed.

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -8,6 +8,13 @@
     "moduleResolution": "bundler",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "allowJs": true,
+    // A file named jsconfig.json defaults this to 2, which makes tsc read and
+    // check the JavaScript inside node_modules. Since this project has almost
+    // no dependencies, resolution walks past its own node_modules and up the
+    // filesystem, and any unrelated node_modules above the repository — a
+    // stray one in a home directory, say — gets typechecked as if it were ours.
+    // That reports a hundred errors in third-party code and none of them here.
+    "maxNodeModuleJsDepth": 0,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noImplicitReturns": true,

--- a/package.json
+++ b/package.json
@@ -5,10 +5,12 @@
   "description": "No build. This file exists so Node treats the .js files as the ES modules they already are, to pin @types/node so the tests can be typechecked, and to pin playwright for the browser smoke test. Nothing is bundled or compiled, no dependency is shipped, and the site is still plain files served as-is.",
   "scripts": {
     "test": "node --test tests/*.test.js",
+    "pretest:browser": "npm install --no-audit --no-fund && npx playwright install chromium",
     "test:browser": "node --test tests/browser/*.test.js",
     "lint": "npx -y oxlint@1 --deny-warnings -A all -D correctness -D eqeqeq -D no-var -D prefer-const -D no-self-compare -D no-template-curly-in-string -D require-await js/ tests/ index.js",
     "format": "npx -y prettier@3 --write .",
     "format:check": "npx -y prettier@3 --check .",
+    "pretypecheck": "npm install --no-audit --no-fund",
     "typecheck": "npx -y -p typescript@5 tsc -p jsconfig.json"
   },
   "devDependencies": {


### PR DESCRIPTION
`npm run typecheck` reported 110 errors on a clean checkout. Ten were real — `tests/browser/smoke.test.js` cannot resolve playwright without an install. The other hundred were in files belonging to no one:

```
../../../../node_modules/string_decoder/lib/string_decoder.js  73
../../../../node_modules/punycode/punycode.js                  27
```

Four levels up is a home directory. Those errors survived `npm ci`, because installing locally does not add `punycode` or `string_decoder` either — neither is a dependency of this project. `--explainFiles` gives the chain:

```
Imported via "punycode" from '.../@types/node/process.d.ts'
```

`@types/node`'s `process.d.ts` imports both by name, resolution finds neither in our `node_modules`, walks up and out of the repository, and typechecks whatever it lands in. CI never saw this: a runner has no stray `node_modules` above the workspace. Anyone whose home directory does, sees a hundred errors that have nothing to do with their change and cannot be fixed by installing.

## The cause is the filename

TypeScript's config parser special-cases a file named `jsconfig.json` and injects five defaults before reading ours:

```
allowJs: true
maxNodeModuleJsDepth: 2      <- this one
allowSyntheticDefaultImports: true
skipLibCheck: true
noEmit: true
```

`maxNodeModuleJsDepth: 2` means read and check the JavaScript inside `node_modules`, however far away that turns out to be. A `tsconfig.json` defaults it to `0`. Setting it to `0` explicitly is the whole fix — a byte-identical copy of this file named `tsconfig.json` already reported zero.

Keeping the name. It says the thing this repository most wants understood — JavaScript project, nothing is compiled — and of the four remaining implied defaults, `allowJs` and `noEmit` we set ourselves and `allowSyntheticDefaultImports` follows from bundler resolution regardless. Only `skipLibCheck` is still arriving invisibly; a rename would flip it to `false` and start checking every `.d.ts` in `node_modules`, which passes today but would put a future `@types/node` bump in the blast radius.

## The ten real errors

A separate problem: the install was documented rather than enforced, so `npm run typecheck` and `npm run test:browser` both failed for anyone who skipped a step the README mentioned. They now install for themselves through `pretypecheck` and `pretest:browser`. A satisfied install is a no-op costing 125ms, and `package-lock.json` is untouched by it. CI keeps its `npm ci` for the exact lockfile and now calls `npm run typecheck`, so it runs the same command as everyone else.

## Verified from a deleted `node_modules`

| | |
|---|---|
| `npm test` | 99 pass, 0 fail, no install |
| `npm run typecheck` | 0 errors |
| `npm run lint` | clean |
| `npm run format:check` | clean |
| `npm run test:browser` | 24 pass, 0 fail, single command |

`CLAUDE.md` records the failure mode, since the shape of it is the misleading part — a wall of errors in `../../` paths means the install was skipped, not that the code is broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)