### PR TITLE
Archive the eight cities no citation has ever pointed at

### DIFF
--- a/dataFiles/cities.csv
+++ b/dataFiles/cities.csv
@@ -87,18 +87,12 @@ Metapontion,Metapontion,88,,40.383868,16.824063,Italy,10
 Aigina,Aigina,89,coordinates are temple of Aphaia on Aegina,37.754475,23.53304,Cyclades & western Aegean islands,1
 Pyrrha,Pyrrha,90,coordinates from Inventory,39.1,26.15,Lesbos,8
 Egypt,EGYPT (region),91,coordinates are Naucratis,30.90071,30.591777,,
-Italy,ITALY (region),92,coordinates are mod. Acri,39.481432,16.390228,Italy,10
 Ionia,IONIA (region),93,coordinates are Mount Mycale (near Panionium),37.666667,27.083333,Ionia,6
 Sanctuary of Poseidon Petraios,Sanctuary of Poseidon Petraios,94,"coordinates are the vale of Tempe, where the sanctuary lay (though it is still undiscovered)",39.875996,22.554418,Thessaly,12
 Acharnae,Acharnae,95,,38.083333,23.733333,Attica,2
-Mt. Ida,Mt. Ida,96,,35.226667,24.7725,Crete,17
-Knossos,Knossos,97,,35.298056,25.163056,Crete,17
-Sea of Crete,Sea of Crete,98,or Knossian Sea,35.926953,24.944044,Crete,17
-Troezen,Troezen,99,,37.483333,23.35,Peloponnese,9
 Mt. Olympus,Mt. Olympus,100,,40.085556,22.358611,Northern Greece,11
 Alpheos,Alpheos,101,(river at Olympia),37.634566,21.6263755,Peloponnese,9
 Lydia,LYDIA (region),102,Should we just use Sardis for this instead of following coordinates?,38.8131598,29.7190513,Lydia,14
-Sipylus,Sipylus,103,"(Lydian city near Smyrna). The location of this city is unknown. I'm basically just making this up -- ""imagineering"" it, as it were. In reality, the following coordinates are for Mount Sipylos, which is the best I could do.",38.5672198,27.454722,Lydia,14
 Pisa,Pisa,104,,37.644,21.654,Peloponnese,9
 Peloponnese,PELOPONNESE (region),105,,37.2641846,22.4967727,Peloponnese,9
 Cyprus,Cyprus,106,,35.1697515,33.4369908,Cyprus,18
@@ -147,7 +141,6 @@ Lycia,LYCIA (region),150,"A coastal region in southern Turkey. The coordinates a
 Mt. Parnes,Mt. Parnes,151,"Parnes is a mountain in between Boitia and Attica, modern Mount Parnitha.",38.1734,23.7174,Attica,2
 Zacynthus,Zacynthus,153,island in Ionian Sea,37.8,20.75,Ionian Sea,19
 Amyclae,Amyclae,155,,37.033333,22.433333,Peloponnese,9
-Aphidnae,Aphidnae,157,,38.2,23.833333,,
 Assos,Assos,160,,39.487778,26.336944,Troad,28
 Carystus,Carystus,161,,38.016541,24.420381,euboeia,22
 Cerbesia,Cerbesia,162,"coordinates are for Hierapolis, cf. Ogden 2013 p. 112 citing Strabo",37.925,29.125833,Phrygia,23
@@ -203,7 +196,6 @@ Susa,Susa,222,,32.19,48.26,,
 Syria,Syria,223,,35.79,36.79,,
 Tartessus,Tartessus,224,"Tartessos (Greek: Ταρτησσός) or Tartessus was a semi-mythical harbor city and the surrounding culture on the south coast of the Iberian Peninsula (in modern Andalusia, Spain), at the mouth of the Guadalquivir River. It appears in sources from Greece and the Near East starting during the first millennium BC, for example Herodotus, who describes it as beyond the Pillars of Heracles(Strait of Gibraltar)",37.5,-6.5,,
 Megara Hyblaia,Megara Hyblaia,225,Sicilian Megara,37.203717,15.181777,Sicily,7
