### PR TITLE
Close the activity popup's headings with the tags that opened them

### DIFF
--- a/js/popups/popups.js
+++ b/js/popups/popups.js
@@ -57,7 +57,7 @@ function createActivePopupHtml(data, bubble) {
 
   if (bornPoetCities.length > 0) {
     nativeHeader = `
-      <h5 style="color:${LYRIC_GREY}">${nativeTitle}</h2>
+      <h5 style="color:${LYRIC_GREY}">${nativeTitle}</h5>
       ${createNumberedListOfPoets(bornPoetCities.map(pc => getPoetDisplay(data, pc.poetId).detailName))}
     `;
     nativeDetails = `
@@ -68,7 +68,7 @@ function createActivePopupHtml(data, bubble) {
 
   if (otherPoetCities.length > 0) {
     nonNativeHeader = `
-      <h5 style="color:${LYRIC_GREY}">${nonNativeTitle}</h2>
+      <h5 style="color:${LYRIC_GREY}">${nonNativeTitle}</h5>
       ${createNumberedListOfPoets(otherPoetCities.map(pc => getPoetDisplay(data, pc.poetId).detailName))}
     `;
     nonNativeDetails = `
@@ -78,7 +78,7 @@ function createActivePopupHtml(data, bubble) {
   }
 
   return `
-    <h3 style="color:${LYRIC_GREY}">${cityname}</h2>
+    <h3 style="color:${LYRIC_GREY}">${cityname}</h3>
     ${nonNativeHeader}
     ${nativeHeader}
     <h4 style="color:${LYRIC_GREY}">DETAILS</h4>
@@ -130,7 +130,7 @@ function createDetailedGeoListOfPoets(poets, data) {
         <span style="color:${LYRIC_RED}">${idx + 1}</span>. ${poet.poetname}<br>
         Dates: ${getPoetDisplay(data, poet.poetId).dates}<br>
         ${poet.references.map(reference => renderReference(reference)).join("<br><br>")}
-      </p >
+      </p>
       `;
       })
       .join(" ")}


### PR DESCRIPTION
Closes #370.

Four malformed tags in `js/popups/popups.js`, three of them in the ACTIVITY popup the places map opens on by default:

| line | was | now |
| --- | --- | --- |
| 60 | `<h5 ...>${nativeTitle}</h2>` | `</h5>` |
| 71 | `<h5 ...>${nonNativeTitle}</h2>` | `</h5>` |
| 81 | `<h3 ...>${cityname}</h2>` | `</h3>` |
| 133 | `</p >` | `</p>` |

## Nothing changes on screen, and nothing changed in the accessibility tree either

The issue's rationale doesn't hold, and it's worth amending on that point. An `h1`–`h6` end tag pops to the nearest open heading whatever its level, so `</h2>` genuinely closes the `<h3>` above it. Parsing the old markup in Chromium:

```
<h3> ATHENS
<h5> NON-NATIVE LYRIC ACTIVITY IN ATHEN
<p> 1. Aeschylus
  <span> 1
<h4> DETAILS
```

That's the structure the source reads as, with the paragraph a sibling of the heading rather than swallowed by it — so a screen reader was already announcing the right thing. `</p >` is valid HTML besides: an end tag may carry whitespace before the `>`. This is hygiene, not a rendered or announced bug.

## Why a linter and a format check both missed it

Because this markup isn't HTML to anything in the pipeline. It's a JavaScript template literal — one opaque token to Prettier's JS parser, one to oxlint's AST — and neither has reason to guess a string holds markup rather than SQL or prose. The same four lines in a `.html` file fail `format:check` outright:

```
[error] probe.html: SyntaxError: Unexpected closing tag "h2". It may happen when
        the tag has already been closed by another tag. (1:30)
> 1 | <h3 style="color:#555">ATHENS</h2>
```

## Why not prefix the templates with `/* HTML */`

Prettier does format embedded HTML in a template tagged that way, handles `${}` interpolation fine, and would normalise `</p >`. It's the obvious thing to reach for, and I tried it on `popupsCommon.js` before deciding against it:

- It rewrites `<br>` to `<br />`, with no option to opt out. That churns every popup string and **breaks the two citation-credit assertions** in `tests/popups.test.js`, which match `<br>` literally (`# pass 125  # fail 2`).
- It reflows the generated strings — `<p>` blocks collapse to one line, `${createGenreString(...)}` joins the `Source(s):` line. Rendering is unchanged because that whitespace collapses, but nothing in the suite guards the rendered result.
- It wants the prefix at twenty-odd sites, nested fragments inside `.map()` callbacks included.
- And on markup that doesn't parse — exactly this bug — it **silently skips the template and exits 0**. It buys formatting, not validation.

So the gap stays open. It's a narrow one: these popups are the only markup-in-JS in the repository.

## Checks

`npm test` (127 pass), `lint`, `format:check` and `typecheck` are all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
