### PR TITLE
Trim the newline out of Plataea and the trailing space off Lamynthios

### DIFF
--- a/dataFiles/cities.csv
+++ b/dataFiles/cities.csv
@@ -196,9 +196,7 @@ Ladon,Ladon,212,a river and tributary of the Alphios,37.59,21.82,,
 Libya,LIBYA (region),214,pin dropped in vicinity of ancient region of Libya,32.82,21.85,,
 Naucratis,Naucratis,215,,30.9,30.616,,
 Mt. Parnassus,Mt. Parnassus,216,The mountain above delphi,38.53,22.62,,
-"Plataea
-","Plataea
-",218,i.e. Plataiai,38.221257,23.273345,,
+Plataea,Plataea,218,i.e. Plataiai,38.221257,23.273345,,
 Mt. Ptoios,Mt. Ptoios,219,non-polis oracle site of Apollo on a mountain,38.48,23.32,,
 Sinope,Sinope,220,,42.025776,35.143037,,
 Susa,Susa,222,,32.19,48.26,,

--- a/dataFiles/poets.csv
+++ b/dataFiles/poets.csv
@@ -68,7 +68,7 @@ Krateuas,Krateuas,20,Suda E 3695; Scholia in Euripidem Vitae Euripidis 5.18,fl. 
 Kydides,Kydides,47,Stefanis 1520; Aspiotes 1143,fl. 450–425,,
 Lamprocles,Lamprocles,119,"Campbell, Greek Lyric vol. 4 (LCL 461); Aspiotes 1177; Brill’s New Pauly",fl. 500–450,,
 Lamprus,Lamprus,120,"Campbell, Greek Lyric vol. 3 (LCL 476); Aspiotes 1178",possibly late sixth-early fifth?,"Natasha: ""possibly late sixth--early 5th?""",
-Lamynthios ,Lamynthios ,28,"Aspiotes 1179; Campbell, Greek Lyric vol. 5 (LCL 144); Brill’s New Pauly",5th c.,,
+Lamynthios,Lamynthios,28,"Aspiotes 1179; Campbell, Greek Lyric vol. 5 (LCL 144); Brill’s New Pauly",5th c.,,
 Lasus,Lasus,121,"Campbell, Greek Lyric vol. 3 (LCL 476); Aspiotes 1183; Brill’s New Pauly",fl. c. 500,"NP (Robbins, Emmet (Toronto))",
 Leotrophides,Leotrophides,77,Aspiotes 1189,5th c.,,
 Licymnius,Licymnius,3,"Campbell, Greek Lyric vol. 5 (LCL 144); Aspiotes 1199; Brill’s New Pauly",fl. 425–400,,

