### PR TITLE
Name a genre once when two sources attest it

### DIFF
--- a/js/popups/popupsCommon.js
+++ b/js/popups/popupsCommon.js
@@ -59,12 +59,15 @@ export function createDetailedListOfPoets(poets, data) {
  * @returns {string}
  */
 function createGenreString(lookups, poetId) {
-  const genres = getGenres(lookups, poetId);
-  const genreNames = genres.map(genre => genre.genre).join(", ");
+  // genres.csv is one row per citation rather than per genre, so a poet
+  // attested in the same genre by two sources has two rows. This line names the
+  // genres a poet worked in and shows none of the citations behind them, so a
+  // name repeated is only ever a repetition.
+  const genreNames = [...new Set(getGenres(lookups, poetId).map(genre => genre.genre))].filter(Boolean);
   // Blank when a poet has no genres, and also when the ones they have are
   // unnamed, which is what reading the joined string off the row did.
-  if (!genreNames) return "";
-  return `${genres.length > 1 ? "Genres" : "Genre"}: ${genreNames}<br>`;
+  if (!genreNames.length) return "";
+  return `${genreNames.length > 1 ? "Genres" : "Genre"}: ${genreNames.join(", ")}<br>`;
 }
 
 /**

--- a/tests/data-integrity.test.js
+++ b/tests/data-integrity.test.js
@@ -655,8 +655,13 @@ describe("known data bugs: incomplete or inconsistent fields", () => {
       row => filled(row.source_citation) && !(filled(row.source_translation) && filled(row.source_translator))
     );
     assert.equal(incomplete.length, KNOWN_INCOMPLETE_CITATION_COUNT);
-    // renderReference() prints `Citation: X: "" (trans. )` for these. This is
-    // the shape of issues #313 and #329. geopoetCities and genres are clean.
+    // These used to render `Citation: X: "..." (trans. )`, which is the shape of
+    // issues #313 and #329, until #356 stopped renderReference() printing a
+    // credit with nobody in it. Seventeen of the eighteen are Pindar titles and
+    // are meant to carry no translator, per the December 2015 corrections; the
+    // eighteenth, Stesandros at Ath. 14.638b, is a real omission. The count is
+    // still worth pinning, because it is now invisible on the page.
+    // geopoetCities and genres are clean.
     for (const file of CLEAN_CITED_CSVS) {
       const bad = raw[file].filter(
         row => filled(row.source_citation) && !(filled(row.source_translation) && filled(row.source_translator))

--- a/tests/popups.test.js
+++ b/tests/popups.test.js
@@ -11,6 +11,7 @@ import { loadInitializedData, ALL_DATES } from "./helpers/loadData.js";
 import { calcPlacesPoetCities, calcGeoPoetCities } from "../js/renderMap/calcPoetCities.js";
 import { calculatePlacesBubbles, calculateGeoBubbles } from "../js/renderMap/calcBubbles.js";
 import { createTravelPopupHtml } from "../js/popups/travelPopups.js";
+import { createDetailedListOfPoets } from "../js/popups/popupsCommon.js";
 
 const { data } = loadInitializedData();
 
@@ -201,6 +202,39 @@ describe("citation credits", () => {
 
   test("a translation that has a translator still credits them", () => {
     assert.match(popupFor(bubbles, "Locri"), /Citation: O\. 10 Title: ".*" \(trans\. Race\)<br>/);
+  });
+});
+
+describe("the genre line", () => {
+  // genres.csv is one row per citation rather than per genre, so a poet
+  // attested in one genre by two sources has two rows. No poet does today —
+  // the only pair the data ever had was Kinesias 14 and Cinesias 4, and those
+  // are not merged — so the case is built here rather than found.
+  const cinesias = data.poets.find(poet => poet.poetDetailName === "Cinesias");
+  assert.ok(cinesias, "expected Cinesias in poets.csv");
+  const poetId = cinesias.poetId;
+
+  /**
+   * The same data with one poet's genre list doubled.
+   * @param {Genre[]} genres
+   * @returns {string}
+   */
+  function detailFor(genres) {
+    const doubled = { ...data, genresByPoetId: { ...data.genresByPoetId, [poetId]: genres } };
+    return createDetailedListOfPoets([{ poetId }], doubled);
+  }
+
+  test("a genre attested by two sources is named once", () => {
+    const [dithyramb] = data.genresByPoetId[poetId];
+    const html = detailFor([dithyramb, { ...dithyramb }]);
+    assert.match(html, /Genre: Dithyramb<br>/);
+    assert.doesNotMatch(html, /Dithyramb, Dithyramb/, "the genre is named twice");
+  });
+
+  test("distinct genres are all named, and pluralised", () => {
+    const [dithyramb] = data.genresByPoetId[poetId];
+    const html = detailFor([dithyramb, { ...dithyramb, genre: "Paean" }]);
+    assert.match(html, /Genres: Dithyramb, Paean<br>/);
   });
 });
 


### PR DESCRIPTION
`genres.csv` is one row per **citation**, not per genre, so a poet attested in the same genre by two sources has two rows. `createGenreString()` joined the names straight off the rows, so such a poet would be described as:

> Genres: Dithyramb, **Dithyramb**

and the count choosing between "Genre" and "Genres" counted rows rather than names. The line names the genres a poet worked in and shows none of the citations behind them, so a name repeated is only ever a repetition.

## No poet triggers this today

The only pair the data has ever had was Kinesias 14 against Cinesias 4, and #364 archived the Kinesias row rather than merging it, so the two Dithyramb citations stayed apart.

Worth fixing anyway. Adding a second source for a genre a poet already has is an ordinary editorial act — the file is organised to invite it — and the failure would be silent, in the poet's own popup, with nothing to catch it.

## The tests build the case rather than find it

By doubling one poet's entry in `genresByPoetId` and rendering through `createDetailedListOfPoets()`, which needs no change to the module surface. The first fails without the fix; the second holds the other side, that distinct genres are all still named and still pluralised.

## Also: a comment #356 made false

The `BUG:` test for the eighteen incomplete citations still said `renderReference()` prints `(trans. )` for them. It stopped doing that in #356. The note now records what the eighteen actually are — seventeen Pindar titles that are *meant* to carry no translator per the December 2015 corrections, and Stesandros at `Ath. 14.638b`, which is a real omission — and why the count is still worth pinning now that it is invisible on the page. See #378.

| check | result |
| --- | --- |
| `npm test` | 129 pass |
| `npm run lint` | clean |
| `npm run format:check` | clean |
| `npm run typecheck` | clean |
| `npm run test:browser` | 28 pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)