### PR TITLE
Assert that every poet is placed by some citation

### DIFF
--- a/tests/data-integrity.test.js
+++ b/tests/data-integrity.test.js
@@ -75,6 +75,38 @@ const KNOWN_UNREFERENCED_CITY_IDS = new Set([
 ]);
 
 /**
+ * Poets no citation places anywhere, so no map draws them.
+ *
+ * Deliberately kept, unlike the cities archived in #362. An unreferenced city
+ * was a coordinate looked up ahead of a citation that never came; an unplaced
+ * poet is a finding — the catalogue attests the poet and dates them, and no
+ * source puts them in a place. All fourteen have rows in dates.csv, twelve have
+ * sources, five have genres, and none is a renumbering of a poet who is on the
+ * map: the near-misses in poets_cities are other people (Dionysius Chalkus and
+ * Dionysius of Thebes are not Dionysius of Chios, Euripides is not Euripides
+ * the Younger, Phrynis is not Phrynichos).
+ *
+ * A NEW name here is much more likely to be a data-entry slip, which is what
+ * the test below is for.
+ */
+const KNOWN_UNPLACED_POET_IDS = new Set([
+  47, // Kydides
+  58, // Chares
+  62, // Dionysius of Chios
+  63, // Diphilos
+  67, // Euripides the Younger
+  74, // Karkinos
+  77, // Leotrophides
+  79, // Pankrates
+  81, // Phrynichos
+  88, // Timonides
+  90, // Xenokrates
+  95, // Ananius
+  103, // Charixena
+  125 // Panarces
+]);
+
+/**
  * Rows whose cityname label does not match the cities.csv entry they point at,
  * as [cityId, label]. Most are harmless spelling variants (Aegina/Aigina,
  * Ceos/Ioulis). The three marked BUG are different places entirely.
@@ -233,6 +265,24 @@ describe("referential integrity", () => {
         referenced.has(id(city.cityId)),
         `${city.cityname} (cityId ${city.cityId}) is in cities.csv but no citation points at it, ` +
           `so no map draws it — add the citation, or move the row to removed_data.txt`
+      );
+    }
+  });
+
+  // The same question for poets. Every control bar list is built from the join
+  // tables rather than from poets.csv — createGeoImaginaryPoets() from
+  // geopoetCities, createTravelPoets() from the drawn lines, and even
+  // "poets with unknown travels" from poets that have poets_cities rows but no
+  // born-and-active pair — so a poet neither table names appears nowhere at all,
+  // not even as a filter that draws nothing.
+  test("every poet is placed by some citation", () => {
+    const placed = new Set([...raw.poetCities, ...raw.geopoetCities].map(row => id(row.poetId)));
+    for (const poet of raw.poets) {
+      if (KNOWN_UNPLACED_POET_IDS.has(id(poet.poetId))) continue;
+      assert.ok(
+        placed.has(id(poet.poetId)),
+        `${poet.poetname} (poetId ${poet.poetId}) has no poets_cities or geographical imaginary row, ` +
+          `so no map places them — check the poetId before adding them to KNOWN_UNPLACED_POET_IDS`
       );
     }
   });


### PR DESCRIPTION
The mirror of the cities rule added in #362, with the **opposite default**.

Fourteen of the 133 poets in `poets.csv` have no `poets_cities` row and no geographical imaginary row:

> Ananius, Chares, Charixena, Dionysius of Chios, Diphilos, Euripides the Younger, Karkinos, Kydides, Leotrophides, Panarces, Pankrates, Phrynichos, Timonides, Xenokrates

## They appear nowhere at all

Every control bar list is built from the join tables, never from `poets.csv` — `createGeoImaginaryPoets()` from `geopoetCities`, `createTravelPoets()` from the drawn lines, and even "POETS WITH UNKNOWN TRAVELS" from poets that *have* `poets_cities` rows but lack a born-and-active pair. A poet neither table names is not even a filter that draws nothing.

## But they are kept

This is the difference from the eight cities #362 archived. An unreferenced city was a coordinate looked up ahead of a citation that never arrived — Sipylus admitted as much in its own note. **An unplaced poet is a finding**: the catalogue attests the poet and dates them, and no source puts them in a place.

All fourteen have rows in `dates.csv`, twelve have `sources`, five have genres. That is not staging, and unlike a coordinate it cannot be recovered from Pleiades. The existing "every poet has dates" test already treats `poets.csv` as a roster to be kept complete rather than as a feed for the map.

## None of them is a renumbering

Worth ruling out, given Kinesias 14 / Cinesias 4. The near-misses in `poets_cities` are other people:

| unplaced | near-miss on the map | same person? |
| --- | --- | --- |
| Dionysius of Chios (62) | Dionysius Chalkus (109), Dionysius of Thebes (21) | no |
| Euripides the Younger (67) | Euripides (114) | no |
| Phrynichos (81) | Phrynis (5) | no |

So the exception set is the point of the test rather than a wart on it. A new name in it is far more likely to be a mistyped `poetId` than a fifteenth unplaceable poet — and that now fails the build.

| check | result |
| --- | --- |
| `npm test` | 128 pass |
| `npm run lint` | clean |
| `npm run format:check` | clean |
| `npm run typecheck` | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)