### PR TITLE
Report data problems to the console, not to a dialog the reader dismisses

### DIFF
--- a/js/assertUnreachable.js
+++ b/js/assertUnreachable.js
@@ -6,10 +6,10 @@
  * compiling. That is what lets the callers drop their casts — after an
  * if/else chain ending here, the remaining values are known, not merely assumed.
  *
- * At runtime it does what this codebase has always done with an unexpected
- * state — alert, then fail — except that it fails immediately and names the
- * offending value, instead of continuing and throwing something unrelated a
- * few lines later.
+ * At runtime it names the offending value and fails immediately, instead of
+ * continuing and throwing something unrelated a few lines later. It reports to
+ * the console rather than to a dialog: a reader of the map can do nothing about
+ * a union we failed to handle, so the message is for us.
  *
  * @param {never} value
  * @param {string} message
@@ -17,6 +17,6 @@
  */
 export function assertUnreachable(value, message) {
   const description = `${message}: ${String(value)}`;
-  alert(description);
+  console.error(description);
   throw new Error(description);
 }

--- a/js/calcData/data.js
+++ b/js/calcData/data.js
@@ -201,9 +201,9 @@ function sortPoetCities(lookups, poetCities) {
  * Reports poets that are on the map but missing the display data popups show.
  *
  * Reported once per poet rather than once per row, which is what the priming
- * pass did — a poet with five rows alerted five times. Reporting it here rather
- * than where popups read it keeps it to startup: at render time the same alert
- * would fire again on every redraw.
+ * pass did — a poet with five rows was reported five times. Reporting it here
+ * rather than where popups read it keeps it to startup: at render time the same
+ * message would be repeated on every redraw.
  * @param {Csvs} csvs
  * @param {Lookups} lookups
  */
@@ -213,7 +213,7 @@ function warnAboutIncompletePoets(csvs, lookups) {
     const poet = getPoet(lookups, poetId);
     // getPoet has already logged the missing id; there is nothing more to say.
     if (!poet) continue;
-    if (!poet.poetDetailName) alert(`Poet ${poet.poetname} with poetId ${poetId} lacks a details name`);
+    if (!poet.poetDetailName) console.error(`Poet ${poet.poetname} with poetId ${poetId} lacks a details name`);
     if (!poet.dates) console.log(`Poet ${poet.poetname} with poetId ${poetId} lacks dates`);
     if (!poet.sources) console.log(`Poet ${poet.poetname} with poetId ${poetId} lacks sources`);
   }

--- a/js/calcData/getters.js
+++ b/js/calcData/getters.js
@@ -108,7 +108,7 @@ function parseFilter(selectedId, allowed, mapName) {
   const filterType = allowed.find(known => known === type);
   if (!filterType) {
     const message = `"${type}" is not a ${mapName} filter (selectedId "${selectedId}")`;
-    alert(message);
+    console.error(message);
     throw new Error(message);
   }
   return { type: filterType, num: parseInt(stringNum) };

--- a/js/calcData/parseCsvs.js
+++ b/js/calcData/parseCsvs.js
@@ -54,7 +54,9 @@ export async function parseCsvs() {
 async function parseCsv(filename) {
   const response = await fetch(filename);
   // fetch resolves for a 404, so without this the error page is parsed as CSV
-  // and the map draws nothing, with no indication why.
+  // and the map draws nothing, with no indication why. This is the one place
+  // the app still alerts: the failure is one a reader can see but not diagnose,
+  // and everything else it used to alert about was a note to ourselves.
   if (!response.ok) {
     const message = `could not load ${filename}: ${response.status} ${response.statusText}`;
     alert(message);

--- a/tests/helpers/loadData.js
+++ b/tests/helpers/loadData.js
@@ -45,27 +45,26 @@ export function loadRawCsvs() {
  * The CSVs run through the real initializeData(), i.e. the same object the
  * browser builds before it draws anything. Use this for behaviour assertions.
  *
- * The app reports missing lookups by calling alert() and console.log(), neither
- * of which should ever fire against good data, so both are captured and handed
- * back for assertion rather than printed.
- * @returns {{ data: Data, alerts: string[], logs: string[] }}
+ * The app reports missing lookups by calling console.error() and console.log(),
+ * neither of which should ever fire against good data, so both are captured and
+ * handed back for assertion rather than printed.
+ * @returns {{ data: Data, errors: string[], logs: string[] }}
  */
 export function loadInitializedData() {
   /** @type {string[]} */
-  const alerts = [];
+  const errors = [];
   /** @type {string[]} */
   const logs = [];
 
-  const globals = /** @type {{ alert?: (message: string) => void }} */ (globalThis);
-  const realAlert = globals.alert;
+  const realError = console.error;
   const realLog = console.log;
-  globals.alert = message => alerts.push(String(message));
+  console.error = (/** @type {unknown[]} */ ...args) => errors.push(args.join(" "));
   console.log = (/** @type {unknown[]} */ ...args) => logs.push(args.join(" "));
 
   try {
-    return { data: initializeData(loadRawCsvs()), alerts, logs };
+    return { data: initializeData(loadRawCsvs()), errors, logs };
   } finally {
-    globals.alert = realAlert;
+    console.error = realError;
     console.log = realLog;
   }
 }

--- a/tests/initializeData.test.js
+++ b/tests/initializeData.test.js
@@ -13,7 +13,7 @@ import { createPlacesInterfaceHtml } from "../js/interface/placesInterface.js";
 import { createTravelInterfaceHtml } from "../js/interface/travelInterface.js";
 import { createGeoImaginaryInterfaceHtml } from "../js/interface/geoImaginaryInterface.js";
 
-const { data, alerts, logs } = loadInitializedData();
+const { data, errors, logs } = loadInitializedData();
 
 const poetIdByName = (/** @type {string} */ name) => {
   const poet = data.poets.find(p => p.poetname === name);
@@ -22,8 +22,8 @@ const poetIdByName = (/** @type {string} */ name) => {
 };
 
 describe("initializeData runs clean", () => {
-  test("no alerts", () => {
-    assert.deepEqual(alerts, [], "initializeData alerted, which means a poet lookup failed");
+  test("no console errors", () => {
+    assert.deepEqual(errors, [], `initializeData reported an error:\n  ${errors.join("\n  ")}`);
   });
 
   test("no console warnings about unresolved ids", () => {
@@ -124,7 +124,7 @@ describe("hydration", () => {
     // Popups read these through getPoetDisplay() when they render, and it falls
     // back to "" rather than leaking "undefined" into the page — so a poet
     // missing them renders a blank line instead of failing. This is what
-    // warnAboutIncompletePoets() alerts about at startup, asserted directly.
+    // warnAboutIncompletePoets() reports at startup, asserted directly.
     const mapped = new Set([...data.poetCities, ...data.geopoetCities].map(pc => pc.poetId));
     for (const poetId of mapped) {
       const poet = data.poetsById[poetId];


### PR DESCRIPTION
Closes #371.

Three of the four `alert()` calls in `js/` were developer diagnostics that a visitor met as a **modal dialog they had to dismiss**. None of them is something a reader of the map can act on.

| call | what it says | when |
| --- | --- | --- |
| `data.js:216` | `Poet X with poetId N lacks a details name` | startup, **once per poet** |
| `assertUnreachable.js:20` | `<message>: <value>` | a union we failed to handle |
| `getters.js:111` | `"X" is not a places filter` | a control bar id that does not parse |

All three now use `console.error`.

## Why each one

**`warnAboutIncompletePoets()`** fires at startup for every poet with no `poetDetailName`, so a bad import stacks up dialogs one behind the other. The two lines either side of it already report the same class of problem with `console.log`.

**`assertUnreachable()`** and **`parseFilter()`** alert a message and then *throw the same string*, so the dialog sat on top of an error the console shows anyway. The throw is unchanged — the `console.error` is what survives if anything ever catches it.

## The CSV alert stays

`parseCsvs.js:60` is the one a reader needs. A CSV that fails to load means an **empty map**: a failure they can see but not diagnose, and the dialog is the only thing that says so. The comment there now records that it is the last one and why.

## Test bookkeeping

`loadInitializedData()` stubbed `globalThis.alert` to capture the one alert `initializeData()` could raise — Node has no `alert`, so the stub was also what kept the call from throwing. With the call gone the capture would be dead and the `no alerts` assertion vacuous, so it captures `console.error` instead and hands it back as `errors` alongside `logs`.

The browser suite needed **no change**, and quietly gets stricter: page console errors already go into the same list `no console errors, page errors or alerts throughout` asserts is empty, so these three now fail `test:browser` if they ever fire. The alert only ever reached the dialog handler.

## Not done here

`data.js:217-218` still use `console.log` for the missing `dates` and `sources` on the same poet, so that three-line block now reports at two levels. #371 scoped itself to `alert()`, and which level those two belong at is a separate call — the helper already captures `console.error` if they are raised.

| check | result |
| --- | --- |
| `npm test` | 127 pass |
| `npm run lint` | clean |
| `npm run format:check` | clean |
| `npm run typecheck` | clean |
| `npm run test:browser` | 28 pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)