### PR TITLE
Give Claros the latitude its longitude already agrees with

### DIFF
--- a/dataFiles/cities.csv
+++ b/dataFiles/cities.csv
@@ -203,7 +203,7 @@ Susa,Susa,222,,32.19,48.26,,
 Syria,Syria,223,,35.79,36.79,,
 Tartessus,Tartessus,224,"Tartessos (Greek: Ταρτησσός) or Tartessus was a semi-mythical harbor city and the surrounding culture on the south coast of the Iberian Peninsula (in modern Andalusia, Spain), at the mouth of the Guadalquivir River. It appears in sources from Greece and the Near East starting during the first millennium BC, for example Herodotus, who describes it as beyond the Pillars of Heracles(Strait of Gibraltar)",37.5,-6.5,,
 Megara Hyblaia,Megara Hyblaia,225,Sicilian Megara,37.203717,15.181777,Sicily,7
-Claros,Claros,226,,384725,27.192987,,
+Claros,Claros,226,http://pleiades.stoa.org/places/599719,38.0047324117,27.192987,,
 Daskyleion,Daskyleion,229,,40.128889,28.071667,,
 Gyrae,Gyrae,230,"Can't find this one, it is a reference to the cliffs that the lesser Ajax died on. (probably a mountain chain on Tenos; see Sandback CR 1942 pp. 63-5; coordinates are now the rugged mountain of Exomvourgo on tenos)",37.577222,25.1675,Cyclades,1
 Ismaros,Ismaros,232,"Thracian Ismaros, pin dropped in possible area",40.980201,25.263959,,

--- a/tests/data-integrity.test.js
+++ b/tests/data-integrity.test.js
@@ -96,9 +96,6 @@ const acceptedCityLabels = new Set(ACCEPTED_CITY_LABEL_VARIANTS.map(([cityId, la
 /** poets_cities rows carrying a citation but no translation or translator. */
 const KNOWN_INCOMPLETE_CITATION_COUNT = 18;
 
-/** Cities whose coordinates are malformed and plot far outside the map. */
-const KNOWN_BROKEN_COORDINATE_CITY_IDS = new Set([226]);
-
 /**
  * The mapped world runs from Ethiopia in the south to Scythia in the north, and
  * from Tartessus and Erytheia beyond the Pillars of Heracles in the west
@@ -243,7 +240,6 @@ describe("field values", () => {
       const lat = parseFloat(city.lat);
       const long = parseFloat(city.long);
       assert.ok(Number.isFinite(lat) && Number.isFinite(long), `${city.cityname} has unparseable coordinates`);
-      if (KNOWN_BROKEN_COORDINATE_CITY_IDS.has(id(city.cityId))) continue;
       assert.ok(
         lat > WORLD_BOUNDS.minLat && lat < WORLD_BOUNDS.maxLat,
         `${city.cityname} latitude ${lat} is outside the mapped world — a lost decimal point?`
@@ -505,17 +501,6 @@ function cityById(cityId) {
 }
 
 /**
- * cities.csv row for a name, asserting it exists.
- * @param {string} cityname
- * @returns {RawCity}
- */
-function cityByName(cityname) {
-  const city = raw.cities.find(c => c.cityname === cityname);
-  assert.ok(city, `${cityname} is no longer in cities.csv`);
-  return city;
-}
-
-/**
  * The single row in a join table carrying a given cityname label.
  * @param {PoetCityCsv} file
  * @param {string} label
@@ -569,21 +554,6 @@ describe("known data bugs: places plotted in the wrong location", () => {
       134,
       "the same fragment also refers to Aetolia itself"
     );
-  });
-});
-
-describe("known data bugs: malformed coordinate", () => {
-  test("BUG: Claros' latitude is missing its decimal point", () => {
-    const claros = cityByName("Claros");
-    assert.equal(id(claros.cityId), 226);
-    assert.equal(claros.lat, "384725");
-    // The longitude, 27.192987, matches pleiades:599719 to five decimals, so the
-    // latitude should be that entry's 38.0047324117 — not 38.4725, which is what
-    // simply reinserting a decimal point would give.
-    assert.equal(claros.long, "27.192987");
-    // Nothing references Claros yet, so nothing is visibly misplaced today.
-    const referenced = [...raw.poetCities, ...raw.geopoetCities].filter(row => id(row.cityId) === 226);
-    assert.equal(referenced.length, 0);
   });
 });
 


### PR DESCRIPTION
Third of five stacked PRs. Based on #357.

`cities.csv:208` gave Claros a latitude of `384725`:

```
Claros,Claros,226,,384725,27.192987,,
```

The obvious repair is to put the decimal point back and call it `38.4725`. That would be wrong. The longitude, `27.192987`, matches [pleiades:599719](http://pleiades.stoa.org/places/599719) — Klaros — to five decimal places, and that entry's latitude is `38.0047324117`. Reinserting a decimal point would put the sanctuary about 52 km north of itself, in the hills behind Colophon rather than in the valley by the sea.

So the fix takes the latitude from the same Pleiades entry the longitude already came from, and the row now carries that entry's URL as its note, as Cephallenia and others do.

## Nothing was drawn wrong, because nothing is drawn

Unlike Etruria in #354, no `poets_cities` or geographical imaginary row points at cityId 226. Claros is a placed but unreferenced city, waiting for a citation.

The value mattered anyway. `384725` is a perfectly good number, so the day someone adds that citation, Leaflet would have projected it 384,725 degrees north and clipped the circle to `d="M0 0"` without a word — precisely what Etruria did.

## Test bookkeeping

Per the instructions at the top of `data-integrity.test.js`:

- `KNOWN_BROKEN_COORDINATE_CITY_IDS` held nothing but 226, so the set and the `continue` that skipped it both go. "coordinates are either both blank or both plausible for the mapped world" now covers every row of `cities.csv` with no exceptions, and passes.
- `BUG: Claros' latitude is missing its decimal point` is deleted, and with it the last test in `known data bugs: malformed coordinate`, so the `describe` goes too.
- `cityByName()` was that test's only caller and is removed with it. Leaving it fails lint and typecheck, which is how it was noticed.

| check | result |
| --- | --- |
| `npm test` | 99 pass (one fewer — the deleted bug test) |
| `npm run lint` | clean |
| `npm run format:check` | clean |
| `npm run typecheck` | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
