### PR TITLE
Restore the project notes as text

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,6 +5,13 @@
 # The data. Prettier has no CSV formatter, and these are edited in spreadsheets.
 dataFiles/
 
+# Transcribed minutes and research notes, kept as they were written. Reflowing
+# them would put this repository's line-length preferences into someone else's
+# words. notes/README.md is ours, so it is formatted.
+notes/corrections-2015-12.md
+notes/minutes/
+notes/research/
+
 # Generated.
 node_modules/
 package-lock.json

--- a/notes/README.md
+++ b/notes/README.md
@@ -1,0 +1,119 @@
+# Project notes
+
+Meeting minutes and research notes from 2014–15, when the map was a CartoDB
+application and the data lived in spreadsheets. They were deleted in
+`4c3ed7d "delete old map"` (4 December 2023) along with the map they belonged
+to, and are restored here as text.
+
+They are worth having back because the CSVs still carry decisions taken in these
+meetings, and nothing else in the repository says so. A row that looks like a
+mistake is quite often a ruling — and the reverse is also true, which is why the
+index below distinguishes rulings that landed from rulings that did not.
+
+Converted from RTF and DOCX with `textutil`; the wording is unchanged.
+
+## Contents
+
+- `minutes/` — seventeen meetings, February 2014 to September 2015.
+- `corrections-2015-12.md` — A.-E. Peponi's corrections of December 2015, run
+  through to a "FINAL Dec. 13th". The densest single document here: most of the
+  vocabulary the interface still uses was settled in it.
+- `research/travel-questions.md` — open questions about the corpus, including
+  the caveat that Bacchylides' places of activity are victory sites rather than
+  attested visits.
+- `research/geographical-imaginary-examples.md` — the worked examples the
+  geographical imaginary was piloted on (Olympian 1, Bacchylides 17).
+- `research/new-poets-searches.md`, `research/searches.md` — how the poet list
+  was assembled, from the New Pauly and the TLG canon.
+
+## Decisions that still bind the data
+
+Each of these is a standing ruling, not a one-off fix. Where it is recorded in a
+GitHub issue the issue number is given, since the issues are searchable and
+these files are not.
+
+**A poet may have several attested birthplaces, and all of them are shown.**
+Issue #33, "pick one birthplace for tyrtaeus", was closed "We no longer do
+this"; #208 and #218 then asked for the alternative traditions to be displayed.
+Thirteen poets have more than one. This is why Tyrtaeus has three and Sappho
+two, and it is not a data error.
+
+**ACTIVITY splits into NATIVE and NON-NATIVE, non-native first.** Peponi's
+suggestion, issue #165: "The NON-NATIVE should come first, I think, since this
+is more unexpected." Renamed from "NATIVE POETS ACTIVE IN X" to "NATIVE LYRIC
+ACTIVITY IN X" in the December corrections, on the reasoning that "a poet was
+not necessarily there but his poetry was circulating in that area". Still what
+`createActivePopupHtml` renders.
+
+**Being born in a city and counting as a native of it are different questions.**
+Issues #257 (Alcman) and #284 (Euripides): "Though we have to state his birth on
+Salamis it is important to include him in the native poets of Athens." The
+answer was the `nativeid` column, and `28f4504 "changed active query from
+relationshipid to nativeid"` pointed the old ACTIVITY query at it. **This did
+not survive the rewrite** — v2 splits on `relationshipId`, so Alcman is a native
+of Sparta again, which is what #257 was raised to prevent. `nativeid` is
+otherwise a copy of `relationshipId` on every row of `poets_cities.csv`, which
+is why it looks redundant.
+
+**A disputed origin says "See also: <the other cities>".** How #208, #218 and
+the second half of #257 were closed — a derived line in the old query,
+`'<br>See also: ' || string_agg(birth_cities.city_name, ...)`. **Also dropped in
+the rewrite**, and now open issue #332, which asks for "Poets possibly born in
+Sardis" and wonders whether Alcman is the only case. He is not; there are
+thirteen.
+
+**Tyrtaeus is not active in Sicily.** Issue #271: "Messena (Sicily) - Tyrtaeus -
+erase this location from his activity (it refers to the Pelop. location)", with
+#272 adding the Messenian region he goes to instead. The two Sicilian rows were
+retired by blanking their `relationshipid` rather than being deleted, which left
+them showing under ACTIVITY for another decade.
+
+**Pindar and Bacchylides get dotted lines wherever the evidence is a title.**
+December corrections: "IN GENERAL : to be consistent we need dotted lines for
+Pindar and Bacchylides in all cases we use TITLES." The `dotted` column.
+
+**TRAVEL is called MOBILITY, and ALL TRAVEL is ALL CASES.** December
+corrections, for the same reason as the ACTIVITY rename: the term "covers us in
+all cases where it seems that the poetry is mobile but we do not know if the
+poet was actually there". Still in `travelInterface.js`.
+
+**ORIGIN SOURCE and ACTIVITY SOURCE are singular.** December corrections, item 3. Still in `travelPopups.js`.
+
+**The project does not adjudicate its sources.** December corrections: 'Intro –
+please add a couple of words: "We report and display data based on the ancient
+sources, without judging whether they are all historically accurate"'. Still the
+third sentence of the essay, in `js/essay/essay.js`.
+
+The December corrections also settle a long list of regimes — Salamis follows
+Athens, Isthmus follows Corinth, the sanctuary of Poseidon Petraios follows
+Larisa, Mt. Ptoios follows Akraiphia, Messenia follows Sparta after the
+Messenian Wars — and are the place to check before changing `city_politics.csv`.
+
+## Not restored
+
+The rest of what `4c3ed7d` deleted documents a map that no longer exists: the
+CartoDB SQL under `queries/`, the CartoDB CSS, the jQRangeSlider vendor docs,
+and the letters and blog drafts under `humanities + design/`. They are still in
+git, one command away:
+
+    git show 4c3ed7d^:'queries/big activity query with native and non-native poets.txt'
+
+`old/humanities + design/12-9-13 meeting.rtf` is deliberately left out: it
+records a login and password for the Palladio beta.
+
+## Stephanis
+
+`old/` also held working material from I. E. Stephanis, _Διονυσιακοὶ Τεχνῖται_
+(Heraklion 1988) — the preface in full, and page scans with transcriptions:
+
+    old/intro to stefanis.txt          the ΠΡΟΛΟΓΟΣ, 20 KB of Greek
+    old/stefanis p. 95.JPG
+    old/stefanis p. 117.JPG   + .rtf   transcription
+    old/stefanis p. 118.JPG   + .rtf
+    old/stefanis p. 352.JPG   + .rtf
+    old/stefanis p. 441.JPG   + .rtf
+    old/stefanis p. 442.JPG   + .rtf
+
+Left out of this restore because republishing scanned pages of an in-copyright
+book is a decision for the project rather than a cleanup. The blobs are in the
+history either way.