--- a/tests/data-integrity.test.js
+++ b/tests/data-integrity.test.js
@@ -85,7 +85,6 @@ const ACCEPTED_CITY_LABEL_VARIANTS = [
   [179, "Therapne"],
   [206, "Euripus"],
   [216, "Parnassus"],
-  [218, "Plataea"],
   [219, "Mt. Ptoïon"],
   [254, "Camarina"], // BUG: plotted on Erythrae in Ionia. Camarina is in Sicily.
   [254, "Ionian Erythrae"],
@@ -444,16 +443,22 @@ describe("csv schema", () => {
 
 describe("hygiene", () => {
   test("names have no leading or trailing whitespace", () => {
+    // A stray space, or a newline inside a quoted field, is easy to introduce
+    // from a spreadsheet and hard to spot afterwards. The display names are
+    // checked alongside the sort names because both halves of a row are edited
+    // together and both went wrong together in Plataea and Lamynthios.
     const offenders = [];
     for (const city of raw.cities) {
-      if (city.cityname !== city.cityname.trim()) offenders.push(`cities.csv: ${JSON.stringify(city.cityname)}`);
+      for (const name of [city.cityname, city.infowindowName]) {
+        if (name !== name.trim()) offenders.push(`cities.csv: ${JSON.stringify(name)}`);
+      }
     }
     for (const poet of raw.poets) {
-      if (poet.poetname !== poet.poetname.trim()) offenders.push(`poets.csv: ${JSON.stringify(poet.poetname)}`);
+      for (const name of [poet.poetname, poet.poetDetailName]) {
+        if (name !== name.trim()) offenders.push(`poets.csv: ${JSON.stringify(name)}`);
+      }
     }
-    // Two rows are already like this; a stray newline inside a quoted field is
-    // easy to introduce from a spreadsheet and hard to spot afterwards.
-    assert.ok(offenders.length <= 2, `unexpected whitespace in names:\n  ${offenders.join("\n  ")}`);
+    assert.deepEqual(offenders, [], `unexpected whitespace in names:\n  ${offenders.join("\n  ")}`);
   });
 
   test("every poet has dates", () => {
@@ -636,16 +641,5 @@ describe("known data bugs: incomplete or inconsistent fields", () => {
       );
       assert.equal(bad.length, 0);
     }
-  });
-
-  test("BUG: two names carry stray whitespace", () => {
-    const cityOffenders = raw.cities.filter(c => c.cityname !== c.cityname.trim());
-    const poetOffenders = raw.poets.filter(p => p.poetname !== p.poetname.trim());
-    assert.equal(cityOffenders.length, 1);
-    assert.equal(cityOffenders[0].cityname, "Plataea\r\n");
-    assert.equal(poetOffenders.length, 1);
-    assert.equal(poetOffenders[0].poetname, "Lamynthios ");
-    // A newline inside a quoted CSV field, almost certainly from a spreadsheet.
-    // Both render with stray space in tooltips and sort inconsistently.
   });
 });


### PR DESCRIPTION
Last of five stacked PRs. Based on #359.

Two rows carried whitespace inside a name. Both look like a spreadsheet export:

```
cities.csv:199  "Plataea\r\n","Plataea\r\n",218,i.e. Plataiai,38.221257,...
poets.csv:71    Lamynthios ,Lamynthios ,28,"Aspiotes 1179; ...
```

The Plataea one is a CRLF inside a quoted field, so the record spanned three physical lines of a file that is otherwise one line per row; `cities.csv` loses two lines here without losing a row.

## Both halves of each row are fixed

The sort name and the display name, because the display names are the ones that reach the page. Dumping every bubble's popup html across places/origin, places/activity, places/genre and geographical imaginary, 14 lines change:

```diff
-     <h3 style="color:#AAAAAA">PLATAEA
- </h3>
+     <h3 style="color:#AAAAAA">PLATAEA</h3>

-         <span ...>2</span>. Lamynthios <br>
+         <span ...>2</span>. Lamynthios<br>
```

The `infowindowName` newline was being written straight into the middle of an `h3` and an `h5` on the Plataea bubble, and Lamynthios was listed with a trailing space in Athens and Sparta. Html collapses both to a space when it renders, which is why neither was ever reported.

## Test bookkeeping

Per the instructions at the top of `data-integrity.test.js`:

- `BUG: two names carry stray whitespace` is deleted.
- The hygiene test's `offenders.length <= 2` tolerance becomes `deepEqual([])`, so it names the offending strings when it fails instead of counting them.
- It also checks `infowindowName` and `poetDetailName`, not just the two sort names. Those are the fields the popups read, and in both of these rows they went wrong together with their sort name. Neither has any other offender today.
- `[218, "Plataea"]` leaves `ACCEPTED_CITY_LABEL_VARIANTS`: it was only there because the sole row labelled Plataea could not match a `cities.csv` entry called `"Plataea\r\n"`. "no NEW cityname disagrees with the city it references" now covers that row and passes.

| check | result |
| --- | --- |
| `npm test` | 97 pass (one fewer — the deleted bug test) |
| `npm run lint` | clean |
| `npm run format:check` | clean |
| `npm run typecheck` | clean |
| `npm run test:browser` | 24 pass, run on this branch with all five stacked |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
