### PR TITLE
Replace three of the four omit lists with the rules they stood in for

### DIFF
--- a/dataFiles/removed_data.txt
+++ b/dataFiles/removed_data.txt
@@ -6,12 +6,30 @@ Adespota,Adespota,152,,,,
 Castorion,Castorion,33,,,,
 
 removed poets_cities
+
+Aristonous's two rows are why he is not on the travel map, and the ruling behind
+them is "Aristonous : erase – travels nowhere" (notes/corrections-2015-12.md).
+The team disagreed with it on the record — issue #138, "He does travel: Athens
+and Delphi" — but what the map showed either way was nothing: he is dated
+350–300 BCE and the date slider stops at 400, which is what #138 was eventually
+closed on. Restoring these rows restores a poet no setting of the slider reaches.
+createTravelPoets() struck his poetId out by hand as well, until archiving the
+rows here made that redundant.
+
 Aristonous,38,Athens,2,performed,3,3,,,Inscription,,IG 12.5 444 80-1 = Parian Marble 67,"ἀφ' οὗ Ἀρ[ι]στ[όνους ὁ κιθαρωιδὸς ἐνίκησεν] Ἀθήνησιν, ἔτη ΗΔΔΔ𐅃, ἄρχοντος Ἀθήνησιν Ἀριστοκράτους.",It has been 135 years [=399/8 BCE] since Arist[onous the kitharode won] at Athens during the archonship of Aristocrates at Athens.,Driscoll,,yes
 Aristonous,38,Delphi,30,born,1,1,,,Plutarch,,Plut. Lys. 18.10,"ἐπεὶ μέντοι ὁ κιθαρῳδὸς Ἀριστόνους ἑξάκις Πύθια νενικηκὼς ἐπηγγέλλετο τῷ Λυσάνδρῳ φιλοφρονούμενος, ἂν νικήσῃ πάλιν, Λυσάνδρου κηρύξειν ἑαυτόν, “Ἦ δοῦλον;” εἶπεν.","However, when Aristonoüs the harper, who had been six times victor at the Pythian games, told Lysander in a patronizing way that if he should be victorious again, he would have himself proclaimed under Lysander’s name, “That is,” Lysander replied, “as my slave?”",,,yes
 Oenopas (Oinonas),78,Italy,,,1,1,,Assuming Oinopas = Oinonas,Athenaeus,,Ath. 1.20a,περὶ τὸ ἐξ Ἰταλίας Οἰνώα (sic),concerning Oinonas (sic) from Italy,Sansom,,
 Bacchylides,100,Ceos,46,,3,3,dotted,,Bacchylides inscription,,Bacchyl. 1 Title,<ΑΡΓΕΙΩΙ ΚΕΙΩΙ> <ΠΑΙΔΙ ΠΥΚΤΗΙ (?) ΙΣΘΜΙΑ>,"For Argeius of Ceos Boy Boxer, Isthmian Games",Campbell,,no
 
 looks like we didn't trust this oeniades data point
+
+This was the origin of his only journey, Thebes -> Athens, and the surviving
+Athens row carries the same doubt: "the poets master webpage says he is from
+Thebes, but it is not listed here (and I can't seem to find anything mentioning
+thebes with him)". With no birthplace left he is a poet of unknown travel, under
+places, which is where the old map had him too. Restoring this row puts him back
+on the travel map; createTravelPoets() no longer strikes his poetId out by hand.
+
 Oeniades,29,Thebes,,,1,1,,,Inscription,,"IG P2 3064, 3 + Hesperia 28, 1959, 275-277",Οἰνιάδην δὲ τὸν Τιμοθέου,Oiniades son of Timotheos,Sansom,,yes
 
 removed geographical_imaginary_group

--- a/js/calcData/data.js
+++ b/js/calcData/data.js
@@ -137,7 +137,7 @@ function derive(csvs, lookups) {
     linesByActiveCityId: groupById(lines, line => line.activeCityId, identity),
     travelPoets: createTravelPoets(lines, lookups),
     travelCities: createTravelCities(lines),
-    regionsForInterface: createRegionsForInterface(csvs)
+    regionsForInterface: createRegionsForInterface(csvs, lines)
   };
 }
 