--- a/notes/corrections-2015-12.md
+++ b/notes/corrections-2015-12.md
@@ -1,0 +1,322 @@
+# Corrections, December 2015 (A.-E. Peponi)
+
+Corrections December 2015
+AEP
+
+GENERAL ISSUES:
+
+1. Lists of Poets by name
+
+I. Poets with unknown travels ( under places)
+II. Poets with known travels ( under travel)
+
+2. Genres
+
+	•	Sappho, Alcaeus, Anacreon, Ibycus, Stesichorus, Simonides : Unclassified melic comes first.
+	•	Is there any logic in the sequence of genres in our listing? Should it be alphabetical for the rest?
+
+             3. ORIGIN SOURCE ( NOT plural)
+                ACTIVITY SOURCE ( NOT plural)
+
+             4. Pindar and Bacchylides : All cases where we only use the “title” should be shown as dotted lines. The term to use is “TITLE” ( not inscription). In these cases we do not need to say whose the translation is ( Race etc). Please use the term “title” in both Pindar and Bacchylides.
+
+             5. RETURN TO THE FIRST PAGE? “Home”? “homepage” ?
+
+            6. Move title/names of the project to the left. Also—red thin outline?
+
+   SPECIFIC ISSUES :
+
+   Poets with known travel
+
+  Alcman: In the box of Origin add just before Suda : “For both possibilities see for instance: Suda xxx”
+
+  Anacreon : in all three boxes of Origin italicize “ Anacreon of Teos” ( otherwise confusing)
+
+  Arion :  When the same source is repeated please italicize or underline each time the part that is relevant.
+   Also : we do *not* need Italy as a region here. Redundant. Please eliminate this line.
+
+Aristonous : erase – travels nowhere
+
+Bacchylides:
+Origin source ( in Sicily) : it is listed twice. Please eliminate one of them.
+Replace “ Inscription” with “Title”
+Dotted lines for all cases we rely on the Title.
+Thinner lines in general? The way they are now does not work—not friendly.
+Petraia : Two different lines for the same place?
+
+Diagoras
+Melos Corinth/ Melos Pellene—overlapping. Can we do something about this?
+
+Euenos : Again—when the same source is repeated please differentiate through underlining or italicizing, depending on what we want to emphasize each time.
+
+Eumelos : Again—same source used multiple times—please differentiate accordingly.
+
+Euripides :  Besides  tragedy : xxxx
+
+Hermippus : Besides comedy : xxx
+
+Hipponax : Origin source: Please cut the second part that refers to him going to Clazomenai.
+
+Ibycus : Lines Overlap.
+                  Also—please add Test.5 ( LIFE) for activity , travel> Corinth.
+
+Ion of Samos : activity : not understandable > what is it supposed to convey?
+
+Licymnus : in ACTIVITY put an asterisk after Gorgias of Leontini and at the bottom please write : “Gorgias settled in Athens after 427BC”
+
+Magnes : how do we know about his lyric identity?
+
+Melampus : same source used—underline or italicize accordingly
+
+Melanippides : Please clarify his association with Athens. You need to add/include Pherecrates’ name, otherwise things are not understandable. Probably the part of [Plut] Mus. that should be cited is the part in the middle of Campbell 6 : “ …the comic poet Pherecrates brought Music –twelve strings”
+
+Meletos: confusing—association with lyric?
+
+Pindar : all lines relying on TITLES should be dotted . ( not evidence from the VITA)
+	•	Also—Cynoscephalai > Messenia – wrong box referring to Acragas?
+
+  Pratinas Why unknown genres?
+  “Besides Satyr Play possibly hyporchema, dithyramb”
+
+ Pronomus : oveplapping lines
+
+Thespis of Thebes : how do we know he is relevant to lyric production?
+
+…es ( NOT –Es) – I keep forgetting how we know he is associated with lyric production.
+
+SMALL GEOGRAPHICAL REGION
+
+Ionian Sea --- please make corrections
+Cyclades and Western Aegean: thinner lines?
+In general: thinner lines where there is a lot of info
+
+GENRES:
+MODEL :e.g.  * POET(s) born in Rhodes and associated with Iambos etc
+ERASE ORIGIN INFO –KEEP ONLY DATE
+	•	Citation ( throughout the word is misspelled) – I prefer: SOURCE
+
+Hyporchema : Add Pratinas—with Athenaeus as citation ( Campbell 708)
+
+In Partheneia please add Anacreon. Source : Campbell 501 (just the first line in English and Greek) and add : see also Lucian Ver. Hist. 2.15
+
+POLITICS
+
+Please use Regime ( instead of government—I notice Josh prefers this as well in Polis)
+Please use the word Uncertain ( instead of ?)
+
+EXAMPLES
+
+Miletus -> MACEDONIA (region)
+POET(S)
+1. Timotheus
+DETAILS
+1. Timotheus
+Regimes (data from Hansen and Nielsen): Democracy->Kingship
+Dates: Late 5th to Early 4th c.
+
+Teos -> Athens
+POET(S)
+1. Anacreon
+DETAILS
+1. Anacreon
+Regime (data from Hansen and Nielsen): Uncertain->Democracy
+Dates: fl. 550–500
+
+Kynoskephalai -> Himera
+POET(S)
+1. Pindar
+DETAILS
+1. Pindar
+Regimes (data from Hansen and Nielsen): Uncertain ->Tyranny
+Dates: fl. 500–450
+
+BUT : COULD YOU PLEASE CHECK AGAIN REGIMES in THEBES—I am wondering if we should take it for granted they had oligarchy .
+
+1. Ion of Chios   (-- YES, to your suggestion but please use the term
+                          Regimes )
+Regimes (data from Hansen and Nielsen): Oligarchy/Tyranny/Mixed->Democracy
+Dates: 5th c.
+
+Changes in Regimes—apart from Kunoskephalai ( Thebes), Marathon,
+
+*Sardis> please change into : Kingship
+* Methymna> I am puzzled with this “uncertain”—Methymna probably had oligarchic and tyrannical regimes in the time of Sappho, Alcaeus—could you please check again?
+* Mysia> Kingship
+* Eresos > the same as Methymna in Sappho’s/Alcaeus’ times – please check again
+* Sicily—You have it as “ uncertain” -- but this is not accurate. Sicily is a region and the various poleis on it had their own regimes. We should eliminate the region category “Sicily” from the political regimes map.
+* Salamis – in general, it should follow regimes of Athens ( even if there were exceptions, they must have been very few). BUT YOU SEEM TO HAVE SALAMIS TWICE on the spreadsheet (?)
+* Persepolis – Kingship
+
+----------
+
+FINAL ( or semi-final corrections) Dec. 8-10 2015
+
+1. PLACES
+
+Poets with unknown travel
+
+Alkimachus ??> Very confusing because he does travel but we do not know from where. EITHER  erase the name OR after “ Musician labeled Alkimaknos ADD : OF UNKNOWN ORIGIN in all 4 cases
+
+Ananius> nothing seems to be shown. Eliminate.
+
+Exekestides >  After  the English translation you have to add OF UNKNOWN ORIGIN ( otherwise it is not clear why we have him in this category)
+
+Hegemon: I believe we had eliminated him in the past. Please let me know.
+
+Melanippides the Elder : better to eliminate. ( probably the same as the younger ( or so PLV seems to suggest—let’s not confuse people )
+
+Oenopas : please eliminate—I do not see anything on the map about him
+
+[Izzy] ** PLEASE ADD** : Hybrias – on Crete--  ( categories : unknown travel and Skolia) – mentioned by Athenaeus—please add reference ( see also Brill’s New Pauly )
+
+TRAVEL
+
+	•	How is it possible that nobody moves FROM Central Greece?
+
+GEOGRAPHICAL IMAGINARY
+
+	•	Please eliminate Aristotle ( we do not have him anywhere else and he does not really add much to the material)
+	•	Scythinus is nowhere else on our lists – please eliminate
+	•	Please change from “References in the poetry of xxx” to just
+“ References”
+
+GENERAL:
+
+-Es on the list of poets should be –es
+
+CORRECTIONS FRIDAY DEC. 11
+
+  GENERAL
+
+	•	Before we installed the home sign on the map, there used to be a sign showing that a page is (still) loading. This was useful because it showed that things are working well but sometimes it takes some more time to reach the results. Can we re-install it or un-cover it?
+
+	•	 When one accesses the site it always has to start with the Intro page. This is not the case now. Can it be fixed?
+
+	•	Intro – please add a couple of words :“ We report and display data based on the ancient sources, without judging whether they are all historically accurate”
+
+	•	Credits and Acknowledgments :
+
+** Campbell, David. 1982-1993?. Greek Lyric. Vols. 1–5. Cambridge, Mass.: Harvard University Press.
+( I **think** the earliest is 1982 but the latest 1993—Izzy, Please check and correct accordingly).
+** The same with Gerber – Izzy, please check.
+
+	•	Acknowledgments ( erase the word, instead put Many thanks to….)
+             Many thanks to
+Stanford’s Department of Classics for financial support.
+The rest follow alphabetically
+
+	•	On the video-clip , on the Intro-page it says : Lyric Mapping HD. Can we instead ( or in addition) have the same white fonts say : HOW TO USE
+
+ MORE DETAILS :
+	•	Ion of Samos : It is still unclear what the Activity Source says about him.
+	•	Meletos ( on Travelling poets) is mentioned as a Tragedy poet. Why do we need him? Better erase.
+	•	Melanippides : Please eliminate “ Possibly active in Athens” – let’s take it for granted since Comedy refers to him.
+	•	Pindar :
+	•	For the Abderites—shouldn’t this be dotted? It is based on the title—right?
+	•	The same for the Naxians
+	•	The same for Ceans
+	•	The same for Acharnae
+	•	Do we have Pindar connected to Athens anywhere ? Not sure I can see it. Please use the title of 75 SM ( see Vol. II, Race). Dotted line.
+	•	IN GENERAL : to be consistent we need dotted lines for Pindar and Bacchylides in all cases we use TITLES.
+	•	Not sure what the source associating him with Delphi says. Please clarify.
+	•	Pratinas
+Yes, please add “possibly  hyporchema, dithyramb)
+	•	Thespis of Thebes ( please add “of Thebes” next to the name on the list).
+Since the same source is used for both ORIGIN and ACTIVITY for Thespis please show in bold which part of the source applies accordingly.
+
+GEOGRAPHICAL IMAGINARY
+	•	Please eliminate from the list : Aninius, Scythinus.
+
+                         TRAVEL/REGION
+    I am still puzzled as to why nobody moves FROM Central Greece. If Central Greece is just Delphi here, we should eliminate it.
+
+             ALSO—let’s eliminate EUnicus for now. We can add him later.
+
+DECEMBER 12,  CHANGES NEEDED
+
+PINDAR
+
+1. All lines start from THEBES ( not Kynoskephalai). And you do not need to show Pindar moving from Kynoskephalai to Thebes, for Kynoskephalai is considered part of Thebes.
+
+2. Pindar> Syracuse – Please use the VITA, NOT the title of the ode  — please find it on TLG or elsewhere.
+Consequently the line from Thebes to Syracuse should NOT be dotted.
+
+“ ἐπέβαλλε δὲ τοῖς χρόνοις Σιμωνίδῃ ᾗ νεώτερος πρεσβυτέρῳ· τῶν γοῦν αὐτῶν μέμνηνται ἀμφότεροι πράξεων. […] ἀλλὰ καὶ ἀμφότεροι παρὰ
+Ἱέρωνι τῷ Συρακοσίων τυράννῳ γεγένηνται.”
+
+2. The source connecting Pindar to Delphi . Better this one below ( TLG or elsewhere) . So the line should NOT be dotted.
+Πινδάρου ἀποφθέγματα.
+
+Παραγενόμενος δὲ εἰς Δελφοὺς καὶ ἐρωτώμενος τί
+πάρεστι θύσων, εἶπε· παιᾶνα
+
+3. The lines connecting Pindar with Olympia, Nemea, Isthmus ( NOT Isthmia—the correct name for the place is Isthmus, the festival is Isthmia)  should be dotted ( not clear ancient evidence showing he was actually there, as far as I can see).
+
+Now—because of the dotted lines in the case of Pindar and Bacchylides, we need to make some other changes.
+1.    The ACTIVITY boxes opening under PLACES .
+Instead of  NON-NATIVE POETS ACTIVE IN XX
+             Or  NATIVE POETS ACTIVE IN XX
+I propose :
+ 	NON-NATIVE LYRIC ACTIVITY IN XX
+ 	NATIVE LYRIC ACTIVITY IN XX
+( The idea behind this change  is that a poet was not necessarily there but his poetry was circulating in that area. This should not be too difficult, David—correct? You change it only once, I think, and it applies to all cases. Please let me know of I am wrong)
+
+2.    Under TRAVEL instead of TRAVEL  and then ALL TRAVEL  we change into MOBILITY and then ALL CASES . ( but we do keep the general category “Travel” for our title and for the top of the sidebar . The term MOBILITY covers us in all cases where it seems that the poetry is mobile but we do not know if the poet was actually there, according to ancient sources—as in Pindar and Bacchylides. Plus, this way we avoid repetition of the same term ) .
+
+3. Under GEO IMAGINARY please change POETIC LOCATIONS to
+                                                                            LOCATIONS IN POETRY ( clearer)
+
+SECOND PART OF CORRECTIONS DEC.12
+1.     Acknowledgments > Not elegant the way we have them now.
+I propose : leave some white space after the end of the biblio and for the acknowledgments please use the same font and size you used on the first page in the “PLEASE CITE AS …” section. Also—list horizontally, not vertically ( and no need to include the phrase “ the following” :
+Many thanks to : Stanford's Department of Classics for financial support , Ancient World Mapping Center CartoDB, jQRangeSlider , Mapbox , Orbis, Pleiades , Stanford Humanities + Design Lab
+
+2. 	POETS UNDER PLACES
+ Scythinus – does not show anything after clicking—please eliminate.
+	3.	GENRES :
+UNCLASSIFIED MELIC : the pop-up box > change “POETS BORN IN XXX AND ASSOCIATED WITH ANOTHER UNCLASSIFIED MELIC GENRE “
+To: “POET(S) BORN IN XXX AND ASSOCIATED WITH UNCLASSIFIED MELIC“
+3. 	TRAVEL > eliminate Kynoskephalai from the list of PLACES to/from.
+ 	4.  GEO IMAGINARY> Melanippides does not show anything. Please eliminate.
+
+FINAL  Dec. 13th
+
+   	1. Simonides- Pindar to Acragas – they still look as going to a Democracy . Please make these lines as well leading to a tyranny. (it is safer this way)
+2. “Pindar” going from Thebes to Abdera > please change Democracy into uncertain for Abdera. So the line should not be there at all, since it will not be attached to a Democracy—right?
+3.     Solon going to Egypt – I can see this line under Oligarchy. Egypt has kingship throughout—so shouldn’t this be shown and indicated for Solon’s destination regime?
+4.     Under TYRANNY can we eliminate the line Mytilene> Sicily? It does not provide info and is confusing.
+5.     Under TYRANNY we have Solon and Alcaeus going to Egypt. They both go to a KINGSHIP( has to be shown) . As far as their origin regime is concerned, Alcaeus going to Egypt from a tyranny is correct. But Solon’s case is incorrect—he went to Egypt when Athens was oligarchic—can we erase the tyranny line for Solon?
+
+Alkimakhos -- I think we should indicate right next to his name (when the box pops up) that he is of "unknown origin". I know I had told you to put it at the end of the citation--sorry. But I think users should see  that his origin is unknown as soon as they click on his name-- otherwise they will not understand why we have him under "unknown travels"
+
+Two other cases ( apart from the ones below) :
+1.Can we eliminate Anacreon going to DEMOCRACY in Athens? We should keep him going to TYRANNY in Athens only.
+2. Can we eliminate the orange line with Pindar going to Syracusan oligarchy? I prefer to keep him going to tyrannical Syracuse only.
+
+Aigina - Added regime information --- checked--GREAT!
+Arne - Not a real historically attested place -- CAN WE ELIMINATE FROM REGIME MAP?
+HN (433n2) says: “Furthermore, following Bakhuizen ((1989) 65–66), I have left out Αρνη (Hom. Il. 2.507; Hes. fr. 218; Strabo 9.2.35; Steph. Byz. 123.18, π λις), which allegedly was swallowed up by Lake Kopais (Strabo 9.2.35). It seems to be a mythical toponym, not even to be placed on an atlas of Bronze Age settlements. However, Fossey (1988) 382–83 identifies Homeric Arne with a settlement (Magoula Balomenou) which has substantial remains from the Bronze Age plus some Roman and Late Roman.”
+Cephallenia - The island has 4 poleis on it, but H&N don’t have regime information for any of them.UNCERTAIN
+Cyme - Added regime information--GREAT
+Isthmus - Not sure what to do. Currently 'uncertain' like Nemea. ISTHMUS GOES WITH CORINTH REGIMES
+Larissa - Added regime information (oligarchy all time periods), changed spelling to “Larisa” (per H&N and NP)GREAT
+Messenia - Not sure what to do-- GOES WITH SPARTA AFTER THE MESSENIAN WARS (8TH C) -- SO IT IS SAFER TO GIVE IT THE SAME REGIME AS SPARTA
+Metapontion - Added regime information--GREAT
+Mt. Ptoios - Perhaps add the regime information of Akraiphia, its controlling polis? YES! [[ Or ‘uncertain’ like Nemea, Isthmus ( ISTHMUS GOES WITH CORINTH) ?
+Peloponnese - Not sure what to do ( IS IT POSSIBLE TO ELIMINATE THE LINE GOING TO PEL. FOR REGIMES (ONLY)?
+Pyrrha - Added regime information (completely unknown) OK
+Sanctuary of Poseidon Petraios - Not sure what to do? Uncertain again? I WOULD TAKE IT AS PART OF LARISA--THUS OLIGARCHY
+Sicily - Not sure what to do. CAN YOU ELIMINATE THE LINE GOING TO SICILY (GENERAL) FOR POLITICS?
+Tripodiskos - Added Megara’s regime information --GREAT!
+
+Please erase the orange dotted line for Pindar going to oligarchic Acragas as well. Since the line is about his ode for Theron it does not make sense. We will keep only the line showing Acragas as tyranny.
+
+With the Western Locri the case seems different -- it is oligarchy throughout --right?
+
+Dithyramb-- we should add Melanippides on Melos -- please use Suda's  second (b) entry. ( I do remember we had a problem re origin-- but let's take Melos for granted. [And let's take for granted he was active in Athens as well])
+
+Cinesias - we have him both in Athens and in Thebes for the dithyramb.
+
+Nome-- Stesichorus' citation seems to have more dashes than needed?
+
+Also -- there is a slight discrepancy in Athens -- ORIGIN and NATIVE LYRIC ACTIVITY 13 vs 14?

--- a/notes/minutes/2014-02-17.md
+++ b/notes/minutes/2014-02-17.md
@@ -1,0 +1,37 @@
+# Meeting, 17 February 2014
+
+on graph view, be able to get popup for connecting lines (poet or whatever) — or multiple popups for multiple poets.
+
+cut down options on source and target?
+
+table — nice idea, but at the moment totally useless for us. maybe we need to rework our tables? locked down google spreadsheet?
+be able to click through to the table from the map view
+
+how do they envision the grid working? upload images.
+
+1. save preloaded data.
+2. option to restrict the options of the viewer into select number of things. # of options don’t help, but confuse. birth city -> other associated city preloaded into graph view.
+3. on graph view, get popup for connecting lines, or open table view.
+
+difference between visualize and map?
+
+1 use case is:
+
+1. Where did a poet go?
+
+How do you get rid of facet filters?
+
+first city, second city
+
+DImension points must change name
+place name labels on map
+
+Is it possible to merge the two tables, the one for lines and the one for points?
+
+Order of dimensions on the table? Be nice for poet name to be the default.
+
+Any idea why we don’t have dates for some of these figures? E.g. Castorion, Cleomenes, Hermolochus.
+
+rolling through timeline: diachronic video view
+how to do bce dates?
+for points map allow choice to be birth city, other associated city, or death city.

--- a/notes/minutes/2014-02-25.md
+++ b/notes/minutes/2014-02-25.md
@@ -1,0 +1,32 @@
+# Meeting, 25 February 2014
+
+notes for meeting 2-25-14
+
+how do they envision the grid working? upload images.
+
+1. save preloaded data.
+2. option to restrict the options of the viewer into select number of things. # of options don’t help, but confuse. or maybe birth city -> other associated city preloaded into graph view.
+	Order of dimensions on the table? Be nice for poet name to be the default.
+3. on graph view, get popup for connecting lines, or be able to click through to the table from the map view.
+* start with facet filter open? and with some dimensions chosen?
+4. dimension points not a great name. Relabel?
+5. label cities with their name
+6. BCE dates.
+7.
+
+nice:
+
+1. diachronic video view?
+2. for points map allow multiple choices: i.e. both birth city and other associated city
+3. don’t understand multiple things selected in facet filter. if in graph view you select government democracy and other associated polis athens you get lots of places that aren’t democracies, like Melos.
+4. blank in the facet filter?
+
+1 use case is:
+
+1. Where did a poet go?
+* Where do poets perform?
+* Are some cities more interested in some genres than others?
+2. Where do the poets who come to Athens from?
+3. Are poets who come to Athens from democracies?
+
+bug with poet name: can’t scroll down past first 10 (only in Firefox)

--- a/notes/minutes/2014-04-15.md
+++ b/notes/minutes/2014-04-15.md
@@ -1,0 +1,11 @@
+# Meeting, 15 April 2014
+
+H+D 4/15/14
+
+RAW. “The missing link between spreadsheets and vector graphics.”
+
+use git to clone palladio:
+sudo git clone https://github.com/humanitiesplusdesign/palladio.git
+
+username: davidfdriscoll
+password: ildwvii7

--- a/notes/minutes/2015-04-02.md
+++ b/notes/minutes/2015-04-02.md
@@ -1,0 +1,12 @@
+# Meeting, 2 April 2015
+
+labels
+why is sipylum look bad?
+labels — change fonts, make clearer.
+selective labels — only for cities with 2 poets or more, or whatever. + important poets.
+add archaic poets
+start zoomed in on western asia minor & mainland greece. on all maps.
+
+poets  (linemap.html)— no bubbles.
+
+add archaic poets

--- a/notes/minutes/2015-04-04.md
+++ b/notes/minutes/2015-04-04.md
@@ -1,0 +1,44 @@
+# Meeting, 4 April 2015
+
+lyricmapping.stanford.edu
+
+remove network for greek song label at top of screen (DONE)
+deselecting automatically — no combining. (DONE)
+move boxes to side
+why doesn’t the dates work?
+
+“Poets associated with dithyramb who performed in Athens”: x, y, z (### in total)
+
+make infobox permanent when clicked on. mouse over each poet name and get his dates & his sources.
+
+No explanation necessary when place of birth selected.
+
+iambs -> iambos (DONE)
+
+half centuries instead of quarter centuries.
+
+copy orbis box, put on right.
+
+when start just dots. no names.
+
+change name to places instead of cities. (DONE)
+
+POETS
+
+put “-es” at the end. (DONE)
+
+rename to travel (DONE)
+
+no bubbles; fewer labels; same deep red. (MOSTLY DONE; can’t get labels to work)
+
+change “other associated city” to “place of performance” on infobox. (DONE)
+
+only include poets who are known to have travelled. (DONE)
+
+choose more vibrant colors for the lines.
+
+for macedonia and thessaly, place name should spread over the area + be a different font to indicate that we’re talking about an area, not a specific city.
+
+check to see if an arrowhead is possible
+
+start by seeing all the lines. but add button for clear, just the cities.

--- a/notes/minutes/2015-04-06.md
+++ b/notes/minutes/2015-04-06.md
@@ -1,0 +1,19 @@
+# Meeting, 6 April 2015
+
+Izzy’s.
+
+region: Sicily. larger label for Sicily. then people attested for Sicily in general then go there. also Arcadia
+but NOT Ionia (Ibycus goes to Samos).
+
+victor. separate category in addition to birth, performance, death.
+line from victor’s city to place of victory (e.g. Syracuse to Olympia)
+maybe table for after place and travel maps working ok.
+maybe called athletes.
+
+multiple birth cities. indicate both.
+
+corinna box. when open say the questionable nature of her dating.
+
+no lyric as a separate genre
+
+add something about the distinction between lyric and melic.

--- a/notes/minutes/2015-04-14.md
+++ b/notes/minutes/2015-04-14.md
@@ -1,0 +1,36 @@
+# Meeting, 14 April 2015
+
+to do
+
+timeline — the arrows are misleading. (done)
+when one date see selected slider. (done — created range)
+put timeline at end (done)
+turn off arrows (done)
+find alternative range slider? (nope)
+with ruler (done)
+colors: chosen period in the same red. (done)
+arrows text: black on white like genre box. (done)
+
+places/travel boxes: font should be different and distinct from options. (done)
+text-size should be larger (done)
+indicate selected places/travel with same red underline (done)
+“visual continuity”
+
+tooltip: change label color to same color as “place of” “genre” etc. in selection box (tried to)
+change order of names in tooltips to correct alphabetical order (made issue)
+add key for sources: first poet = 1, second poet =2, then mapped onto the sources box. (made issue)
+
+macedonia: make letters spread out (added character spacing)
+
+arrows: make bigger (done)
+line colors: update from bottom of izzy’s spreadsheet (will not do)
+
+change genre name to iambos in sql (added to github)
+
+put destination first, not origin (done)
+
+politics: color of city depends on politics?
+or shape of city depends on politics?
+but politics changes over time?
+
+add new poets from izzy’s spreadsheet (made issue)

--- a/notes/minutes/2015-04-22.md
+++ b/notes/minutes/2015-04-22.md
@@ -1,0 +1,15 @@
+# Meeting, 22 April 2015
+
+* remove choral dance, comedy, epic, tragedy, prose (done)
+* change psogon to psogos (done)
+* make lines thicker when just one poet selected (line width 3, arrow width 10). (added to issues)
+* place of birth. when 2 birthplaces list both (added to issues)
+* omit instruments. (done)
+* dates. for alcman should read 700-600. (done)
+* consistent abbreviations. natasha will think about it.
+* hyporchema (done)
+* numbers should be red for poets and sources (done)
+* for genres and instruments, only select for poets’ birthplaces. (added to issues)
+* why doesn’t iambos work? (done)
+* Stesichorus. why not a line to mainland Locris? more generally check lines (added to issues)
+* make a decision about Tyrtaeus. pick one birthplace.

--- a/notes/minutes/2015-04-23.md
+++ b/notes/minutes/2015-04-23.md
@@ -1,0 +1,22 @@
+# Meeting, 23 April 2015
+
+PLACES:
+Under places>genres>hymns, numbered list of poets and sources is in reverse order (2, 1). (also the case elsewhere, e.g. places>instrument>aulos.) (already an issue)
+
+Take out following genres: enoplion, eulogy, komos, polemisterion, psogos, satyr. (done)
+
+Add enkomion to Simonides' genres; iambos to Timocreon's. (done)
+
+TRAVEL:
+Make 'floating window' flush with the sides of the browser window (cp. Orbis). (done)
+
+Make 'floating window' narrower in order to see the Ionian coast when first selecting 'Travel'. (done)
+
+Make subcategory windows (e.g. Poet) scrollable. (done)
+
+Regions: 'Aegean islands' should include all islands (including the Ionian islands); Asia minor should only be continental. (this looks really great.) (done)
+
+To think about for next meeting:
+Should 'parody' be a genre, or should it be subsumed into iambos?
+
+regions: separate origin and destination? different colored lines? (added to issues)

--- a/notes/minutes/2015-04-28.md
+++ b/notes/minutes/2015-04-28.md
@@ -1,0 +1,17 @@
+# Meeting, 28 April 2015
+
+eliminate parody (added to issues)
+arrows: background same red, text (e.g. 700 BCE) white
+other unclassified melic, including sappho alcaeus anacreon ibycus. simonides.  (izzy) (added to issues)
+include thessaly and macedonia in mainland greece (added to issues)
+change label to “geographical regions” (DONE)
+
+make timeline with travel (added to issues)
+
+politics. two categories, origin and destination (like cities).
+origin: democracy, tyranny, oligarchy
+then display the poet only if the city is a democracy at the time he leaves it (for example)
+
+move places map to upper-right corner
+
+merge origin and destination with thick lines and different colors

--- a/notes/minutes/2015-05-05.md
+++ b/notes/minutes/2015-05-05.md
@@ -1,0 +1,17 @@
+# Meeting, 5 May 2015
+
+combine destination/origin with political systems with different colors
+dots only for cities that are democracies at the time being
+somehow mark other cities?
+add political information to the poet pop-ups
+
+add timeline
+
+source pages? (all done)
+add list of lyric poets sources to website
+change sources font to genre, make colon, then “victor list”
+add poets list also
+
+victors page spreadsheet templates (done)
+
+improve timeline look — make intermediate steps visible at all times, change amount of red depending on what is selected.

--- a/notes/minutes/2015-05-08.md
+++ b/notes/minutes/2015-05-08.md
@@ -1,0 +1,29 @@
+# Meeting, 8 May 2015
+
+Places:
+When selecting a city in the places (w/out selecting origin or activity), fill in the bubble with all that we know about though cities (origin, activity, political [all dates], etc.). Is this possible? (added to issues) (done)
+Sources: open up a new tab/window? (done)
+When selecting Places > Origin/Activity > a city (e.g. Mytilene), update the political activity (ask about this) (currently shows government from cities spreadsheet) (done)
+Add all cities listed under origin to activity list. (done)
+For first screen in Places, hide timeline until something else is selected? (done)
+Travel:
+Some lines are purple and  -- is it possible to disambiguate all overlapping lines? how do we prevent lines from overlapping or being too close together? (added to issues, ask about it) (on issues)
+Sappho: when hovering over Mytilene, it should say tyranny (done)
+Change 'City' to 'Places' (done)
+Would it be possible to select a region + a political constitution, e.g. Asia Minor Oligarchies? (ask about this) (hold off on this)
+Political: (all done)
+Macedonia: change to 'kingship' (source: New Pauly) all dates
+Thessaly: change to 'mixed' (can be changed in the future if necessary) all date
+Mytilene: change 650 to 'tyranny'
+After opening travel, why does everything disappear when changing timeline? (done)
+After opening travel, is it possible to NOT show infoboxes (thus, it would be like a static 'book cover')
+
+import/export; poets travelling in opposite direction curve other way.
+curve east one direction, curve west the other direction
+
+tooltip for lines.
+scroll-downable
+say Athens -> Corinth.
+then numbered poets
+then genres, instruments ,etc. with numbers
+

--- a/notes/minutes/2015-05-09.md
+++ b/notes/minutes/2015-05-09.md
@@ -1,0 +1,12 @@
+# Meeting, 9 May 2015
+
+import/export; poets travelling in opposite direction curve other way.
+curve east one direction, curve west the other direction (done)
+
+tooltip for lines.
+scroll-downable
+say Athens -> Corinth.
+then numbered poets
+then genres, instruments ,etc. with numbers
+merge lines in same direction; make line thicker to account for number of poets
+

--- a/notes/minutes/2015-08-05.md
+++ b/notes/minutes/2015-08-05.md
@@ -1,0 +1,26 @@
+# Meeting, 5 August 2015
+
+change color of line on hover: green (a faded green; almost transparent). or transparent. places map too.
+
+restore nus; change weird boxes to original greek letters
+
+change formatting
+1. Simonides
+Suda κ 1361: “xyz” (trans. Campbell)
+αβψδεφ
+
+change bubble size for Athens
+
+bubble map sources. click red more in pop up to show source.
+
+geographical imaginary 3rd option after a reduced places and travel. bubble map.
+
+geographical imaginary options:
+
+author
+referent
+timeline
+
+geographical imaginary popup:
+
+1. poets. details. poet. dates. fragments.

--- a/notes/minutes/2015-08-18.md
+++ b/notes/minutes/2015-08-18.md
@@ -1,0 +1,44 @@
+# Meeting, 18 August 2015
+
+change appearance of places/travel/geographical imaginary tabs
+
+popup on places travel and geographical imaginary. 1 sentence or two. explanation of the map. in bottom left. not grayed out. no x.
+
+update poetic world of:
+update referents
+
+check cityids in geographical imaginary (done)
+
+mark griffith’s piece in laws volume. for dorian problem.
+
+yes dialect. no glens.
+
+goods. Critias fr. 2.
+
+option a for Natasha’s title (done)
+
+lyricmappingproject.stanford.edu (done)
+
+install web analytics (done)
+
+change appearance of geographical imaginary box. try wo popups
+1. centered orbis-like
+2. natasha’s preference. 1/2 of the screen. top to bottom. no padding or margins.
+
+how to cite us section. natasha will write.
+
+our names in alphabetical order, then headed by “anastasia-erasmia peponi”.
+
+Created by: David Driscoll, Israel McMullin, Stephen Sanson, headed by Anastasia-Erasmia Peponi. (done)
+
+natasha will tell us which lines are dotted
+
+acknowledgments
+
+comment page with form. “contact us”
+
+social networking?
+
+link to other online maps?
+
+expand fragments

--- a/notes/minutes/2015-08-late.md
+++ b/notes/minutes/2015-08-late.md
@@ -1,0 +1,32 @@
+# Meeting, late August 2015 (exact date not recorded)
+
+please cite with: shrink size of the citation box. possibly different color
+more button. with more text.
+italicize words.
+spaces in cited by
+
+create body category.
+then view subcategories.
+garlands as part of attire
+then flower garlands also indexed under flowers (all current garlands)
+
+weather category. elements. including clouds, winds, snow. Castorion imaginaryid 194. rough seas, waves.
+
+animals: horses
+husbandry: horses
+
+food: apples, cheese, figs, wheat (instead of agriculture)
+
+places to sit/recline -> furniture
+
+music: paeans, singers. include phrygian, ionic, etc. dance.
+
+region. in infowindow all-caps, with word region. e.g. “IONIA (region)”
+remove special labels from Macedonia and Thessaly
+region for now with Lydia, all others
+
+urban and domestic architecture -> architecture
+
+leucas. fix coordinates.
+
+get rid of government in places.

--- a/notes/minutes/2015-09-17.md
+++ b/notes/minutes/2015-09-17.md
@@ -1,0 +1,30 @@
+# Meeting, 17 September 2015
+
+delete poets from places map — possibly reintroduce with activity.
+
+by sunday evening. know which are the safest and best examples to show. emphasize travel view?
+
+black: bad color. come back to consider third color.
+places: to/from. remove within.
+
+mistake. priam in argos instead of troy.
+
+for mid-october. eliminate gods/heroes & gods. but in a way that we can restore in the future if desirable.
+improve citations in geographical imaginary. e.g. Timotheus fr. fr. 791.238 on Athens.
+Anacreon fr. 448. expand to include context in Hesychius.
+
+references in timotheus’ poetry instead of simply references.
+
+say this isn’t a replacement for doing your own research.
+
+remove archilochus to siris in travel.
+
+corinna. 5th or 3rd. question marks.
+
+on internet in 2 weeks.
+
+replace cartodb attribution with name of project and our name.
+
+remove lorem ipsum boxes for presentation.
+
+get names and emails after presentation

--- a/notes/research/geographical-imaginary-examples.md
+++ b/notes/research/geographical-imaginary-examples.md
@@ -1,0 +1,11 @@
+# Geographical imaginary: worked examples
+
+Olympian 1
+
+line 8: “From there comes the famous hymn” -- poem travels from Olympia to Syracuse
+
+line 24: “Fame shines for him [Hieron] in the colony of brave men founded by Lydian Pelops,” -- Pelops travels from Lydia to the Peloponnese
+
+Bacchylides 17
+
+line 97: “But sea-dwelling dolphins were swiftly carrying great Theseus to the house of his father” -- ???? how do we map this?

--- a/notes/research/new-poets-searches.md
+++ b/notes/research/new-poets-searches.md
@@ -1,0 +1,18 @@
+# New poets: reference searches
+
+New Pauly (Izzy), search for "lyric poet"
+This search was performed via the online version of the New Pauly—the link to each entry consulted follows the figure.
+Telesilla of Argos {0369} - a poetess from Argos (451/450 BCE), she wrote a poem about the wedding of Zeus and Hera (PMG 717) and a choral ode (PMG 717). The acephalic glyconeus was named a telesillion after her.
+	•	http://referenceworks.brillonline.com/entries/brill-s-new-pauly/telesilla-e1202980
+Ion of Chios {0308} - (480-423/422 BCE) came to Athens around 464 BCE and wrote works of prose (Triagmos, a Pythagorean explanation of the world based on the number 3, and Epidēmiai, a series of travelogues and the first memoirs in literary history), tragedies (ten tetralogies), dithyrambs, hymns (one of which was to kairos), elegies, and encomia.
+	•	http://referenceworks.brillonline.com/entries/brill-s-new-pauly/ion-e526390
+TLG Canon List (Izzy), search for "5th c. BCE lyric"
+All information from this search is fleshed out via--more like ripped from--the New Pauly.
+Cinesias of Athens {0375} - a dithyrambic poet who's creative period ranged from 425-390 BCE.
+	•	http://referenceworks.brillonline.com/entries/brill-s-new-pauly/cinesias-e614040
+Lamynthius of Miletus {0918} - a lyric poet with uncertain dating who might have written erotic lyric poetry. The TLG cannon places him as a 5th c. BCE lyric poet.
+	•	http://referenceworks.brillonline.com/entries/brill-s-new-pauly/lamynthius-e629890
+Cleomenes of Rhegium {0900} - listed as a 5th c. BCE lyric poet in the TLG cannon, but I couldn't find anything else about this dude in the New Pauly.
+Telesilla - see above.
+Ariphon of Sycion {0378} - was a choral poet (?) that performed at Athens some time around 406/398 BCE. He was famous in antiquity for a paean to Hygiea.
+	•	http://referenceworks.brillonline.com/entries/brill-s-new-pauly/ariphron-e135150

--- a/notes/research/searches.md
+++ b/notes/research/searches.md
@@ -1,0 +1,7 @@
+# Source searches
+
+SEARCHES
+
+	•	Suda
+	•	Λυρικ* (Izzy): nothing
+	•

--- a/notes/research/travel-questions.md
+++ b/notes/research/travel-questions.md
@@ -1,0 +1,18 @@
+# Open questions from the travel research
+
+questions about lyric mapping research
+
+1. Did Archilochus go to Naxos? I see lots of references to him fighting Naxians on Thasos, but that’s not the same thing. Maybe fr. 325?
+2. Did Archilochus go to Euboea? see fr. 3.
+3. Do we want to add a century column?
+4. For Bacchylides I have provided all the sites where the victors won. I think this is a questionable assumption — I know there’s a lot of debate about where these odes were performed, let alone all the references in the poetry to the odes being sent w/o their author (e.g. the opening of N. 5).
+
+The stray reference to Mantinea seems to belong more in the geographical imaginary as well.
+5. See Ariphron — should we add the poet Polychares as well?
+6. We should have a list of specifically who we are including. Flute players are out, as are dancers (see e.g. Ath. 14.629A where a Anacus of Phigaleia is named).
+7. Cedeides. currently a date of fl. 550–500, but he’s mentioned in an inscription of c. 415 BCE? test. 2 in Campbell.
+8. Chares. I can’t find anything linking him to Athens besides the reference in Aspiotes. Bowie doesn’t mention it in his NP piece. Maybe look him up in Gerhard’s 1912 edition: http://searchworks.stanford.edu/view/8713406. But this work is not at ASCSA.
+9. Corinna. Closest thing to a connection to Athens is test. 2, where she mocks the opening of Pind. fr. 29.
+10. I can't find any source for Dion of Chios going to Athens. RE hints that Ion of Chios might lay behind this reference.
+11. I have removed Dionysius of Chios. Doesn’t exist — his Aspiotes number is for Dionysius Chalkus.
+12. If we have Echembrotus of Arcadia, why don’t we have Melampus of Cephallenia the kitharode, who competed at Delphi at the same time? Paus. 10.7.4-6.


### PR DESCRIPTION
Seventeen meetings from 2014–15, A.-E. Peponi's corrections of December 2015, and the research notes behind the poet list. All were deleted in 4c3ed7d *"delete old map"* along with the CartoDB application they belonged to.

## Why

The map went; the data did not. The CSVs still carry decisions taken in those meetings, and nothing in the repository says so — which means a ruling and a data-entry error are indistinguishable from the working tree.

Two examples, both from #350. `poets_cities.csv` has eight rows with a blank `relationshipId`. Six are unfinished data entry. Two are issue #271, *"Messena (Sicily) - Tyrtaeus - erase this location from his activity"* — the blank **is** the erasure. Telling them apart meant reading deleted RTF blobs out of git, which is not a thing anyone does.

## What is here

```
notes/
  README.md                    index, and the standing rulings
  corrections-2015-12.md       Peponi's corrections, through to "FINAL Dec. 13th"
  minutes/                     17 meetings, Feb 2014 – Sep 2015
  research/                    travel questions, geographical-imaginary examples,
                               how the poet list was assembled
```

Converted from RTF and DOCX with `textutil`, wording unchanged, and added to `.prettierignore` so it stays that way — reflowing someone else's minutes to this repository's line length would put our formatting preferences into their words.

## The index

`notes/README.md` lists the rulings that still govern the data, each against the code that implements it, because that is the part worth grepping. Still true: MOBILITY / ALL CASES, the NATIVE / NON-NATIVE order ("the NON-NATIVE should come first, since this is more unexpected"), singular ORIGIN SOURCE, dotted lines wherever Pindar and Bacchylides rest on a title, and *"We report and display data based on the ancient sources, without judging whether they are all historically accurate"*, still the third sentence of the essay.

Two are **not** true any more, and are marked as such:

- **`nativeid`** separated "born here" from "counts as a native here" (#257, #284, 28f4504). v2 splits on `relationshipId`, so Alcman is a native of Sparta again — the thing #257 was raised to prevent.
- **"See also: `<the other birthplaces>`"** on a disputed origin, which is how #208, #218 and the second half of #257 were closed. It was a derived line in the old query. It is now open issue #332, which asks whether Alcman is the only such poet: he is not, there are thirteen.

## Not restored

The CartoDB SQL and CSS, the jQRangeSlider vendor docs, the letters and blog drafts — they document a map that no longer exists, and README gives the one-liner to pull any of them back. Also left out: the Stephanis page scans, and one file that records a login and password for the Palladio beta.
