### PR TITLE
Put Etruria back on the map, at the longitude it was missing a point in

### DIFF
--- a/dataFiles/cities.csv
+++ b/dataFiles/cities.csv
@@ -180,7 +180,7 @@ Tmolus,Tmolus,192,modern Bozdag,38.35,28.083333,,
 Lethaeus,Lethaeus,193,pin dropped near Aydin,37.809784,27.58667,,
 Nineveh,Nineveh,195,,36.359444,43.150278,Asia,21
 Priene,Priene,196,,37.659722,27.297778,Ionia,6
-Etruria,ETRURIA (region),197,a random pin drop north of Grosseto,42.924252,118301,Italy,10
+Etruria,ETRURIA (region),197,a random pin drop north of Grosseto,42.924252,11.8301,Italy,10
 Attica,ATTICA (region),198,"roughly the center the of Attica, also the intersection of the Attiki Odos and A/D Pathe Highways.",38.06,23.75,Attica,2
 Celaenae,Celaenae,201,ancient city of Phrygia and capital of the Persian satrapy of Greater Phrygia and modern Dinar,38.065,30.1655,,
 Cephisus,Cephisus,202,"The Cephissus or Kifisos (Greek: Κηφισός) is a river in central Greece. In Greek mythology the river god Cephissus was associated with this river. The river rises at Lilaia in Phocis, on the northwestern slope of Mount Parnassus. It flows east through the Boeotian plain, passing the towns Amfikleia, Kato Tithorea and Orchomenos. https://en.wikipedia.org/wiki/Cephissus_(Boeotia)",38.43,23.24,,

--- a/tests/data-integrity.test.js
+++ b/tests/data-integrity.test.js
@@ -99,7 +99,7 @@ const acceptedCityLabels = new Set(ACCEPTED_CITY_LABEL_VARIANTS.map(([cityId, la
 const KNOWN_INCOMPLETE_CITATION_COUNT = 18;
 
 /** Cities whose coordinates are malformed and plot far outside the map. */
-const KNOWN_BROKEN_COORDINATE_CITY_IDS = new Set([226, 197]);
+const KNOWN_BROKEN_COORDINATE_CITY_IDS = new Set([226]);
 
 /**
  * The mapped world runs from Ethiopia in the south to Scythia in the north, and
@@ -580,7 +580,7 @@ describe("known data bugs: places plotted in the wrong location", () => {
   });
 });
 
-describe("known data bugs: malformed coordinates", () => {
+describe("known data bugs: malformed coordinate", () => {
   test("BUG: Claros' latitude is missing its decimal point", () => {
     const claros = cityByName("Claros");
     assert.equal(id(claros.cityId), 226);
@@ -592,23 +592,6 @@ describe("known data bugs: malformed coordinates", () => {
     // Nothing references Claros yet, so nothing is visibly misplaced today.
     const referenced = [...raw.poetCities, ...raw.geopoetCities].filter(row => id(row.cityId) === 226);
     assert.equal(referenced.length, 0);
-  });
-
-  test("BUG: Etruria's longitude is missing its decimal point", () => {
-    const etruria = cityByName("Etruria");
-    assert.equal(id(etruria.cityId), 197);
-    assert.equal(etruria.long, "118301");
-    assert.equal(etruria.lat, "42.924252");
-    // Should be 11.8301, which with the existing latitude lands in Etruria.
-    // Alternatively pleiades:413122 gives 42.6734380491, 11.5337751287 for the
-    // region as a whole.
-    const referenced = [...raw.poetCities, ...raw.geopoetCities].filter(row => id(row.cityId) === 197);
-    assert.equal(referenced.length, 1);
-    assert.equal(
-      referenced[0].poetname,
-      "Critias",
-      "Critias refers to Etruria, so a dot is visibly misplaced on the map"
-    );
   });
 });
 


### PR DESCRIPTION
`cities.csv` gave Etruria a longitude of `118301` where it meant `11.8301`:

```
Etruria,ETRURIA (region),197,a random pin drop north of Grosseto,42.924252,118301,Italy,10
```

The row's own note says where it should be, and 42.924252, 11.8301 is that pin, inland of Grosseto in Tuscany. So the fix is the decimal point.

## What the wrong value actually did

Not what the test asserting it claimed. That test said "a dot is visibly misplaced on the map". It was not misplaced — it was never drawn, and nothing reported a problem:

- `118301` is a perfectly good number, so nothing threw and nothing was skipped. `calculateGeoBubbles()` built bubble 197 in full — price, tooltip, popup html — and `drawBubbles()` only checks `bubble.city.lat && bubble.city.long`, both truthy, so it handed Leaflet two circles as usual.
- `L.latLng` validates `NaN` and nothing else (`this.lat=+t,this.lng=+e`), and spherical Mercator projects longitude linearly, so the circles landed **328.6 world-widths east** of the meridian — 5,383,472 px east of Tuscany at zoom 6. `initializeMap()` sets no `maxBounds`, so that is pannable-to in principle and unreachable in practice.
- `L.Circle` then clipped them. `_empty()` is `this._radius && !this._renderer._bounds.intersects(this._pxBounds)`, so the svg renderer emitted each path with `d="M0 0"`.

So the citation it belongs to — Critias on the Etruscan bowl of beaten gold, researched, transcribed, translated and credited in `geographical_imaginary_group.csv` — had a popup built on every render of the geographical imaginary map, into a spot no one could reach.

## Verification

In headless Chromium against the served site, before and after. Asking Leaflet for the old coordinate directly still reports `_empty()` true and `d="M0 0"`; the corrected one paints both circles centred within 3px of `map.latLngToContainerPoint(42.924252, 11.8301)`. No console errors either way, which is why this survived.

## Test bookkeeping

Per the instructions at the top of `data-integrity.test.js`, fixing a known bug means deleting the test that asserts it and its exception entry:

- cityId 197 leaves `KNOWN_BROKEN_COORDINATE_CITY_IDS`, so "coordinates are either both blank or both plausible for the mapped world" now covers Etruria instead of skipping it — and passes.
- `BUG: Etruria's longitude is missing its decimal point` is deleted.
- Claros is the only malformed coordinate left, hence the singular `describe`.

Nothing else changes: 168 of 170 geographical imaginary bubbles are drawable, as before, so the browser test's expected path counts are untouched.

All four checks from `CLAUDE.md` are clean, plus the browser suite:

| check | result |
| --- | --- |
| `npm test` | 98 pass (one fewer than before — the deleted bug test) |
| `npm run lint` | clean |
| `npm run format:check` | clean |
| `npm run typecheck` | clean |
| `npm run test:browser` | 24 pass |

## Not fixed here

The `BUG: one Adespota reference to Thrace is plotted on Priapus` test prescribes repointing cityId 240 → 129, which looks backwards: that row's Greek and translation are about *Priapis facing the Bosporus* and its note reads "a city on the Hellespont", which describes Priapus (240), not Thrace. The `cityname` label may be the wrong half. It needs an editorial call, so it is left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
