### PR TITLE
Stop printing an empty translator credit on Pindar's ode titles

### DIFF
--- a/js/popups/popupsCommon.js
+++ b/js/popups/popupsCommon.js
@@ -73,10 +73,13 @@ function createGenreString(lookups, poetId) {
  */
 export function renderReference(reference) {
   if (reference) {
-    let source_poem = "";
-    if (reference.source_poem) source_poem = `${reference.source_poem}.`;
+    const source_poem = reference.source_poem ? `${reference.source_poem}.` : "";
+    // Pindar's ode titles carry no translator on purpose: the December 2015
+    // corrections in notes/corrections-2015-12.md ask for the title without a
+    // credit. Printing the parenthesis anyway left "(trans. )" on the page.
+    const translator = reference.source_translator ? ` (trans. ${reference.source_translator})` : "";
     return `
-    Citation: ${source_poem}${reference.source_citation}: "${reference.source_translation}" (trans. ${reference.source_translator})<br>
+    Citation: ${source_poem}${reference.source_citation}: "${reference.source_translation}"${translator}<br>
     Greek: ${reference.source_greektext}
     `;
   } else {

--- a/tests/popups.test.js
+++ b/tests/popups.test.js
@@ -60,6 +60,18 @@ function popupFor(bubbles, cityname) {
   return bubble.popupHtml;
 }
 
+/**
+ * One bubble set per map view, for the sweeps that assert something no popup
+ * anywhere should contain.
+ * @type {[string, Record<number, Bubble>][]}
+ */
+const ALL_VIEWS = [
+  ["places/origin", placesBubblesFor({ type: "relationship", num: 1 })],
+  ["places/activity", placesBubblesFor({ type: "relationship", num: 3 })],
+  ["places/genre", placesBubblesFor({ type: "genre", num: 2 })],
+  ["geographical imaginary", geoBubblesFor({ type: "all", num: 1 })]
+];
+
 describe("places map: origin", () => {
   const bubbles = placesBubblesFor({ type: "relationship", num: 1 });
 
@@ -175,21 +187,43 @@ describe("travel map", () => {
   });
 });
 
+describe("citation credits", () => {
+  // Pindar's ode titles are entered with the translation but no translator, as
+  // the December 2015 corrections in notes/corrections-2015-12.md ask for:
+  // "In these cases we do not need to say whose the translation is (Race etc)."
+  const bubbles = placesBubblesFor({ type: "relationship", num: 3 });
+
+  test("a title with no translator is printed without an empty credit", () => {
+    const aitna = popupFor(bubbles, "Aitna");
+    assert.match(aitna, /Citation: P\. 1 Title: "FOR HIERON OF AETNA"<br>/);
+    assert.doesNotMatch(aitna, /trans\./, "the Aetna title has no translator, so it should carry no credit");
+  });
+
+  test("a translation that has a translator still credits them", () => {
+    assert.match(popupFor(bubbles, "Locri"), /Citation: O\. 10 Title: ".*" \(trans\. Race\)<br>/);
+  });
+});
+
 describe("popup html is well formed enough to render", () => {
   test("no popup leaks 'undefined' or 'NaN' into the page", () => {
-    /** @type {[string, Record<number, Bubble>][]} */
-    const VIEWS = [
-      ["places/origin", placesBubblesFor({ type: "relationship", num: 1 })],
-      ["places/activity", placesBubblesFor({ type: "relationship", num: 3 })],
-      ["places/genre", placesBubblesFor({ type: "genre", num: 2 })],
-      ["geographical imaginary", geoBubblesFor({ type: "all", num: 1 })]
-    ];
-    for (const [view, bubbles] of VIEWS) {
+    for (const [view, bubbles] of ALL_VIEWS) {
       for (const bubble of Object.values(bubbles)) {
         const html = bubble.popupHtml;
         const cityname = bubble.city.cityname;
         assert.doesNotMatch(html, /undefined/, `${view} popup for ${cityname} contains "undefined"`);
         assert.doesNotMatch(html, /NaN/, `${view} popup for ${cityname} contains "NaN"`);
+      }
+    }
+  });
+
+  test("no popup renders an empty translator credit", () => {
+    for (const [view, bubbles] of ALL_VIEWS) {
+      for (const bubble of Object.values(bubbles)) {
+        assert.doesNotMatch(
+          bubble.popupHtml,
+          /\(trans\. \)/,
+          `${view} popup for ${bubble.city.cityname} credits nobody in a "(trans. )"`
+        );
       }
     }
   });


### PR DESCRIPTION
First of five stacked PRs fixing the mechanical half of the outstanding data-integrity bugs. Based on `master`.

`renderReference()` named the translator unconditionally:

```js
Citation: ${source_poem}${reference.source_citation}: "..." (trans. ${reference.source_translator})<br>
```

so the 18 `poets_cities` rows that carry a translation but no translator rendered `Citation: P. 1 Title: "FOR HIERON OF AETNA" (trans. )`. This is the shape of issues #329 ("Citations broken again") and #313 ("citations are inconsistent").

## The blank translator is not the bug

Seventeen of the eighteen are Pindar poem titles — thirteen cited as `O. 4 Title` and the like, plus three papyrus titles (fr. 52b, 52d, 52m) and one from Strabo — and `notes/corrections-2015-12.md` asks for exactly that:

> Pindar and Bacchylides: All cases where we only use the "title" should be shown as dotted lines. […] In these cases we do not need to say whose the translation is (Race etc).

Every one of the seventeen is `dotted`, as the same note asks. The data is following an editorial decision the renderer was ignoring, so the fix is to drop the parenthesis when there is nobody to name, not to invent a credit.

## Tests

Both fail without the change:

- **a title with no translator is printed without an empty credit** pins the Aetna popup, which is the `P. 1` title.
- **no popup renders an empty translator credit** sweeps every bubble of every view for `(trans. )`, so a newly blank translator in a row that ought to have one is still caught. The 282 credited citations across those four views are untouched.

The view list the "undefined or NaN" sweep already built is hoisted to `ALL_VIEWS` so the second sweep can share it.

## Not fixed here

Data edits and editorial calls rather than rendering:

- `poets_cities.csv:246`, Stesandros at `Ath. 14.638b`, is the one genuine omission in the eighteen — a prose translation from Olson's Loeb Athenaeus with no credit. It now renders cleanly rather than visibly, but the count is still guarded by "incomplete poets_cities citations do not increase".
- `O. 10 Title` credits Race where the other seventeen titles credit nobody, and all fourteen Bacchylides titles credit Campbell, which the 2015 note also says is unnecessary.

| check | result |
| --- | --- |
| `npm test` | 101 pass (three new) |
| `npm run lint` | clean |
| `npm run format:check` | clean |
| `npm run typecheck` | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