-Claros,Claros,226,http://pleiades.stoa.org/places/599719,38.0047324117,27.192987,,
 Daskyleion,Daskyleion,229,,40.128889,28.071667,,
 Gyrae,Gyrae,230,"Can't find this one, it is a reference to the cliffs that the lesser Ajax died on. (probably a mountain chain on Tenos; see Sandback CR 1942 pp. 63-5; coordinates are now the rugged mountain of Exomvourgo on tenos)",37.577222,25.1675,Cyclades,1
 Ismaros,Ismaros,232,"Thracian Ismaros, pin dropped in possible area",40.980201,25.263959,,

--- a/dataFiles/removed_data.txt
+++ b/dataFiles/removed_data.txt
@@ -38,3 +38,18 @@ Aristotle,151,400.00,,
 Aristotle,151,375.00,,
 Aristotle,151,350.00,,
 Aristotle,151,325.00,,
+
+removed cities
+Nothing has ever referenced these: no poets_cities row, no geographical_imaginary_group
+row, and none of them is a destination_id, in any revision of those files. They read as
+places staged in the gazetteer for a citation that never arrived. Coordinates are kept
+here so that restoring one is a paste rather than a fresh lookup.
+cityname,infowindowName,cityId,notes,lat,long,region,regionId
+Italy,ITALY (region),92,coordinates are mod. Acri,39.481432,16.390228,Italy,10
+Mt. Ida,Mt. Ida,96,,35.226667,24.7725,Crete,17
+Knossos,Knossos,97,,35.298056,25.163056,Crete,17
+Sea of Crete,Sea of Crete,98,or Knossian Sea,35.926953,24.944044,Crete,17
+Troezen,Troezen,99,,37.483333,23.35,Peloponnese,9
+Sipylus,Sipylus,103,"(Lydian city near Smyrna). The location of this city is unknown. I'm basically just making this up -- ""imagineering"" it, as it were. In reality, the following coordinates are for Mount Sipylos, which is the best I could do.",38.5672198,27.454722,Lydia,14
+Aphidnae,Aphidnae,157,,38.2,23.833333,,
+Claros,Claros,226,http://pleiades.stoa.org/places/599719,38.0047324117,27.192987,,

