### PR TITLE
Write down the commit and PR conventions, and keep session links out of them

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,3 +28,30 @@ rather than obvious: without `@types/node`, TypeScript resolves the missing
 packages by walking up out of the repository, then reports errors in whatever
 unrelated `node_modules` it lands in. A wall of errors in files with `../../`
 paths means the install was skipped, not that the code is broken.
+
+## Commit messages and PR descriptions
+
+Both are a one-sentence summary and then a fuller description. The summary is
+the commit subject, or the PR title; shorter is better as long as it stays
+specific. Say what the change does, in the imperative, and say enough of why
+that the line stands on its own — `Report data problems to the console, not to
+a dialog the reader dismisses`, not `fix: alerts`. No `type:` prefix and no
+issue number: the squash merge appends the PR number itself.
+
+The description carries the argument. What was wrong, what the change does
+about it, and the decisions the diff cannot show — the option rejected, the
+case deliberately left alone, why a number is that number. Cite issues, files
+and old commits by name where they carry the reasoning. Close with a line
+saying which checks were run and that they pass.
+
+The PR description and the commit message are that argument in two renderings,
+not the same text. The PR body is markdown and uses it: `##` headings, tables,
+code fences, backticks, en dashes. The commit message is plain text, so that it
+reads in `git log` — no headings, no backticks, ASCII, wrapped at about 80
+columns, tables recast as paragraphs or `-` bullets. Write the PR body first,
+then render it down.
+
+Keep the `Co-authored-by: Claude ...` trailer and the "Generated with Claude
+Code" footer; the attribution is wanted. Never include a `Claude-Session:`
+trailer or any other `claude.ai` link. This repository is public and those
+sessions are not.


### PR DESCRIPTION
Nothing in `CLAUDE.md` said how a commit message or a PR description is supposed to look here, so each session re-derived it from whatever the last few commits happened to do. The shape is stable enough to write down: **a one-sentence summary and then a fuller description**, in both places, with the summary carrying enough of the *why* to stand on its own in `git log`.

The section is descriptive rather than aspirational — it was written after reading #383, #375 and #382 against the commits they squashed into, and it records what those already do.

## What it says

| | |
| --- | --- |
| **The summary** | Imperative and specific. No `type:` prefix, no issue number — the squash merge appends the PR number itself. |
| **The description** | What was wrong, what the change does about it, and the decisions the diff cannot show. Closes with a line saying which checks were run. |
| **The two renderings** | The PR body is markdown and uses it. The commit message is the same argument as plain text, so that it reads in `git log`. |

## Two judgement calls

**"Shorter is better" is qualified rather than numbered.** Subjects on `master` run 12 to 86 characters, median 59 — longer than the usual fifty-character advice, and long for a reason:

```
Label the Adespota Priapis fragment Priapus, which is where it is already drawn
Report data problems to the console, not to a dialog the reader dismisses
```

Both spend their length on being specific, so the guidance asks for short-but-specific rather than setting a column count.

**The two-renderings paragraph is the part most worth recording,** because it is the easiest to get wrong. The PR bodies use `##` headings, tables and code fences; *none* of the last twenty-five commit bodies has a heading in it. They carry the same material as plain ASCII prose, wrapped at about 80 columns, with tables recast as paragraphs or `-` bullets.

## Left unspecified on purpose

- `Closes #NNN` sits at the top of a PR body and the bottom of a commit message, and #382 said `Fixes` instead. No settled rule to state.
- When a change is small enough to skip the fuller description.

## Session links

The Claude attribution stays — the `Co-authored-by` trailer and the "Generated with Claude Code" footer are both wanted. The `Claude-Session:` trailer is not, because this repository is public.

Seventeen commits on `master` still carry one, and nine PR bodies did until they were edited. **Those commits are being left alone deliberately.** GitHub keeps `refs/pull/N/head` forever and will not let you rewrite it, so a force-push would clean `git log` while the PR "Commits" tab went on serving the same message — and the links resolve to "this session could not be found" for anyone not signed in as their author. What is left is untidy rather than a leak, and not worth rewriting 37 commits across 43 branches to tidy.

## Verification

`npm test` (133 pass), `lint`, `format:check` and `typecheck` are all clean. `test:browser` was not run: the change is one markdown file and draws nothing.
