### PR TITLE
Say "See also:" where the sources disagree about a birthplace

### DIFF
--- a/js/calcData/data.js
+++ b/js/calcData/data.js
@@ -110,8 +110,30 @@ function createLookups(csvs) {
       csvs.dates,
       date => date.poetId,
       date => date.date
-    )
+    ),
+    birthCityIdsByPoetId: createBirthCityIdsByPoetId(csvs.poetCities)
   };
+}
+
+/**
+ * Every city a poet is attested as born in, in file order and without repeats.
+ *
+ * Distinct by city rather than by row, because what this feeds — the "See also:"
+ * line on a birthplace popup — names places and not testimonia. Three sources
+ * call Tyrtaeus an Athenian; a reader standing on Athens wants to be told about
+ * Miletus and Sparta, once each.
+ * @param {PoetCity[]} poetCities
+ * @returns {Record<number, number[]>}
+ */
+function createBirthCityIdsByPoetId(poetCities) {
+  /** @type {Record<number, number[]>} */
+  const byPoetId = {};
+  for (const poetCity of poetCities) {
+    if (poetCity.relationshipId !== 1) continue;
+    if (!byPoetId[poetCity.poetId]) byPoetId[poetCity.poetId] = [];
+    if (!byPoetId[poetCity.poetId].includes(poetCity.cityId)) byPoetId[poetCity.poetId].push(poetCity.cityId);
+  }
+  return byPoetId;
 }
 
 /**

--- a/js/calcData/getters.js
+++ b/js/calcData/getters.js
@@ -33,6 +33,27 @@ export function getCity(lookups, cityId) {
 }
 
 /**
+ * The poet's other attested birthplaces, named, for a popup being shown at
+ * `cityId`. Empty for the 80 poets the sources agree about, which is why
+ * callers render nothing rather than an empty label.
+ *
+ * Sorted by name so the order does not depend on which row of the CSV came
+ * first, and plainly rather than with sortAlphabetically(): that lives in
+ * data.js, which imports this module, and city names all start with a letter.
+ * @param {Lookups} lookups
+ * @param {number} poetId
+ * @param {number} cityId the birthplace the popup is already showing
+ * @returns {string[]}
+ */
+export function getOtherBirthplaces(lookups, poetId, cityId) {
+  const cityIds = lookups.birthCityIdsByPoetId[poetId] ?? [];
+  return cityIds
+    .filter(otherCityId => otherCityId !== cityId)
+    .map(otherCityId => getCity(lookups, otherCityId).cityname)
+    .sort();
+}
+
+/**
  * @param {Lookups} lookups
  * @param {number} cityId
  * @returns {CityPolitics[]}

--- a/js/popups/popupsCommon.js
+++ b/js/popups/popupsCommon.js
@@ -1,5 +1,5 @@
 import { LYRIC_RED } from "../constants/colors.js";
-import { getGenres, getPoetDisplay } from "../calcData/getters.js";
+import { getGenres, getPoetDisplay, getOtherBirthplaces } from "../calcData/getters.js";
 
 /**
  * Anything a detail paragraph can be rendered from: a rendered poet-city row in
@@ -8,7 +8,12 @@ import { getGenres, getPoetDisplay } from "../calcData/getters.js";
  *
  * A poetId is now the whole of it. The display strings used to be carried on the
  * row as well, which is why this was an intersection with PoetPrimed.
- * @typedef {{ poetId: number, reference?: Reference }} DetailedPoet
+ *
+ * cityId and relationshipId are optional for the same reason the reference is:
+ * a Line has neither, since it is a journey between two cities rather than a
+ * claim about one. They are what renderOtherBirthplaces() needs to tell a
+ * birthplace entry from any other, and a RenderedPoetCity carries both.
+ * @typedef {{ poetId: number, cityId?: number, relationshipId?: RelationshipId, reference?: Reference }} DetailedPoet
  */
 
 /**
@@ -43,11 +48,36 @@ export function createDetailedListOfPoets(poets, data) {
         ${createGenreString(data, poet.poetId)}
         Source(s): ${display.sources}<br>
         ${renderReference(poet.reference)}
+        ${renderOtherBirthplaces(data, poet)}
       </p>
       `;
       })
       .join(" ")}
   `;
+}
+
+/**
+ * "See also: Sardis" under a birthplace whose poet has others attested.
+ *
+ * The CartoDB map derived this in SQL and showed it inside the citation block,
+ * which is how issues #208, #218 and the second half of #257 were closed; the
+ * rewrite dropped it, so the map has been asserting one birthplace per bubble
+ * with nothing to say the sources disagree. Rendered here rather than written
+ * into a notes column so that it cannot fall out of step with the rows it
+ * describes — the note added by hand for #257 overwrote Alcman's citation and
+ * has been wrong ever since.
+ *
+ * Birthplaces only. A place of activity has no alternatives to offer, and a
+ * travel line reaches this without a cityId at all.
+ * @param {Data} data
+ * @param {DetailedPoet} poet
+ * @returns {string}
+ */
+export function renderOtherBirthplaces(data, poet) {
+  if (poet.relationshipId !== 1 || poet.cityId === undefined) return "";
+  const others = getOtherBirthplaces(data, poet.poetId, poet.cityId);
+  if (others.length === 0) return "";
+  return `<br>See also: ${others.join(", ")}`;
 }
 
 /**

--- a/js/popups/travelPopups.js
+++ b/js/popups/travelPopups.js
@@ -1,5 +1,10 @@
 import { LYRIC_GREY, LYRIC_RED } from "../constants/colors.js";
-import { createNumberedListOfPoets, createDetailedListOfPoets, renderReference } from "./popupsCommon.js";
+import {
+  createNumberedListOfPoets,
+  createDetailedListOfPoets,
+  renderReference,
+  renderOtherBirthplaces
+} from "./popupsCommon.js";
 import { getPoetDisplay } from "../calcData/getters.js";
 
 /**
@@ -24,6 +29,15 @@ export function createTravelPopupHtml(data, line) {
 
 /**
  * Renders the citation behind either end of an arc, for every poet on it.
+ *
+ * The ORIGIN SOURCE end also names the poet's other attested birthplaces. That
+ * matters more here than in a bubble popup: an arc asserts a journey out of one
+ * city, and for the thirteen poets whose origin is disputed the map draws one
+ * arc per tradition without ever saying that is what they are. It is also what
+ * has to be in place before the zero-length lines can be dropped — those are
+ * precisely the cases where the poet was born and active in the same city, so
+ * removing them silently deletes a birthplace from the travel map unless the
+ * remaining arcs mention it.
  * @param {TravelArc} line
  * @param {"bornPc" | "activePc"} direction which end of the journey to cite
  * @param {Data} data
@@ -36,6 +50,7 @@ function createTravelSource(line, direction, data) {
     <p>
     <span style="color:${LYRIC_RED}">${idx + 1}</span>. ${getPoetDisplay(data, pl.poetId).detailName}<br>
     ${renderReference(pl[direction])}
+    ${renderOtherBirthplaces(data, pl[direction])}
     </p>
     `;
     })

--- a/tests/initializeData.test.js
+++ b/tests/initializeData.test.js
@@ -125,6 +125,7 @@ describe("hydration", () => {
       "govsByCityId",
       "govsById",
       "datesByPoetId",
+      "birthCityIdsByPoetId",
       "linesByPoetId",
       "linesByBornCityId",
       "linesByActiveCityId"
@@ -199,6 +200,22 @@ describe("travel lines", () => {
       "Sparta -> Messenia",
       "Sparta -> Sparta"
     ]);
+  });
+
+  test("birthplaces are counted by city, not by testimonium", () => {
+    // What "See also:" is built from. Tyrtaeus has five rows with
+    // relationshipId 1 and three cities, because three sources call him an
+    // Athenian; the alternatives offered to a reader are places.
+    const birthplaces = (/** @type {string} */ name) =>
+      data.birthCityIdsByPoetId[poetIdByName(name)].map(cityId => data.citiesById[cityId].cityname).sort();
+    assert.deepEqual(birthplaces("Tyrtaeus"), ["Athens", "Miletus", "Sparta"]);
+    assert.deepEqual(birthplaces("Alcman"), ["Sardis", "Sparta"]);
+    assert.deepEqual(birthplaces("Tynnichus"), ["Chalcis"]);
+
+    // The 13 the map has to hedge, out of 93 poets with a birthplace at all.
+    const withBirthplace = Object.values(data.birthCityIdsByPoetId);
+    assert.equal(withBirthplace.length, 93);
+    assert.equal(withBirthplace.filter(cityIds => cityIds.length > 1).length, 13);
   });
 
   test("a poet with two attested birthplaces gets a line from each", () => {

--- a/tests/popups.test.js
+++ b/tests/popups.test.js
@@ -84,6 +84,24 @@ describe("places map: origin", () => {
     }
   });
 
+  test("a disputed birthplace names the alternatives", () => {
+    // Issues #208, #218 and the second half of #257, all closed in 2015 by a
+    // derived line in the CartoDB query and all silently reopened when the
+    // rewrite dropped it. The wording is that line's: "See also: " and the
+    // other cities, alphabetically.
+    assert.match(popupFor(bubbles, "Sardis"), /See also: Sparta/);
+    assert.match(popupFor(bubbles, "Sparta"), /See also: Sardis/);
+    // Three sources call Tyrtaeus an Athenian, so the naive version of this
+    // would repeat Athens at Miletus. Places, not testimonia.
+    assert.match(popupFor(bubbles, "Miletus"), /See also: Athens, Sparta/);
+    assert.match(popupFor(bubbles, "Athens"), /See also: Miletus, Sparta/);
+  });
+
+  test("an undisputed birthplace says nothing", () => {
+    // 80 of the 93 poets with a birthplace. Chalcis holds only Tynnichus.
+    assert.doesNotMatch(popupFor(bubbles, "Chalcis"), /See also:/);
+  });
+
   test("popups carry dates, sources and the Greek text of the citation", () => {
     const sardis = popupFor(bubbles, "Sardis");
     assert.match(sardis, /Dates:/);
@@ -172,6 +190,29 @@ describe("travel map", () => {
     assert.match(html, /ORIGIN SOURCE/);
     assert.match(html, /ACTIVITY SOURCE/);
     assert.match(html, /THEBES/);
+  });
+
+  test("an arc out of a disputed origin names the other traditions", () => {
+    // Where the "See also:" line earns the most: an arc asserts a journey out
+    // of one city, and Alcman's Sardis -> Sparta is drawn beside a Sparta ->
+    // Sparta that has no length and cannot be seen. Without this the travel map
+    // shows only the Lydian tradition, and says nothing of the Laconian one.
+    const line = data.lines.find(l => l.bornCity.cityname === "Sardis" && l.activeCity.cityname === "Sparta");
+    assert.ok(line, "expected Alcman's Sardis -> Sparta line");
+    const html = createTravelPopupHtml(data, {
+      fromCity: line.bornCity,
+      toCity: line.activeCity,
+      poetLines: [line],
+      dotted: false,
+      color: "#fc1804",
+      name: "SARDIS -> SPARTA",
+      weight: 3
+    });
+    const origin = html.slice(html.indexOf("ORIGIN SOURCE"), html.indexOf("ACTIVITY SOURCE"));
+    assert.match(origin, /See also: Sparta/);
+    // Only the origin end. The other end is a place of activity, which has no
+    // alternatives to offer.
+    assert.doesNotMatch(html.slice(html.indexOf("ACTIVITY SOURCE")), /See also:/);
   });
 });
 

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -430,6 +430,12 @@ interface Lookups {
   govsByCityId: Record<number, CityPolitics[]>;
   govsById: Record<number, string>;
   datesByPoetId: Record<number, number[]>;
+  /**
+   * Every city a poet is attested as born in, distinct. Only 13 of the 93 poets
+   * with a birthplace have more than one entry; those are the ones whose popups
+   * carry a "See also:" line.
+   */
+  birthCityIdsByPoetId: Record<number, number[]>;
 }
 
 /** The travel lines and the control bar lists, derived from the CSVs through the lookups. */


### PR DESCRIPTION
Stacked on #350, which is what gives Euripides a second birthplace to point at. Base retargets to `master` when that merges.

## The gap

Thirteen of the ninety-three poets with a birthplace have more than one attested, and the map states each of them flatly. Click Sardis and Alcman is a poet born in Sardis; click Sparta and he is a poet born in Sparta. Nothing tells you these are the same claim reported two ways.

## It used to say so

The CartoDB map derived the line in SQL:

```sql
'<br>See also: ' || string_agg(birth_cities.city_name, ', ' ORDER BY birth_cities.city_name ASC)
```

That is how **#208** — *"Tyrtaeus> double/triple places of birth. Indicate this."* — and **#218** were closed, both with the comment *"See also: again"*, and how the second half of **#257** was answered. The rewrite dropped it, so all three have been quietly reopened since 2023, and **#332** is the same request arriving for a fourth time.

Restored here, and still derived rather than written down. The one time this was recorded by hand — the note the December 2015 corrections asked for on Alcman's Sardis row — it went **into** `source_citation` instead of in front of it, so that row has cited the note and not the Suda ever since. A derived line cannot drift from the rows it describes.

| bubble | poet | line |
|---|---|---|
| Sardis | Alcman | `See also: Sparta` |
| Sparta | Alcman | `See also: Sardis` |
| Miletus | Tyrtaeus | `See also: Athens, Sparta` |
| Salamis | Euripides | `See also: Athens` |

Keyed by **city, not by row**: three sources call Tyrtaeus an Athenian, and a reader standing on Miletus should be told about Athens once. That is what `birthCityIdsByPoetId` holds.

## Travel arcs get it too

At the ORIGIN SOURCE end, where it earns the most. An arc asserts a journey out of one city, and for a disputed origin the map draws one arc per tradition without ever saying that is what they are.

It is also the prerequisite for dropping the zero-length lines. Those are exactly the poets born and active in the same city — Alcman: Sparta, Corinna: Thebes, Tyrtaeus: Sparta — so removing them takes a birthplace off the travel map altogether unless the surviving arcs mention it. That is the second of the two `BUG:` tests in `initializeData.test.js`, and this unblocks it.

## Deliberately not here

Both need Peponi rather than code:

- **"possibly born in".** She asked for it in February 2025 and confirmed when asked that it applies **to Alcman alone**, not to all thirteen — *"No, we should not do it for all poets — it applies only to Alcman."* It is a per-row judgement, not a count: the Suda calls the Sardis tradition *wrong*, which is not true of Sappho's two Lesbian towns. No column expresses that yet. The existing test that watches for the copy change is left in place and still passes.
- **`nativeCityId`**, separating being born in a city from counting as a native of it (#257, #284). Needs a decision for each of the thirteen.

## Verification

106 tests, 24 browser tests, lint, format and typecheck pass. New tests cover the four cases above, that an undisputed birthplace says nothing, that a place of activity never gets the line, and that the count stays at 13 of 93.