--- a/tests/data-integrity.test.js
+++ b/tests/data-integrity.test.js
@@ -57,6 +57,24 @@ const KNOWN_UNMAPPED_GEO_CITY_IDS = new Set([
 const KNOWN_ORPHAN_GENRE_POET_IDS = new Set([14, 31, 33, 113]);
 
 /**
+ * Cities no citation points at, so no map draws them.
+ *
+ * Each still has nine city_politics rows, which is why they are here rather
+ * than in removed_data.txt with the other eight: deleting the city means
+ * deleting that regime history too, and Attica shows the rows can outlive the
+ * citation by accident — the geographical imaginary row that referenced it was
+ * archived in December 2023 and the city was left behind. Whether the politics
+ * is worth keeping without a poet attached is an editorial call.
+ */
+const KNOWN_UNREFERENCED_CITY_IDS = new Set([
+  24, // Megalopolis
+  25, // Stageira
+  67, // Siris
+  86, // Kynoskephalai
+  198 // Attica (region), orphaned by the Aristotle archiving
+]);
+
+/**
  * Rows whose cityname label does not match the cities.csv entry they point at,
  * as [cityId, label]. Most are harmless spelling variants (Aegina/Aigina,
  * Ceos/Ioulis). The three marked BUG are different places entirely.
@@ -196,6 +214,25 @@ describe("referential integrity", () => {
       assert.ok(
         bigRegionIds.has(id(region.bigRegionId)),
         `${region.regionname} has unknown bigRegionId ${region.bigRegionId}`
+      );
+    }
+  });
+
+  // The other direction. Every test above asks whether a row's cityId resolves;
+  // this asks whether a city is reachable from any row, which is what decides
+  // whether it is ever drawn or exercised. Claros sat in cities.csv for two
+  // years with a latitude of 384725 because nothing referenced it, so nothing
+  // ran over it — the coordinate check skipped it by way of an exception set.
+  test("every city is referenced by some citation", () => {
+    const referenced = new Set(
+      [...raw.poetCities, ...raw.geopoetCities].filter(row => filled(row.cityId)).map(row => id(row.cityId))
+    );
+    for (const city of raw.cities) {
+      if (KNOWN_UNREFERENCED_CITY_IDS.has(id(city.cityId))) continue;
+      assert.ok(
+        referenced.has(id(city.cityId)),
+        `${city.cityname} (cityId ${city.cityId}) is in cities.csv but no citation points at it, ` +
+          `so no map draws it — add the citation, or move the row to removed_data.txt`
       );
     }
   });


### PR DESCRIPTION
`cities.csv` had 230 rows and the maps draw 217 of them. Of the thirteen left over, **eight are referenced by nothing at all** — no `poets_cities` row, no geographical imaginary row, and none of them is a `destination_id`.

| id | city | id | city |
| --- | --- | --- | --- |
| 92 | Italy | 99 | Troezen |
| 96 | Mt. Ida | 103 | Sipylus |
| 97 | Knossos | 157 | Aphidnae |
| 98 | Sea of Crete | 226 | Claros |

## These are not orphans

Checking **every revision** of both join tables, none of the eight has ever been referenced. No citation was deleted out from under them. They are gazetteer entries staged for a citation that never arrived, and Sipylus says so in its own note:

> (Lydian city near Smyrna). The location of this city is unknown. I'm basically just making this up -- "imagineering" it, as it were.

## Why move them out

An unreferenced row is an unexercised row. Claros is the demonstration: its latitude was `384725` from the initial import until #358 — two years — and nothing caught it, because nothing drew it. The coordinate plausibility check was *skipping* it through an exception set, precisely because it was malformed. Same shape as Etruria in #354, minus the symptom.

They go to `removed_data.txt` rather than being deleted outright, following the December 2023 archiving in `a4910ce`. The rows carry real work — Sipylus has a paragraph of reasoning, Claros now has a latitude and longitude that agree with pleiades:599719 — and git recovers everything, but nobody greps git. The archive takes the **corrected** Claros, not the broken one, so restoring it is a paste rather than a landmine.

## Nothing changes on screen

No dropdown enumerates `cities.csv`. `createTravelCities()` derives from the drawn lines and the region filters come from `regions.csv`. The browser suite draws the same 24 views, `initializeData()` reports no alerts and no logs, and 222 cities load where 230 did.

## The new test

It runs the other direction from the ones around it. Those ask whether a row's `cityId` resolves; this asks whether a city is reachable from any row, which is what decides whether it is ever drawn — or ever checked.

## Five cities stay

`KNOWN_UNREFERENCED_CITY_IDS` holds Megalopolis, Stageira, Siris, Kynoskephalai and Attica. Each is referenced only by `city_politics`, which puts nothing on a map — `getGovs()` is consulted only for the endpoints of a travel line — but each also has **nine rows of regime history**, so removing the city means removing that too.

Attica is the reason to be careful: it was referenced until `a4910ce` archived the Aristotle geographical-imaginary row and left the city behind. These look like accidents of an earlier cleanup rather than places nobody wanted, which is an editorial call rather than a mechanical one.

| check | result |
| --- | --- |
| `npm test` | 127 pass |
| `npm run lint` | clean |
| `npm run format:check` | clean |
| `npm run typecheck` | clean |
| `npm run test:browser` | 28 pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)