@@ -308,16 +308,11 @@ function createAlphabetizedListOfPoetsFromIds(poetIds, lookups) {
  * @returns {FilterOption[]}
  */
 function createGeoImaginaryPoets(csvs, lookups) {
-  // Aristotle (151) and Castorion (33) used to be listed here too. Both were
-  // removed from poets.csv in December 2023, so neither can appear in
-  // geopoetCities to be omitted from.
-  const poetIdsToOmit = [
-    4, // Cinesias
-    100, // Bacchylides
-    149 // Pindar
-  ];
-
-  const poetIds = new Set(csvs.geopoetCities.map(pc => pc.poetId).filter(poetId => !poetIdsToOmit.includes(poetId)));
+  // Every poet with a reference the map can place; the rest would open on an
+  // empty map. Excludes Cinesias (#377), Pindar and Bacchylides (#326).
+  const poetIds = new Set(
+    csvs.geopoetCities.filter(pc => pc.cityId && lookups.citiesById[pc.cityId]).map(pc => pc.poetId)
+  );
 
   const geoImaginaryPoets = createAlphabetizedListOfPoetsFromIds(poetIds, lookups);
 
@@ -353,13 +348,7 @@ function putPoetIdAtEnd(array, poetId) {
  * @returns {FilterOption[]}
  */
 function createTravelPoets(lines, lookups) {
-  // why do we omit these guys?
-  const poetIdsToOmit = [
-    29, // Oeniades
-    38 // Aristonous
-  ];
-
-  const poetIds = new Set(lines.map(line => line.poetId).filter(poetId => !poetIdsToOmit.includes(poetId)));
+  const poetIds = new Set(lines.map(line => line.poetId));
   return createAlphabetizedListOfPoetsFromIds(poetIds, lookups);
 }
 
@@ -382,27 +371,28 @@ function createTravelCities(lines) {
 }
 
 /**
+ * The regions offered as travel filters: those a line actually runs to or from,
+ * less the six the 2015 control bar left out by hand.
  * @param {Csvs} csvs
+ * @param {Line[]} lines
  * @returns {FilterOption[]}
  */
-function createRegionsForInterface(csvs) {
+function createRegionsForInterface(csvs, lines) {
   const regionIdsToOmit = [
-    27, // Aeolis
-    21, // Asia
-    29, // Asia Minor islands
+    // Taken off the bar on 14 May 2015, with no reason recorded anywhere.
     13, // Cythera
     6, // Ionia
     10, // Italy
-    33, // Macedonia
-    16, // Mysia
-    25, // Phoenicia
-    23, // Phrygia
-    24, // Scythia
-    20, // Thrace
-    28 // Troad
+    // Postdate the bar and were never added to it, which strands their cities:
+    // a BUG test in tests/initializeData.test.js.
+    27, // Aeolis - Cyme
+    21, // Asia - Persia
+    29 // Asia Minor islands - Samos, Chios
   ];
+
+  const travelled = new Set(lines.flatMap(line => [line.bornCity.regionId, line.activeCity.regionId]));
   return csvs.regions
-    .filter(region => !regionIdsToOmit.includes(region.regionId))
+    .filter(region => travelled.has(region.regionId) && !regionIdsToOmit.includes(region.regionId))
     .map(region => ({ id: region.regionId, name: region.regionname }))
     .sort((a, b) => sortAlphabetically(a.name, b.name));
 }
@@ -511,6 +501,8 @@ function convertMixedGovIds(govId) {
  * @returns {FilterOption[]}
  */
 function createGenreIdsWithNames(lookups) {
+  // Neither is a genre: Diaskeue is a reworking of a text, and "Possibly lyric"
+  // is the hedge asked for in issues #169, #186 and #187.
   const genresToOmit = [
     1, // Diaskeue
     31 // Possibly lyric

--- a/notes/README.md
+++ b/notes/README.md
@@ -89,6 +89,58 @@ Athens, Isthmus follows Corinth, the sanctuary of Poseidon Petraios follows
 Larisa, Mt. Ptoios follows Akraiphia, Messenia follows Sparta after the
 Messenian Wars — and are the place to check before changing `city_politics.csv`.
 
+## Where the control bar lists came from
+
+Issue #373: four `*ToOmit` lists in `js/calcData/data.js`, twenty hardcoded ids,
+no reason given for any of them. Three of the four turned out not to be editorial
+decisions at all. The CartoDB control bars were hand-written HTML, one radio
+button per line, and v2 reproduces them by subtracting from the CSVs whatever
+those bars did not list. Set against the last version of the old map, the match
+is exact:
+
+    git show 4c3ed7d^:production/html/linemap.html      poets, small regions
+    git show 4c3ed7d^:production/html/bubblemap.html    genres
+    git show 4c3ed7d^:production/html/imaginary.html    geographical imaginary
+
+The poet lists were generated rather than typed — the SQL is still in
+`4c3ed7d^:queries/`, and `query to update poets on travel map.txt` is the
+ancestor of `createTravelPoets()`. The small region and genre bars were typed by
+hand, which is why only they had to be reproduced by subtraction.
+
+The one list that is not a reproduction is the geographical imaginary, where v2
+also drops Pindar. He was on the old bar, and his button showed nothing: all
+fifteen of his rows have a blank `cityId`, in the CartoDB data as in this one.
+Issue #130 had already settled that thinness is no reason to leave a poet out
+("any number of references gets you on there", closed "keep them"), so the
+standing rule is the narrower one Peponi applied to Melanippides and Scythinus —
+a poet who shows nothing when clicked comes off the list.
+
+Knowing all that, most of the ids went. Twenty are now eight, and the lists draw
+exactly what they drew before:
+
+- The travel list is gone. Both rulings had already been carried out in the data,
+  so it struck out two poets who could not appear anyway; the reasons are now
+  with the archived rows in `dataFiles/removed_data.txt`.
+- The geographical imaginary list is gone, replaced by the rule it was standing
+  in for — a poet is offered if any one of their references names a city the map
+  can place. Cinesias, Bacchylides and Pindar fail that today, and the work that
+  would change it is #377 and #326 rather than a decision about scope.
+- The small region list keeps six of thirteen. Seven regions are reached by no
+  travel line, which the same kind of rule now handles; the six that remain are
+  the ones a person has to argue for.
+- The genre list keeps both. Neither Diaskeue nor "Possibly lyric" is a genre,
+  and no rule can be asked that.
+
+Two things fell out of this that are worth knowing. Most of the regions above id
+18 exist to place what the geographical imaginary names rather than to be
+travelled to, which is issue #240's "This only matters for the imaginary map";
+but three of them — Aeolis, Asia and Asia Minor islands — hold a city the travel
+map draws, and no hand ever added them to the bar, so Cyme, Persia, Samos and
+Chios are in no small region a reader can select. Samos and Chios were covered
+until 14 May 2015, when region 8 stopped reading "Lesbos & other Asia Minor
+islands (Samos, Chios)" and became plain "Lesbos". That one is a live bug, and is
+asserted as such in `tests/initializeData.test.js`.
+
 ## Not restored
 
 The rest of what `4c3ed7d` deleted documents a map that no longer exists: the

--- a/tests/initializeData.test.js
+++ b/tests/initializeData.test.js
@@ -294,14 +294,6 @@ describe("travel lines", () => {
 });
 
 describe("control bar contents", () => {
-  test("Pindar and Bacchylides are excluded from the geographical imaginary", () => {
-    // Their geographical imaginary is a pilot of one poem each (Olympian 1 and
-    // Ode 17), so they are deliberately kept out of the poet list. See issue #326.
-    const names = data.geoImaginaryPoets.map(poet => poet.name);
-    assert.ok(!names.includes("Pindar"));
-    assert.ok(!names.includes("Bacchylides"));
-  });
-
   test("Sappho or Alcaeus sorts last, after the individually named poets", () => {
     const last = data.geoImaginaryPoets[data.geoImaginaryPoets.length - 1];
     assert.match(last.name, /Sappho/);
@@ -331,6 +323,75 @@ describe("control bar contents", () => {
     for (const { id: cityId } of data.travelCities) {
       assert.ok(data.citiesById[cityId], `control bar offers unknown cityId ${cityId}`);
     }
+  });
+});
+
+// Issue #373. These assert what the reasons in data.js claim, so that finishing
+// the underlying work fails a test rather than leaving a stale name behind.
+describe("what the control bar lists leave out", () => {
+  test("exactly three poets are held out of the geographical imaginary by unplaceable references", () => {
+    // Geocode Ode 17 or give Phthia a cityId and the poet appears here, which
+    // should fail until data.js loses the name.
+    const placeable = new Set(data.geopoetCities.filter(row => data.citiesById[row.cityId]).map(row => row.poetId));
+    const referenced = new Set(data.geopoetCities.map(row => row.poetId));
+    const listed = new Set(data.geoImaginaryPoets.map(poet => poet.id));
+
+    for (const poetId of placeable) {
+      assert.ok(
+        listed.has(poetId),
+        `${data.poetsById[poetId].poetname} has a reference the map can draw but is not offered`
+      );
+    }
+    assert.deepEqual(
+      [...referenced]
+        .filter(poetId => !listed.has(poetId))
+        .map(poetId => data.poetsById[poetId].poetname)
+        .sort(),
+      ["Bacchylides", "Cinesias", "Pindar"]
+    );
+  });
+
+  test("the two poets whose ids used to be struck out here are still off the travel map", () => {
+    // createTravelPoets() struck both out by id until that was found to be
+    // inert. Restoring either archived row puts them back: removed_data.txt.
+    for (const [poetId, name] of [
+      [29, "Oeniades"],
+      [38, "Aristonous"]
+    ]) {
+      assert.ok(
+        !data.lines.some(line => line.poetId === poetId),
+        `${name} travels again; see dataFiles/removed_data.txt before accepting that`
+      );
+    }
+    assert.equal(data.poetsById[38], undefined, "Aristonous is back in poets.csv");
+    assert.ok(
+      data.poetsWithUnknownTravel.some(poet => poet.id === 29),
+      "Oeniades kept his Athens row, so he belongs under poets of unknown travel"
+    );
+  });
+
+  test("every region still named in regionIdsToOmit is one the rule would otherwise offer", () => {
+    // Regions no line reaches are dropped by the rule, so a hand-written id only
+    // earns its place if its region holds a travel city. Seven did not.
+    const listed = new Set(data.regionsForInterface.map(region => region.id));
+    const travelled = new Set(data.lines.flatMap(line => [line.bornCity.regionId, line.activeCity.regionId]));
+    const omittedButTravelled = data.regions
+      .filter(region => !listed.has(region.regionId) && travelled.has(region.regionId))
+      .map(region => region.regionname)
+      .sort();
+    assert.deepEqual(omittedButTravelled, ["Aeolis", "Asia", "Asia Minor islands", "Cythera", "Ionia", "Italy"]);
+  });
+
+  test("the two omitted genres are still in the data, and no other genre is left out", () => {
+    // No rule can tell you these are not genres, so the ids stay. A renumbering
+    // in genres.csv would leave the filter matching nothing, silently.
+    const listed = new Set(data.genreIdsWithName.map(genre => genre.id));
+    const omitted = Object.keys(data.genresByGenreId)
+      .map(Number)
+      .filter(genreId => !listed.has(genreId))
+      .map(genreId => data.genresByGenreId[genreId])
+      .sort();
+    assert.deepEqual(omitted, ["Diaskeue", "Possibly lyric"]);
   });
 });
 
@@ -396,6 +457,46 @@ describe("known bugs: derived travel lines", () => {
     // so his Spartan origin still reaches the map via Sparta -> Messenia.
     const tyrtaeus = data.linesByPoetId[poetIdByName("Tyrtaeus")];
     assert.ok(tyrtaeus.some(l => l.bornCity.cityname === "Sparta" && l.activeCity.cityname !== "Sparta"));
+  });
+});
+
+describe("known bugs: the travel control bar", () => {
+  test("BUG: 18 travel cities are in a small region the bar does not offer", () => {
+    const regionIds = new Set(data.regions.map(region => region.regionId));
+    const listed = new Set(data.regionsForInterface.map(region => region.id));
+    const stranded = [
+      ...new Set(
+        data.lines
+          .flatMap(line => [line.bornCity, line.activeCity])
+          // Cities with no region at all are a separate and bigger gap: 46 of
+          // them, five on the travel map. Issue #240 asked about it and left it.
+          .filter(city => regionIds.has(city.regionId) && !listed.has(city.regionId))
+          .map(city => city.cityname)
+      )
+    ].sort();
+
+    // Fourteen of these were given up knowingly in 2015. Cyme, Persia, Samos and
+    // Chios were not; see createRegionsForInterface and notes/README.md.
+    assert.deepEqual(stranded, [
+      "Chios",
+      "Clazomenae",
+      "Colophon",
+      "Cyme",
+      "Cythera",
+      "Ephesus",
+      "Locri",
+      "Matauria",
+      "Metapontion",
+      "Miletus",
+      "Persia",
+      "Phocaea",
+      "Rhegium",
+      "Samos",
+      "Smyrna",
+      "Tarentum",
+      "Teos",
+      "Thurii"
+    ]);
   });
 });
 


### PR DESCRIPTION
Closes #373.

`js/calcData/data.js` dropped rows from four control bar lists using twenty ids written into the source, with no reason recorded for any of them. Most turn out not to be editorial decisions at all.

## Where they came from

The CartoDB control bars were hand-written HTML, one radio button per line, and v2 reproduces them by subtracting from the CSVs whatever those bars did not list. Against the last version of the old map the match is exact:

```
git show 4c3ed7d^:production/html/linemap.html      poets, small regions
git show 4c3ed7d^:production/html/bubblemap.html    genres
git show 4c3ed7d^:production/html/imaginary.html    geographical imaginary
```

`genresToOmit` is precisely the two genres in `genres.csv` that bar did not list, and `regionIdsToOmit` precisely the thirteen regions. The poet lists were generated rather than typed — the SQL is still in `4c3ed7d^:queries/`, and `query to update poets on travel map.txt` is the ancestor of `createTravelPoets()`.

## List by list

**`createTravelPoets` — deleted.** Both rulings had already been carried out in the data. "Aristonous : erase – travels nowhere" (`notes/corrections-2015-12.md`); #138 records the team disagreeing on the point, and also why the map showed nothing either way, which is that he is dated 350–300 BCE and the slider stops at 400. Oeniades' Theban birth was archived as "looks like we didn't trust this oeniades data point". Neither poet has had a line to filter out since those rows moved to `removed_data.txt`, which is where the reasons now live with them. This is the list that carried `// why do we omit these guys?`.

**`createGeoImaginaryPoets` — deleted,** replaced by the rule it stood in for: a poet is offered if any one of their references names a city the map can place. That is the same test `groupRowsByCity()` applies when deciding what to draw. #130 had already settled that thinness is no reason to leave a poet out ("any number of references gets you on there", closed "keep them"), so drawing nothing is the only ground, and it is the one the December corrections gave for Melanippides and Scythinus. The three poets it excludes today are unfinished work rather than a ruling — Cinesias' one reference names Phthia, cityId 217, which is not in `cities.csv` (#377), and every row of Pindar's Olympian 1 and Bacchylides' Ode 17, the two poems the imaginary was piloted on, has a blank cityId, here and in the CartoDB data before it (#326).

Pindar is the one name v2 added rather than reproduced. He was on the old bar, and his button showed nothing.

**`createRegionsForInterface` — thirteen ids down to six.** Seven regions are reached by no travel line, which the same kind of rule now handles, so a first line to Thrace would put Thrace in the bar. The six left have to be argued for one at a time: three were taken off the bar in a single edit on 14 May 2015 with no reason recorded anywhere, and three postdate the bar and were never added to it.

**`createGenreIdsWithNames` — unchanged,** and the only genuinely editorial list of the four. Neither Diaskeue (a reworking of a text) nor "Possibly lyric" (the hedge asked for in #169, #186 and #187) is a genre, and no rule can be asked that. Both ids keep their reasons.

## Behaviour

Every control bar list renders byte-identically to before — all six were dumped and diffed either side of the change. The four tests replacing "Pindar and Bacchylides are excluded" assert what the remaining comments claim, so finishing #326 or #377 fails a test rather than leaving a stale name in a comment.

## One bug found on the way

Asserted as such rather than fixed: 18 travel cities are in a small region the bar does not offer. Fourteen were given up knowingly in 2015. Cyme, Persia, Samos and Chios were not — their regions postdate the bar, and Samos and Chios were covered until region 8 stopped reading "Lesbos & other Asia Minor islands (Samos, Chios)" in that same 14 May edit. Fixing it means adding three buttons, which is a decision about the interface rather than a cleanup.

`npm test` (133 pass), `test:browser` (28 pass), `lint`, `format:check` and `typecheck` are all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
